### PR TITLE
Fix Ctrl+C (SIGINT) handling for immediate response

### DIFF
--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -199,7 +199,7 @@ func TestClaudeExecutor_parseStream(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			e := &ClaudeExecutor{}
-			result := e.parseStream(strings.NewReader(tc.input))
+			result := e.parseStream(context.Background(), strings.NewReader(tc.input))
 
 			assert.Equal(t, tc.wantOutput, result.Output)
 			assert.Equal(t, tc.wantSignal, result.Signal)
@@ -218,7 +218,7 @@ func TestClaudeExecutor_parseStream_withHandler(t *testing.T) {
 		},
 	}
 
-	result := e.parseStream(strings.NewReader(input))
+	result := e.parseStream(context.Background(), strings.NewReader(input))
 
 	assert.Equal(t, "chunk1chunk2", result.Output)
 	assert.Equal(t, []string{"chunk1", "chunk2"}, chunks)
@@ -229,7 +229,7 @@ func TestClaudeExecutor_parseStream_withDebug(t *testing.T) {
 	input := "not json\n" + `{"type":"content_block_delta","delta":{"type":"text_delta","text":"valid"}}`
 
 	e := &ClaudeExecutor{Debug: true}
-	result := e.parseStream(strings.NewReader(input))
+	result := e.parseStream(context.Background(), strings.NewReader(input))
 
 	assert.Equal(t, "not json\nvalid", result.Output)
 }
@@ -501,7 +501,7 @@ func TestClaudeExecutor_parseStream_largeLines(t *testing.T) {
 			jsonLine := `{"type":"content_block_delta","delta":{"type":"text_delta","text":"` + largeText + `"}}`
 
 			e := &ClaudeExecutor{}
-			result := e.parseStream(strings.NewReader(jsonLine))
+			result := e.parseStream(context.Background(), strings.NewReader(jsonLine))
 
 			require.NoError(t, result.Error, "should handle %d byte line without error", tc.size)
 			assert.Len(t, result.Output, tc.size, "output should contain full text")
@@ -522,7 +522,7 @@ func TestClaudeExecutor_parseStream_multipleLargeLines(t *testing.T) {
 	input := strings.Join(lines, "\n")
 
 	e := &ClaudeExecutor{}
-	result := e.parseStream(strings.NewReader(input))
+	result := e.parseStream(context.Background(), strings.NewReader(input))
 
 	require.NoError(t, result.Error)
 	assert.Len(t, result.Output, lineSize*numLines, "should contain all output from all lines")


### PR DESCRIPTION
Three root causes made Ctrl+C unreliable — sometimes slow, sometimes ignored:

**ClaudeExecutor.parseStream ignored context** — unlike codex/custom executors that check `ctx.Done()` on every scan iteration, the claude executor just looped on `scanner.Scan()` until the pipe closed. Added context parameter and `ctx.Done()` check matching the existing pattern in codex/custom.

**time.Sleep in runner loops blocked cancellation** — six `time.Sleep(iterationDelay)` calls (default 2s each) blocked for full duration even after context cancellation. Replaced all with `sleepWithContext()` method using `select` on timer + `ctx.Done()`.

**No immediate user feedback on Ctrl+C** — nothing was printed until the current blocking operation finished. Added `startInterruptWatcher()` goroutine that prints "interrupting..." to stderr instantly when context is canceled, with cleanup channel to prevent goroutine leaks in tests.

*Includes regression test verifying prompt exit on context cancellation during iteration delay (5s delay, cancels after 50ms, asserts exit well under 5s).*