### PR TITLE
feat(config): add --reset flag for interactive config restoration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,6 +145,9 @@ linters:
           - errcheck
         text: "Error return value of .*.Println.*is not checked"
       - linters:
+          - errcheck
+        text: "Error return value of .*.Fprintln.*is not checked"
+      - linters:
           - gosec
         text: "G104: Errors unhandled"
     paths:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ project/
 **Customization:**
 - Edit files in `~/.config/ralphex/agents/` to modify agent prompts
 - Add new `.txt` files to create custom agents
-- Delete ALL `.txt` files from the directory and restart ralphex to restore defaults
+- Run `ralphex --reset` to interactively restore defaults, or delete ALL `.txt` files manually
 - Alternatively, reference agents installed in your Claude Code directly in prompt files (like `qa-expert`, `go-smells-expert`)
 
 ## Testing
@@ -260,3 +260,10 @@ If you're an AI agent preparing a contribution, complete this checklist:
 - Site source: `site/` directory with `mkdocs.yml`
 - Template overrides: `site/overrides/` with `custom_dir: overrides` in mkdocs.yml
 - **CI constraint**: Cloudflare Pages uses mkdocs-material 9.2.x, must use `materialx.emoji` syntax (not `material.extensions.emoji` which requires 9.4+)
+
+## Workflow Rules
+
+- **CHANGELOG**: Never modify during development - updates are part of release process only
+- **Version sections**: Never add entries to existing version sections - versions are immutable once released
+- **Linter warnings**: Add exclusions to `.golangci.yml` instead of `_, _ =` prefixes for fmt.Fprintf/Fprintln
+- **Exporting functions**: When changing visibility (lowercase to uppercase), check ALL callers including test files

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ ralphex --serve --port 3000 docs/plans/feature.md
 | `-w, --watch` | Directories to watch for progress files (repeatable) | - |
 | `-d, --debug` | Enable debug logging | false |
 | `--no-color` | Disable color output | false |
+| `--reset` | Interactively reset global config to embedded defaults | - |
 
 ## Plan File Format
 
@@ -294,7 +295,7 @@ The entire system is designed for customization - both task execution and review
 **Agent files** (`~/.config/ralphex/agents/`):
 - Edit existing files to modify agent behavior
 - Add new `.txt` files to create custom agents
-- Delete all files and restart to restore defaults
+- Run `ralphex --reset` to interactively restore defaults, or delete all files manually
 - Alternatively, reference agents already installed in your Claude Code directly in prompt files (see example below)
 
 **Prompt files** (`~/.config/ralphex/prompts/`):
@@ -439,7 +440,7 @@ For full mode, start on master - ralphex creates a branch automatically from the
 
 **How do I restore default agents after customizing?**
 
-Delete all `.txt` files from `~/.config/ralphex/agents/` and restart ralphex.
+Run `ralphex --reset` to interactively reset global config. Select which components to reset (config, prompts, agents). Alternatively, delete all `.txt` files from `~/.config/ralphex/agents/` manually.
 
 **How does local .ralphex/ config interact with global config?**
 

--- a/llms.txt
+++ b/llms.txt
@@ -33,6 +33,9 @@ ralphex --codex-only
 
 # interactive plan creation
 ralphex --plan "add user authentication"
