### PR TITLE
fix: increase bufio.Scanner buffer to 16MB for large outputs

### DIFF
--- a/pkg/executor/codex.go
+++ b/pkg/executor/codex.go
@@ -160,6 +160,9 @@ func (e *CodexExecutor) Run(ctx context.Context, prompt string) Result {
 func (e *CodexExecutor) processStderr(ctx context.Context, r io.Reader) error {
 	state := &codexFilterState{}
 	scanner := bufio.NewScanner(r)
+	// increase buffer size for large output lines (16MB max)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 16*1024*1024)
 
 	for scanner.Scan() {
 		select {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -197,9 +197,9 @@ func (e *ClaudeExecutor) parseStream(r io.Reader) Result {
 	var signal string
 
 	scanner := bufio.NewScanner(r)
-	// increase buffer size for large JSON lines
+	// increase buffer size for large JSON lines (16MB max for large diffs with parallel agents)
 	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner.Buffer(buf, 16*1024*1024)
 
 	for scanner.Scan() {
 		line := scanner.Text()


### PR DESCRIPTION
**Problem:** `bufio.Scanner: token too long` error when running ralphex on projects with large diffs. The default scanner buffer is 64KB, which is exceeded when Claude outputs large JSON lines (common with 5 parallel review agents processing diffs).

**Fix:**
- `pkg/executor/executor.go` - increased buffer limit from 1MB to 16MB for Claude JSON stream parsing
- `pkg/executor/codex.go` - added 16MB buffer limit for codex stderr processing (was using default 64KB)

**Tests added:**
- `TestClaudeExecutor_parseStream_largeLines` - verifies lines up to 2MB are handled
- `TestClaudeExecutor_parseStream_multipleLargeLines` - simulates 5 parallel agents with 200KB lines each
- `TestCodexExecutor_processStderr_largeLines` - verifies stderr lines up to 1MB are handled
- `TestCodexExecutor_Run_largeOutput` - end-to-end test with large stderr and stdout