### PR TITLE
feat(git): improve uncommitted changes handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Progress file (`progress-*.txt`) is a real-time execution log—tail it to monit
 
 **Do I need to commit changes before running ralphex?**
 
-No, but recommended. Ralphex creates a new branch and commits per-task. Pre-existing uncommitted changes stay untouched but may cause confusion about what's part of the plan.
+It depends. If the plan file is the only uncommitted change, ralphex auto-commits it after creating the feature branch and continues execution. If other files have uncommitted changes, ralphex shows a helpful error with options: stash temporarily (`git stash`), commit first (`git commit -am "wip"`), or use review-only mode (`ralphex --review`).
 
 **What's the difference between agents/ and prompts/?**
 


### PR DESCRIPTION
**Problem**

When running ralphex on main/master with uncommitted changes, the error doesn't explain why a clean worktree is needed or what options are available.

**Solution**

- If only the plan file is uncommitted → auto-commit it after creating branch, continue execution
- Otherwise → improved error message explaining why and providing options:
  - `git stash && ralphex plan.md && git stash pop`
  - `git commit -am "wip"`
  - `ralphex --review` (skip branch creation)

**Changes**

- Added `HasChangesOtherThan(filePath)` method to git package - checks for uncommitted changes to files other than specified
- Added `FileHasChanges(filePath)` method - checks if specific file has uncommitted changes
- Added `extractBranchName` helper function with package-level regex
- Updated `createBranchIfNeeded` to auto-commit plan file when it's the only change
- Updated README FAQ to reflect new behavior
- Added tests for all new functionality

Related to #19