### PR TITLE
fix: resolve version as unknown when installed via go install

### DIFF
--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -885,3 +885,22 @@ func setupTestRepo(t *testing.T) string {
 
 	return dir
 }
+
+func TestResolveVersion(t *testing.T) {
+	t.Run("ldflags_set", func(t *testing.T) {
+		orig := revision
+		t.Cleanup(func() { revision = orig })
+		revision = "v1.2.3-abc1234"
+		assert.Equal(t, "v1.2.3-abc1234", resolveVersion())
+	})
+
+	t.Run("fallback_to_build_info", func(t *testing.T) {
+		orig := revision
+		t.Cleanup(func() { revision = orig })
+		revision = "unknown"
+		// in test context, debug.ReadBuildInfo returns (devel) module version
+		// but VCS info should be available from the git repo
+		v := resolveVersion()
+		assert.NotEmpty(t, v)
+	})
+}


### PR DESCRIPTION
`go install` doesn't inject ldflags, so `revision` stays `"unknown"`. Added `resolveVersion()` fallback using `debug.ReadBuildInfo()`:

- **`go install @latest`** → module version from tag (e.g. `v0.10.0`)
- **`go install @v0.10.0`** → `v0.10.0`
- **local `go build`** without ldflags → short VCS commit hash (e.g. `abc1234`)
- **`make build`** → unchanged, ldflags take priority

Related to #83
