### PR TITLE
fix: preserve markdown headers in prompt and agent files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,7 @@ project/
 - **Auto-update**: files with only comments/whitespace are safe to overwrite on updates - users get new defaults automatically
 - **User customization**: uncommenting any line marks the file as customized - it will be preserved and never overwritten
 - **Fallback loading**: when loading config/prompts/agents, if file content is all-commented (no actual values), embedded defaults are used
+- **Comment preservation**: comment lines (`# ...`) in prompt and agent files are preserved in loaded content; stripping is only used for emptiness detection to trigger fallback
 - **scalars/colors**: per-field fallback to embedded defaults if missing
 - `*Set` flags (e.g., `CodexEnabledSet`) distinguish explicit `false`/`0` from "not set"
 

--- a/README.md
+++ b/README.md
@@ -503,8 +503,8 @@ The entire system is designed for customization - both task execution and review
 - `review_second.txt` - final review, critical/major issues only (default: 2 agents - quality, implementation; customizable)
 - `finalize.txt` - optional finalize step prompt (disabled by default)
 
-**Comment syntax:**
-Lines starting with `#` (after optional whitespace) are treated as comments and stripped when loading prompt and agent files. Use comments to document your customizations:
+**Comment lines and markdown headers:**
+Lines starting with `#` are preserved in prompt and agent files. Use them freely for markdown headers, documentation comments, or any other purpose:
 
 ```txt
 # security agent - checks for vulnerabilities
@@ -512,6 +512,8 @@ Lines starting with `#` (after optional whitespace) are treated as comments and 
 check for SQL injection
 check for XSS
 ```
+
+Files containing *only* comment lines (every line starts with `#`) are treated as unmodified templates and fall back to embedded defaults. This is how commented-out default files work — once you add any non-comment content, the file is used as-is.
 
 Note: Inline comments are not supported (`text # comment` keeps the entire line).
 


### PR DESCRIPTION
`stripComments` strips ALL `#` lines throughout prompt and agent files, which destroys markdown headers (`## Step 1`, `# Title`, etc.) in prompt body. All 8 prompt files and 5 agent files are affected.

**Fix:** stop calling `stripComments` when loading prompt/agent content. It's now used only for emptiness detection (fallback to embedded defaults when file is all-commented). Added `stripLeadingComments` helper for frontmatter parsing in agent files that have comment lines before `---` delimiter. Added `normalizeCRLF` for CRLF handling previously done inside `stripComments`.

Related to #88
