### PR TITLE
feat(prompts): add DEFAULT_BRANCH template variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,14 @@ project/
 - `simplification.txt` - detects over-engineering
 - `testing.txt` - reviews test coverage and quality
 
-**Template syntax:** Use `{{agent:name}}` in prompt files to reference agents. Each reference expands to Task tool instructions that tell Claude Code to run that agent.
+**Template variables:** Prompt files support variable expansion via `replacePromptVariables()` in `pkg/processor/prompts.go`:
+- `{{PLAN_FILE}}` - path to plan file or fallback text
+- `{{PROGRESS_FILE}}` - path to progress log or fallback text
+- `{{GOAL}}` - human-readable goal (plan-based or branch comparison)
+- `{{DEFAULT_BRANCH}}` - detected default branch (main, master, origin/main, etc.)
+- `{{agent:name}}` - expands to Task tool instructions for the named agent
+
+Variables are also expanded inside agent content, so custom agents can use `{{DEFAULT_BRANCH}}` etc.
 
 **Customization:**
 - Edit files in `~/.config/ralphex/agents/` to modify agent prompts

--- a/README.md
+++ b/README.md
@@ -277,6 +277,20 @@ These 5 agents cover common review concerns and work well out of the box. Custom
 
 ### Template Syntax
 
+Custom prompt files support variable expansion. All variables use the `{{VARIABLE}}` syntax.
+
+**Available variables:**
+
+| Variable | Description | Example value |
+|----------|-------------|---------------|
+| `{{PLAN_FILE}}` | Path to the plan file being executed | `docs/plans/feature.md` |
+| `{{PROGRESS_FILE}}` | Path to the progress log file | `progress-feature.txt` |
+| `{{GOAL}}` | Human-readable goal description | `implementation of plan at docs/plans/feature.md` |
+| `{{DEFAULT_BRANCH}}` | Default branch name (detected from repo) | `main`, `master`, `origin/main` |
+| `{{agent:name}}` | Expands to Task tool instructions for the named agent | (see below) |
+
+**Agent references:**
+
 Reference agents in prompt files using `{{agent:name}}` syntax:
 
 ```
@@ -286,7 +300,7 @@ Launch the following review agents in parallel:
 {{agent:testing}}
 ```
 
-Each `{{agent:name}}` expands to Task tool instructions that tell Claude Code to run that agent.
+Each `{{agent:name}}` expands to Task tool instructions that tell Claude Code to run that agent. Variables inside agent content are also expanded, so agents can use `{{DEFAULT_BRANCH}}` or other variables.
 
 ### Customization
 

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -354,7 +354,7 @@ func TestCreateRunner(t *testing.T) {
 		require.NoError(t, err)
 		defer log.Close()
 
-		runner := createRunner(cfg, o, "/path/to/plan.md", processor.ModeFull, log)
+		runner := createRunner(cfg, o, "/path/to/plan.md", processor.ModeFull, log, "master")
 		assert.NotNil(t, runner)
 	})
 
@@ -368,7 +368,7 @@ func TestCreateRunner(t *testing.T) {
 		defer log.Close()
 
 		// tests that codex-only mode code path runs without panic
-		runner := createRunner(cfg, o, "", processor.ModeCodexOnly, log)
+		runner := createRunner(cfg, o, "", processor.ModeCodexOnly, log, "main")
 		assert.NotNil(t, runner)
 	})
 }

--- a/llms.txt
+++ b/llms.txt
@@ -44,6 +44,23 @@ ralphex --reset
 - `fzf` - for plan selection (optional)
 - `codex` - for external review (optional)
 
+## Customization
+
+Configuration directory: `~/.config/ralphex/`
+
+**Prompt files** (`~/.config/ralphex/prompts/`): `task.txt`, `review_first.txt`, `review_second.txt`, `codex.txt`, `make_plan.txt`
+
+**Agent files** (`~/.config/ralphex/agents/`): Custom review agents referenced via `{{agent:name}}` in prompts
+
+**Template variables** (available in prompt and agent files):
+- `{{PLAN_FILE}}` - path to plan file
+- `{{PROGRESS_FILE}}` - path to progress log
+- `{{GOAL}}` - goal description
+- `{{DEFAULT_BRANCH}}` - detected default branch (main, master, etc.)
+- `{{agent:name}}` - expands to Task tool instructions for named agent
+
+Run `ralphex --reset` to restore default configuration interactively.
+
 ---
 
 ## Claude Code Integration (Optional)

--- a/pkg/config/defaults/prompts/codex.txt
+++ b/pkg/config/defaults/prompts/codex.txt
@@ -5,6 +5,7 @@
 # available variables:
 #   {{PLAN_FILE}} - path to the plan file being executed
 #   {{GOAL}} - human-readable goal description
+#   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
 #   {{CODEX_OUTPUT}} - output from codex code review
 
 External code review evaluation.

--- a/pkg/config/defaults/prompts/make_plan.txt
+++ b/pkg/config/defaults/prompts/make_plan.txt
@@ -5,6 +5,7 @@
 # available variables:
 #   {{PLAN_DESCRIPTION}} - user's original request for what to implement
 #   {{PROGRESS_FILE}} - path to progress file with Q&A history
+#   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
 
 You are helping create an implementation plan for: {{PLAN_DESCRIPTION}}
 

