### PR TITLE
fix: preserve untracked files during branch checkout

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -120,8 +120,8 @@ func (r *Repo) CreateBranch(name string) error {
 		}
 	}
 
-	// checkout the new branch
-	if err := wt.Checkout(&git.CheckoutOptions{Branch: branchRef}); err != nil {
+	// checkout the new branch, Keep preserves untracked files
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: branchRef, Keep: true}); err != nil {
 		return fmt.Errorf("checkout branch: %w", err)
 	}
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -170,6 +170,34 @@ func TestRepo_CreateBranch(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
 	})
+
+	t.Run("preserves untracked files", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		repo, err := Open(dir)
+		require.NoError(t, err)
+
+		// create an untracked file while on master
+		untrackedPath := filepath.Join(dir, "untracked.txt")
+		err = os.WriteFile(untrackedPath, []byte("untracked content"), 0o600)
+		require.NoError(t, err)
+
+		// verify file exists before creating branch
+		_, err = os.Stat(untrackedPath)
+		require.NoError(t, err, "untracked file should exist before branch creation")
+
+		// create and switch to new branch
+		err = repo.CreateBranch("feature")
+		require.NoError(t, err)
+
+		// verify untracked file still exists after branch creation
+		_, err = os.Stat(untrackedPath)
+		require.NoError(t, err, "untracked file should be preserved after branch creation")
+
+		// verify content is intact
+		content, err := os.ReadFile(untrackedPath) //nolint:gosec // test file path
+		require.NoError(t, err)
+		assert.Equal(t, "untracked content", string(content))
+	})
 }
 
 func TestRepo_Add(t *testing.T) {


### PR DESCRIPTION
fixes go-git default checkout behavior which deletes untracked files. this differs from standard git which preserves them.

as suggested by @linnik in https://github.com/umputun/ralphex/pull/9#issuecomment-3781047254 - added `Keep: true` to `CheckoutOptions`.

**changes:**
- `CheckoutBranch()` now uses `Keep: true` to preserve local changes
- added test verifying untracked files survive checkout