### PR TITLE
feat(cli): add auto-plan-mode detection for fresh repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Plans can be created in several ways:
 - **[Claude Code](#claude-code-integration-optional)** - use slash commands like `/ralphex-plan` or your own planning workflows
 - **Manually** - write markdown files directly in `docs/plans/`
 - **`--plan` flag** - integrated option that handles the entire flow
+- **Auto-detection** - running `ralphex` without arguments on master/main prompts for plan creation if no plans exist
 
 The `--plan` flag provides a simpler integrated experience:
 
@@ -181,7 +182,7 @@ Download the appropriate binary from [releases](https://github.com/umputun/ralph
 # execute plan with task loop + reviews
 ralphex docs/plans/feature.md
 
-# use fzf to select plan
+# select plan with fzf, or create one interactively if none exist
 ralphex
 
 # review-only mode (skip task execution)

--- a/llms.txt
+++ b/llms.txt
@@ -22,7 +22,7 @@ brew install umputun/apps/ralphex
 # execute plan with task loop + reviews
 ralphex docs/plans/feature.md
 
-# use fzf to select plan
+# select plan with fzf, or create one interactively if none exist
 ralphex
 
 # review-only mode (skip task execution)


### PR DESCRIPTION
**Summary**

When running `ralphex` without arguments on master/main branch and no plans exist in `docs/plans/`, automatically prompt for plan description and switch to plan creation mode instead of erroring with "no plans found".

**Changes**
- Add `errNoPlansFound` sentinel error for detecting empty/missing plans directory
- Add `isMainBranch()` helper to check for main/master branches  
- Add `promptPlanDescription(io.Reader, colors)` with injectable reader for testability
- Add `tryAutoPlanMode()` to orchestrate auto-plan-mode detection logic
- Treat missing plans directory same as empty directory (both trigger auto-plan-mode)
- Update documentation in README.md and llms.txt

**Behavior**
- On master/main with no plans: prompts "no plans found. what would you like to implement?"
- User enters description → enters plan creation mode
- User presses Ctrl+D or Enter without text → graceful exit
- On feature branch with no plans → still errors with "no plans found"
- `--review` and `--codex-only` modes → skip auto-plan-mode (plan is optional)