### PR TITLE
fix(build): add Windows support with platform-specific build tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,26 @@ Key files:
 ## Platform Support
 
 - **Linux/macOS:** fully supported
-- **Windows:** not supported (uses `syscall.Flock` for progress file locking)
+- **Windows:** builds and runs, but with limitations:
+  - Process group signals not available (graceful shutdown kills direct process only, not child processes)
+  - File locking not available (active session detection disabled)
+
+### Cross-Platform Development
+
+When adding platform-specific code (syscalls, signals, file locking):
+1. Use build tags: `//go:build !windows` for Unix-only code, `//go:build windows` for Windows stubs
+2. Create separate files: `foo_unix.go` and `foo_windows.go`
+3. Keep common code in the main file, extract platform-specific functions
+4. Windows stubs can be no-ops where functionality is optional
+
+Example files:
+- `pkg/executor/procgroup_unix.go` / `procgroup_windows.go` - process group management
+- `pkg/progress/flock_unix.go` / `flock_windows.go` - file locking helpers
+
+Cross-compile to verify Windows builds:
+```bash
+GOOS=windows GOARCH=amd64 go build ./...
+```
 
 ## Configuration
 

--- a/pkg/executor/procgroup_unix.go
+++ b/pkg/executor/procgroup_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package executor
 
 import (

--- a/pkg/executor/procgroup_windows.go
+++ b/pkg/executor/procgroup_windows.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package executor
+
+import (
+	"fmt"
+	"os/exec"
+	"sync"
+)
+
+// processGroupCleanup manages process lifecycle for graceful shutdown on Windows.
+// Note: Windows doesn't support Unix process groups, so this only kills the direct process.
+type processGroupCleanup struct {
+	cmd  *exec.Cmd
+	done chan struct{}
+	once sync.Once
+	err  error
+}
+
+// setupProcessGroup is a no-op on Windows since process groups work differently.
+func setupProcessGroup(_ *exec.Cmd) {
+	// windows doesn't support Setpgid, process groups are handled differently
+}
+
+// newProcessGroupCleanup creates a cleanup handler for the given command.
+// The command must already be started before calling this.
+// Caller must eventually call Wait() to ensure proper resource cleanup.
+func newProcessGroupCleanup(cmd *exec.Cmd, cancelCh <-chan struct{}) *processGroupCleanup {
+	pg := &processGroupCleanup{
+		cmd:  cmd,
+		done: make(chan struct{}),
+	}
+
+	// monitor for cancellation in background
+	go pg.watchForCancel(cancelCh)
+
+	return pg
+}
+
+// watchForCancel monitors the cancel channel and kills the process if triggered.
+func (pg *processGroupCleanup) watchForCancel(cancelCh <-chan struct{}) {
+	select {
+	case <-cancelCh:
+		pg.killProcess()
+	case <-pg.done:
+		// process completed normally, goroutine exits
+	}
+}
+
+// killProcess kills the direct process on Windows.
+// Note: this won't kill child processes spawned by the command.
+func (pg *processGroupCleanup) killProcess() {
+	process := pg.cmd.Process
+	if process == nil {
+		return
+	}
+
+	// on Windows, just kill the process directly
+	_ = process.Kill()
+}
+
+// Wait waits for the command to complete and cleans up resources.
+// It is safe to call multiple times - subsequent calls return the cached result.
+// Callers must eventually call Wait to avoid leaking resources.
+func (pg *processGroupCleanup) Wait() error {
+	pg.once.Do(func() {
+		pg.err = pg.cmd.Wait()
+		close(pg.done)
+		if pg.err != nil {
+			pg.err = fmt.Errorf("command wait: %w", pg.err)
+		}
+	})
+	return pg.err
+}

--- a/pkg/progress/flock_unix.go
+++ b/pkg/progress/flock_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package progress
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// lockFile acquires an exclusive lock on the file.
+func lockFile(f *os.File) error {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("flock: %w", err)
+	}
+	return nil
+}
+
+// unlockFile releases the lock on the file.
+func unlockFile(f *os.File) error {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_UN); err != nil {
+		return fmt.Errorf("flock unlock: %w", err)
+	}
+	return nil
+}
+
+// TryLockFile attempts to acquire a non-blocking exclusive lock.
+// Returns (true, nil) if lock acquired, (false, nil) if file is locked by another process.
+func TryLockFile(f *os.File) (bool, error) {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return false, nil // locked by another process
+		}
+		return false, fmt.Errorf("flock: %w", err)
+	}
+	// got lock, release it immediately
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return true, nil
+}

--- a/pkg/progress/flock_windows.go
+++ b/pkg/progress/flock_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package progress
+
+import "os"
+
+// lockFile is a no-op on Windows.
+// Windows file locking would require LockFileEx which is more complex.
+// The lock is primarily used to detect active sessions, which is a secondary feature.
+func lockFile(_ *os.File) error {
+	return nil
+}
+
+// unlockFile is a no-op on Windows.
+func unlockFile(_ *os.File) error {
+	return nil
+}
+
+// TryLockFile is a no-op on Windows - always returns unlocked.
+// Active session detection via file locks is not supported on Windows.
+func TryLockFile(_ *os.File) (bool, error) {
+	return true, nil // always report as "got lock" (not locked by others)
+}


### PR DESCRIPTION
**Summary**

Fixes Windows build failures by extracting Unix-specific syscalls into platform-specific files with build tags.

**Changes**

- Split `procgroup.go` into `procgroup_unix.go` (Unix implementation) and `procgroup_windows.go` (no-op stubs)
- Extract file locking from `progress.go` and `session_manager.go` into `flock_unix.go` and `flock_windows.go`
- Replace `syscall.SIGINT/SIGTERM` with `os.Interrupt` in main.go for cross-platform signal handling
- Update CLAUDE.md with cross-platform development guidelines

**Windows limitations** (documented in CLAUDE.md)

- Process group signals not available - graceful shutdown kills direct process only, not child processes
- File locking not available - active session detection disabled

**Verification**

Cross-compile works: `GOOS=windows GOARCH=amd64 go build ./...`

Related to #26