### PR TITLE
Add 5-second force exit after SIGINT and suppress ^C echo

### DIFF
--- a/cmd/ralphex/terminal_unix.go
+++ b/cmd/ralphex/terminal_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+// disableCtrlCEcho disables the ECHOCTL terminal flag so that pressing Ctrl+C
+// does not echo "^C" to the terminal. returns a function that restores the original state.
+func disableCtrlCEcho() func() {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return func() {}
+	}
+
+	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return func() {}
+	}
+
+	original := *termios
+	termios.Lflag &^= unix.ECHOCTL
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, termios); err != nil {
+		return func() {}
+	}
+
+	return func() {
+		unix.IoctlSetTermios(fd, ioctlWriteTermios, &original) //nolint:errcheck // best-effort restore
+	}
+}

--- a/cmd/ralphex/terminal_unix_bsd.go
+++ b/cmd/ralphex/terminal_unix_bsd.go
@@ -1,0 +1,10 @@
+//go:build darwin || freebsd || openbsd || netbsd || dragonfly
+
+package main
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlReadTermios  = unix.TIOCGETA
+	ioctlWriteTermios = unix.TIOCSETA
+)

--- a/cmd/ralphex/terminal_unix_other.go
+++ b/cmd/ralphex/terminal_unix_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !freebsd && !openbsd && !netbsd && !dragonfly && !windows
+
+package main
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlReadTermios  = unix.TCGETS
+	ioctlWriteTermios = unix.TCSETS
+)

--- a/cmd/ralphex/terminal_windows.go
+++ b/cmd/ralphex/terminal_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package main
+
+// disableCtrlCEcho is a no-op on windows.
+func disableCtrlCEcho() func() {
+	return func() {}
+}


### PR DESCRIPTION
Auto force-exit after 5 seconds if graceful shutdown hangs on Ctrl+C, removing the need to press Ctrl+C twice. Also suppress ^C terminal echo via ECHOCTL flag manipulation with platform-specific implementations.

**Changes:**
- Modified startInterruptWatcher to start a 5-second timer after context cancellation; calls os.Exit(1) if graceful shutdown does not complete in time
- Added disableCtrlCEcho() with platform-specific implementations: Unix BSD (TIOCGETA/TIOCSETA), Unix Linux/other (TCGETS/TCSETS), Windows (no-op stub)
- Terminal state restored on normal exit via deferred cleanup