+
+# reset global config to defaults (interactive)
+ralphex --reset
 ```
 
 ## Requirements

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,7 @@ type ColorConfig struct {
 func Load(configDir string) (*Config, error) {
 	globalDir := configDir
 	if globalDir == "" {
-		globalDir = defaultConfigDir()
+		globalDir = DefaultConfigDir()
 	}
 
 	// auto-detect local config directory in cwd.
@@ -201,11 +201,11 @@ func loadWithLocal(globalDir, localDir string) (*Config, error) {
 	return c, nil
 }
 
-// defaultConfigDir returns the default configuration directory path.
+// DefaultConfigDir returns the default configuration directory path.
 // returns ~/.config/ralphex/ on all platforms.
 // if os.UserHomeDir() fails, falls back to ./.config/ralphex/ silently -
 // this allows the tool to work even in unusual environments.
-func defaultConfigDir() string {
+func DefaultConfigDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".", ".config", "ralphex")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -146,8 +146,8 @@ iteration_delay_ms = 9999
 	assert.NotEmpty(t, cfg.TaskPrompt)
 }
 
-func Test_defaultConfigDir(t *testing.T) {
-	dir := defaultConfigDir()
+func TestDefaultConfigDir(t *testing.T) {
+	dir := DefaultConfigDir()
 	assert.NotEmpty(t, dir)
 	assert.Contains(t, dir, "ralphex")
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,11 +1,15 @@
 package config
 
 import (
+	"bufio"
+	"bytes"
 	"embed"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // defaultsInstaller implements DefaultsInstaller with embedded filesystem.
@@ -107,4 +111,416 @@ func (d *defaultsInstaller) installDefaultFiles(destDir, embedPath, fileType str
 	}
 
 	return nil
+}
+
+// ResetResult holds the result of the reset operation.
+type ResetResult struct {
+	ConfigReset  bool
+	PromptsReset bool
+	AgentsReset  bool
+}
+
+// Reset interactively resets global configuration to embedded defaults.
+// prompts user for each component (config, prompts, agents) before resetting.
+// local .ralphex/ is not affected.
+func (d *defaultsInstaller) Reset(configDir string, stdin io.Reader, stdout io.Writer) (ResetResult, error) {
+	result := ResetResult{}
+	scanner := bufio.NewScanner(stdin)
+
+	fmt.Fprintf(stdout, "Reset global configuration to defaults (%s)?\n\n", configDir)
+
+	// reset config file
+	configPath := filepath.Join(configDir, "config")
+	configReset, err := d.resetConfigFile(configPath, scanner, stdout)
+	if err != nil {
+		return result, fmt.Errorf("reset config: %w", err)
+	}
+	result.ConfigReset = configReset
+
+	// reset prompts directory
+	promptsDir := filepath.Join(configDir, "prompts")
+	promptsReset, err := d.resetPromptsDir(promptsDir, scanner, stdout)
+	if err != nil {
+		return result, fmt.Errorf("reset prompts: %w", err)
+	}
+	result.PromptsReset = promptsReset
+
+	// reset agents directory
+	agentsDir := filepath.Join(configDir, "agents")
+	agentsReset, err := d.resetAgentsDir(agentsDir, scanner, stdout)
+	if err != nil {
+		return result, fmt.Errorf("reset agents: %w", err)
+	}
+	result.AgentsReset = agentsReset
+
+	// print summary
+	d.printResetSummary(result, stdout)
+
+	return result, nil
+}
+
+// resetConfigFile handles interactive reset of the config file.
+func (d *defaultsInstaller) resetConfigFile(configPath string, scanner *bufio.Scanner, stdout io.Writer) (bool, error) {
+	fmt.Fprintf(stdout, "Config file?\n")
+
+	// read embedded default
+	embeddedData, err := d.embedFS.ReadFile("defaults/config")
+	if err != nil {
+		return false, fmt.Errorf("read embedded config: %w", err)
+	}
+
+	// check if local config exists and differs
+	info, statErr := os.Stat(configPath)
+	switch {
+	case os.IsNotExist(statErr):
+		fmt.Fprintf(stdout, "  missing, will be created from defaults\n")
+	case statErr != nil:
+		return false, fmt.Errorf("stat config: %w", statErr)
+	default:
+		localData, err := os.ReadFile(configPath) //nolint:gosec // user's config file
+		if err != nil {
+			return false, fmt.Errorf("read local config: %w", err)
+		}
+
+		if bytes.Equal(embeddedData, localData) {
+			fmt.Fprintf(stdout, "  skipped (matches defaults)\n")
+			return false, nil
+		}
+
+		fmt.Fprintf(stdout, "  modified (%s), will be reset to defaults\n", info.ModTime().Format("2006-01-02"))
+	}
+
+	if !d.askYesNo(scanner, stdout) {
+		return false, nil
+	}
+
+	// ensure parent directory exists (for first run or after user deleted ~/.config/ralphex/)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		return false, fmt.Errorf("create config dir: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, embeddedData, 0o600); err != nil {
+		return false, fmt.Errorf("write config file: %w", err)
+	}
+
+	return true, nil
+}
+
+// resetPromptsDir handles interactive reset of the prompts directory.
+func (d *defaultsInstaller) resetPromptsDir(promptsDir string, scanner *bufio.Scanner, stdout io.Writer) (bool, error) {
+	fmt.Fprintf(stdout, "\nPrompts directory?\n")
+
+	// find files that differ from embedded defaults
+	differentFiles, err := d.findDifferentFiles(promptsDir, "defaults/prompts")
+	if err != nil {
+		return false, fmt.Errorf("compare prompts: %w", err)
+	}
+
+	// find custom files (not in embedded defaults)
+	customFiles, err := d.findCustomFiles(promptsDir, "defaults/prompts")
+	if err != nil {
+		return false, fmt.Errorf("find custom prompts: %w", err)
+	}
+
+	if len(differentFiles) == 0 {
+		// still show custom files info even when defaults match
+		if len(customFiles) > 0 {
+			fmt.Fprintf(stdout, "  Custom prompts (untouched):\n")
+			for _, f := range customFiles {
+				fmt.Fprintf(stdout, "    %s\n", f)
+			}
+		}
+		fmt.Fprintf(stdout, "  skipped (all files match defaults)\n")
+		return false, nil
+	}
+
+	// display different files with dates
+	fmt.Fprintf(stdout, "  Different from current defaults:\n")
+	for _, f := range differentFiles {
+		if f.missing {
+			fmt.Fprintf(stdout, "    %s (missing)\n", f.name)
+		} else {
+			fmt.Fprintf(stdout, "    %s (%s)\n", f.name, f.modTime.Format("2006-01-02"))
+		}
+	}
+
+	// display custom files (informational)
+	if len(customFiles) > 0 {
+		fmt.Fprintf(stdout, "  Custom prompts (untouched):\n")
+		for _, f := range customFiles {
+			fmt.Fprintf(stdout, "    %s\n", f)
+		}
+	}
+
+	fmt.Fprintf(stdout, "  Note: differences may be your customizations or outdated defaults\n")
+	fmt.Fprintf(stdout, "  Reset will overwrite with current embedded defaults\n")
+
+	if !d.askYesNo(scanner, stdout) {
+		return false, nil
+	}
+
+	// overwrite only files that exist in embedded defaults
+	if err := d.overwriteEmbeddedFiles(promptsDir, "defaults/prompts"); err != nil {
+		return false, fmt.Errorf("overwrite prompts: %w", err)
+	}
+
+	return true, nil
+}
+
+// resetAgentsDir handles interactive reset of the agents directory.
+func (d *defaultsInstaller) resetAgentsDir(agentsDir string, scanner *bufio.Scanner, stdout io.Writer) (bool, error) {
+	fmt.Fprintf(stdout, "\nAgents directory?\n")
+
+	// find files that differ from embedded defaults
+	differentFiles, err := d.findDifferentFiles(agentsDir, "defaults/agents")
+	if err != nil {
+		return false, fmt.Errorf("compare agents: %w", err)
+	}
+
+	// find custom files (not in embedded defaults)
+	customFiles, err := d.findCustomFiles(agentsDir, "defaults/agents")
+	if err != nil {
+		return false, fmt.Errorf("find custom agents: %w", err)
+	}
+
+	if len(differentFiles) == 0 {
+		fmt.Fprintf(stdout, "  skipped (all files match defaults)\n")
+		return false, nil
+	}
+
+	// display different files with dates
+	if len(differentFiles) > 0 {
+		fmt.Fprintf(stdout, "  Different from current defaults:\n")
+		for _, f := range differentFiles {
+			if f.missing {
+				fmt.Fprintf(stdout, "    %s (missing)\n", f.name)
+			} else {
+				fmt.Fprintf(stdout, "    %s (%s)\n", f.name, f.modTime.Format("2006-01-02"))
+			}
+		}
+	}
+
+	// display custom files (informational)
+	if len(customFiles) > 0 {
+		fmt.Fprintf(stdout, "  Custom agents (untouched):\n")
+		for _, f := range customFiles {
+			fmt.Fprintf(stdout, "    %s\n", f)
+		}
+	}
+
+	// count embedded agents for message
+	embeddedCount, err := d.countEmbeddedFiles("defaults/agents")
+	if err != nil {
+		return false, fmt.Errorf("count embedded agents: %w", err)
+	}
+
+	if len(differentFiles) > 0 {
+		fmt.Fprintf(stdout, "  Note: differences may be your customizations or outdated defaults\n")
+		fmt.Fprintf(stdout, "  Reset will overwrite %d default agents, custom agents preserved\n", embeddedCount)
+	} else {
+		fmt.Fprintf(stdout, "  Reset will reinstall %d default agents, custom agents preserved\n", embeddedCount)
+	}
+
+	if !d.askYesNo(scanner, stdout) {
+		return false, nil
+	}
+
+	// overwrite only files that exist in embedded defaults
+	if err := d.overwriteEmbeddedFiles(agentsDir, "defaults/agents"); err != nil {
+		return false, fmt.Errorf("overwrite agents: %w", err)
+	}
+
+	return true, nil
+}
+
+// fileInfo holds information about a file for display.
+type fileInfo struct {
+	name    string
+	modTime time.Time
+	missing bool // true if file doesn't exist locally
+}
+
+// findDifferentFiles returns files in destDir that differ from embedded defaults.
+func (d *defaultsInstaller) findDifferentFiles(destDir, embedPath string) ([]fileInfo, error) {
+	var different []fileInfo
+
+	embeddedEntries, err := d.embedFS.ReadDir(embedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded dir: %w", err)
+	}
+
+	for _, entry := range embeddedEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".txt") {
+			continue
+		}
+
+		destPath := filepath.Join(destDir, entry.Name())
+		info, err := os.Stat(destPath)
+		if os.IsNotExist(err) {
+			// file doesn't exist locally - mark as missing
+			different = append(different, fileInfo{name: entry.Name(), missing: true})
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", entry.Name(), err)
+		}
+
+		// compare content hashes
+		embeddedData, err := d.embedFS.ReadFile(embedPath + "/" + entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read embedded %s: %w", entry.Name(), err)
+		}
+
+		localData, err := os.ReadFile(destPath) //nolint:gosec // user's config file
+		if err != nil {
+			return nil, fmt.Errorf("read local %s: %w", entry.Name(), err)
+		}
+
+		if !bytes.Equal(embeddedData, localData) {
+			different = append(different, fileInfo{name: entry.Name(), modTime: info.ModTime()})
+		}
+	}
+
+	return different, nil
+}
+
+// findCustomFiles returns files in destDir that don't exist in embedded defaults.
+func (d *defaultsInstaller) findCustomFiles(destDir, embedPath string) ([]string, error) {
+	var custom []string
+
+	// build set of embedded file names
+	embeddedNames := make(map[string]bool)
+	embeddedEntries, err := d.embedFS.ReadDir(embedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded dir: %w", err)
+	}
+	for _, entry := range embeddedEntries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".txt") {
+			embeddedNames[entry.Name()] = true
+		}
+	}
+
+	// find local files not in embedded
+	localEntries, err := os.ReadDir(destDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read local dir: %w", err)
+	}
+
+	for _, entry := range localEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".txt") {
+			continue
+		}
+		if !embeddedNames[entry.Name()] {
+			custom = append(custom, entry.Name())
+		}
+	}
+
+	return custom, nil
+}
+
+// countEmbeddedFiles returns the number of .txt files in an embedded directory.
+func (d *defaultsInstaller) countEmbeddedFiles(embedPath string) (int, error) {
+	entries, err := d.embedFS.ReadDir(embedPath)
+	if err != nil {
+		return 0, fmt.Errorf("read embedded dir: %w", err)
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".txt") {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// overwriteEmbeddedFiles overwrites files in destDir with embedded defaults.
+// only overwrites files that exist in embedded defaults - preserves custom files.
+func (d *defaultsInstaller) overwriteEmbeddedFiles(destDir, embedPath string) error {
+	// ensure directory exists
+	if err := os.MkdirAll(destDir, 0o700); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	embeddedEntries, err := d.embedFS.ReadDir(embedPath)
+	if err != nil {
+		return fmt.Errorf("read embedded dir: %w", err)
+	}
+
+	for _, entry := range embeddedEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".txt") {
+			continue
+		}
+
+		embeddedData, err := d.embedFS.ReadFile(embedPath + "/" + entry.Name())
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", entry.Name(), err)
+		}
+
+		destPath := filepath.Join(destDir, entry.Name())
+		if err := os.WriteFile(destPath, embeddedData, 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", entry.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+// Reset is a package-level function that creates a defaultsInstaller and calls Reset.
+// this is the public API for resetting configuration.
+func Reset(configDir string, stdin io.Reader, stdout io.Writer) (ResetResult, error) {
+	installer := newDefaultsInstaller(defaultsFS)
+	return installer.Reset(configDir, stdin, stdout)
+}
+
+// askYesNo prompts the user with [y/N] and returns true for yes.
+func (d *defaultsInstaller) askYesNo(scanner *bufio.Scanner, stdout io.Writer) bool {
+	fmt.Fprintf(stdout, "  [y/N]: ")
+
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(stdout, "\nerror reading input: %v\n", err)
+		} else {
+			fmt.Fprintln(stdout) // EOF
+		}
+		return false
+	}
+
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	return answer == "y" || answer == "yes"
+}
+
+// printResetSummary prints a summary of what was reset.
+func (d *defaultsInstaller) printResetSummary(result ResetResult, stdout io.Writer) {
+	var reset, skipped []string
+
+	if result.ConfigReset {
+		reset = append(reset, "config")
+	} else {
+		skipped = append(skipped, "config")
+	}
+
+	if result.PromptsReset {
+		reset = append(reset, "prompts")
+	} else {
+		skipped = append(skipped, "prompts")
+	}
+
+	if result.AgentsReset {
+		reset = append(reset, "agents")
+	} else {
+		skipped = append(skipped, "agents")
+	}
+
+	fmt.Fprintf(stdout, "\nDone.")
+	if len(reset) > 0 {
+		fmt.Fprintf(stdout, " Reset: %s.", strings.Join(reset, ", "))
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(stdout, " Skipped: %s.", strings.Join(skipped, ", "))
+	}
+	_, _ = fmt.Fprintln(stdout)
 }


### PR DESCRIPTION
**Summary**

Add interactive reset functionality to restore global config, prompts, and agents to embedded defaults. Prompts user for each component before resetting, shows modified files with dates, preserves custom files.

**Changes**

- New `--reset` CLI flag runs before config load for standalone use
- Can combine with other flags (e.g., `ralphex --reset plan.md`)
- Export `DefaultConfigDir()` from config package
- Show custom prompts/agents that won't be affected
- Skip prompt when files already match defaults
- Add linter exclusion for `Fprintln` error handling