### PR TITLE
fix: include stderr content in codex error messages

### DIFF
--- a/pkg/executor/codex.go
+++ b/pkg/executor/codex.go
@@ -219,12 +219,13 @@ func (e *CodexExecutor) processStderr(ctx context.Context, r io.Reader) stderrRe
 
 		line := scanner.Text()
 
-		// capture unfiltered non-empty lines for error context
-		if trimmed := strings.TrimSpace(line); trimmed != "" {
-			if len(trimmed) > maxLineLength {
-				trimmed = trimmed[:maxLineLength] + "..."
+		// capture non-empty lines for error context, preserving original formatting
+		if strings.TrimSpace(line) != "" {
+			stored := line
+			if runes := []rune(stored); len(runes) > maxLineLength {
+				stored = string(runes[:maxLineLength]) + "..."
 			}
-			tail = append(tail, trimmed)
+			tail = append(tail, stored)
 			if len(tail) > maxTailLines {
 				copy(tail, tail[1:])
 				tail = tail[:maxTailLines]

--- a/pkg/executor/codex_test.go
+++ b/pkg/executor/codex_test.go
@@ -533,8 +533,12 @@ func TestCodexExecutor_processStderr_lastLines(t *testing.T) {
 			[]string{"line3", "line4", "line5", "line6", "line7"}},
 		{"fewer than 5 lines keeps all", "line1\nline2\n", []string{"line1", "line2"}},
 		{"empty stderr", "", nil},
-		{"long lines truncated to 256 chars", strings.Repeat("x", 500) + "\n",
+		{"long lines truncated to 256 runes", strings.Repeat("x", 500) + "\n",
 			[]string{strings.Repeat("x", 256) + "..."}},
+		{"preserves leading whitespace", "  indented line\n\t\ttabbed line\n",
+			[]string{"  indented line", "\t\ttabbed line"}},
+		{"truncates by runes not bytes", strings.Repeat("ж", 300) + "\n",
+			[]string{strings.Repeat("ж", 256) + "..."}},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
When codex exits with non-zero status, the error message now includes the last 5 lines of stderr (each truncated to 256 chars), surfacing actual failure reasons like authentication errors or rate limits instead of just "exit status 1".

**Changes:**
- Added `stderrResult` type to capture both processing error and stderr tail from `processStderr`
- `processStderr` now maintains a rolling buffer of last 5 non-empty stderr lines
- Per-line truncation to 256 chars prevents oversized error strings from large stderr output
- Error message includes stderr tail when codex exits non-zero and stderr has content

*Before:* `codex exited with error: exit status 1`
*After:* `codex exited with error: exit status 1\nstderr: Error: authentication failed\nPlease check your API key`