### PR TITLE
fix: IsIgnored now loads global and system gitignore patterns

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -333,7 +333,7 @@ func loadXDGGlobalPatterns() []gitignore.Pattern {
 	}
 
 	var patterns []gitignore.Pattern
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue


### PR DESCRIPTION
## Summary

- Added XDG global gitignore fallback: go-git's `LoadGlobalPatterns()` only reads from `core.excludesfile` in `~/.gitconfig`, but git also checks `~/.config/git/ignore` by default
- Fixed incorrect untracked file detection in `HasChangesOtherThan()`: go-git sets both `Staging` and `Worktree` to `Untracked` for untracked files, but the code incorrectly checked for `Staging == Unmodified`

## Problem

Files ignored via global gitignore (`~/.config/git/ignore`) were reported as uncommitted changes, causing "worktree has uncommitted changes" errors when trying to create branches.

## Test plan

- [x] Unit tests pass
- [x] Verified `.claude/settings.local.json` (ignored via `~/.config/git/ignore`) is now correctly identified as ignored
- [x] Verified `HasChangesOtherThan()` returns `false` when only globally-gitignored files exist