### PR TITLE
feat(git): add diff stats to completion message

### DIFF
--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -204,6 +204,12 @@ func (s *Service) EnsureHasCommits(promptFn func() bool) error {
 	return nil
 }
 
+// DiffStats returns change statistics between baseBranch and HEAD.
+// returns zero stats if baseBranch doesn't exist or HEAD equals baseBranch.
+func (s *Service) DiffStats(baseBranch string) (DiffStats, error) {
+	return s.repo.diffStats(baseBranch)
+}
+
 // EnsureIgnored ensures a pattern is in .gitignore.
 // uses probePath to check if pattern is already ignored before adding.
 // if pattern is already ignored, does nothing.


### PR DESCRIPTION
**Summary**

Display lines added/deleted statistics at completion using go-git Commit.Patch() with FileStats.

- Added `DiffStats` struct and `diffStats()` method to git package
- Added public `DiffStats()` wrapper on Service
- Updated completion message in `executePlan()` to show stats when available
- Output format: `completed in 5m32s (19 files, +622/-3 lines)` when changes exist

**Changes**

- `pkg/git/git.go` - add DiffStats struct, diffStats() and resolveToCommit() methods
- `pkg/git/service.go` - add public DiffStats() wrapper
- `cmd/ralphex/main.go` - update completion message with stats
- `pkg/git/git_test.go` - tests for diffStats and resolveToCommit
- `pkg/git/service_test.go` - tests for Service.DiffStats

Related to #65