--- a/pkg/config/defaults/prompts/review_first.txt
+++ b/pkg/config/defaults/prompts/review_first.txt
@@ -6,6 +6,7 @@
 #   {{PLAN_FILE}} - path to the plan file being executed
 #   {{PROGRESS_FILE}} - path to the progress log (task execution + previous reviews)
 #   {{GOAL}} - human-readable goal description
+#   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
 #   {{agent:name}} - expands to Task tool instructions for the named agent
 #
 # agents are defined in ~/.config/ralphex/agents/ (user) or pkg/config/defaults/agents/ (builtin)
@@ -17,8 +18,8 @@ Progress log: {{PROGRESS_FILE}} (contains task execution and previous review ite
 ## Step 1: Get Branch Context
 
 Run both commands to understand what was done:
-- `git log master..HEAD --oneline` - see commit history (what was implemented)
-- `git diff master...HEAD` - see actual code changes
+- `git log {{DEFAULT_BRANCH}}..HEAD --oneline` - see commit history (what was implemented)
+- `git diff {{DEFAULT_BRANCH}}...HEAD` - see actual code changes
 
 ## Step 2: Launch ALL 5 Review Agents IN PARALLEL
 

--- a/pkg/config/defaults/prompts/review_second.txt
+++ b/pkg/config/defaults/prompts/review_second.txt
@@ -6,6 +6,7 @@
 #   {{PLAN_FILE}} - path to the plan file being executed
 #   {{PROGRESS_FILE}} - path to the progress log (task execution + previous reviews)
 #   {{GOAL}} - human-readable goal description
+#   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
 #   {{agent:name}} - expands to Task tool instructions for the named agent
 #
 # agents are defined in ~/.config/ralphex/agents/ (user) or pkg/config/defaults/agents/ (builtin)
@@ -17,8 +18,8 @@ Progress log: {{PROGRESS_FILE}} (contains task execution and previous review ite
 ## Step 1: Get Branch Context
 
 Run both commands to understand what was done:
-- `git log master..HEAD --oneline` - see commit history (what was implemented)
-- `git diff master...HEAD` - see actual code changes
+- `git log {{DEFAULT_BRANCH}}..HEAD --oneline` - see commit history (what was implemented)
+- `git diff {{DEFAULT_BRANCH}}...HEAD` - see actual code changes
 
 ## Step 2: Launch Review Agents IN PARALLEL
 

--- a/pkg/config/defaults/prompts/task.txt
+++ b/pkg/config/defaults/prompts/task.txt
@@ -5,6 +5,7 @@
 #   {{PLAN_FILE}} - path to the plan file being executed
 #   {{PROGRESS_FILE}} - path to the progress log file
 #   {{GOAL}} - human-readable goal description
+#   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
 
 Read the plan file at {{PLAN_FILE}}. Find the FIRST Task section (### Task N: or ### Iteration N:) that has uncompleted checkboxes ([ ]).
 

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -49,6 +49,12 @@ func (s *Service) IsMainBranch() (bool, error) {
 	return s.repo.IsMainBranch()
 }
 
+// GetDefaultBranch returns the default branch name.
+// detects from origin/HEAD or common branch names (main, master, trunk, develop).
+func (s *Service) GetDefaultBranch() string {
+	return s.repo.GetDefaultBranch()
+}
+
 // HasCommits returns true if the repository has at least one commit.
 func (s *Service) HasCommits() (bool, error) {
 	return s.repo.HasCommits()

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -491,3 +491,27 @@ func TestService_EnsureIgnored(t *testing.T) {
 		assert.Contains(t, string(content), "*.tmp")
 	})
 }
+
+func TestService_GetDefaultBranch(t *testing.T) {
+	t.Run("returns detected default branch", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		svc, err := NewService(dir, noopServiceLogger())
+		require.NoError(t, err)
+
+		branch := svc.GetDefaultBranch()
+		assert.Equal(t, "master", branch)
+	})
+
+	t.Run("returns main when main branch exists", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		svc, err := NewService(dir, noopServiceLogger())
+		require.NoError(t, err)
+
+		// create main branch
+		err = svc.CreateBranch("main")
+		require.NoError(t, err)
+
+		branch := svc.GetDefaultBranch()
+		assert.Equal(t, "main", branch)
+	})
+}


### PR DESCRIPTION
**Summary**

- Add `{{DEFAULT_BRANCH}}` template variable for prompts to replace hardcoded `master` references
- Detect default branch from `origin/HEAD` symbolic ref or common branch names (main, master, trunk, develop)
- Verify local branch exists before returning; fall back to remote-tracking ref (e.g., `origin/main`) if local doesn't exist
- Expand template variables inside agent content so custom agents can use `{{DEFAULT_BRANCH}}`
- Refactor `GetDefaultBranch()` to return just `string` (no error) since it always falls back to "master"
- Document all template variables in README.md, CLAUDE.md, and llms.txt

**Changes**

- `pkg/git/git.go` - add `GetDefaultBranch()` with origin/HEAD detection and local branch verification
- `pkg/git/service.go` - expose via Service wrapper
- `pkg/processor/prompts.go` - add `replaceBaseVariables()`, refactor variable expansion, inline wrapper functions
- `pkg/processor/runner.go` - add `DefaultBranch` to Config, use in codex prompt
- `cmd/ralphex/main.go` - detect and pass default branch through all execution paths
- `pkg/config/defaults/prompts/*.txt` - add `{{DEFAULT_BRANCH}}` to available variables, use in review prompts

Related to #45