### PR TITLE
fix: strengthen review signal handling in prompts

### DIFF
--- a/pkg/config/defaults/prompts/codex.txt
+++ b/pkg/config/defaults/prompts/codex.txt
@@ -41,6 +41,12 @@ Do NOT reject issues just because they existed before this branch - fix them any
 - STOP here and DO NOT output any signal - the external loop will run codex again to verify fixes
 - NEVER output CODEX_REVIEW_DONE after fixing issues
 
+**If you dismissed ALL findings as invalid** (codex reported issues but none are actionable):
+- Explain why each finding is invalid
+- Do NOT commit anything
+- Do NOT output any signal
+- STOP here — the loop will re-run the external tool with your explanations for context
+
 **If Codex reports NO actionable issues** (empty output, "no issues found", "NO ISSUES FOUND"):
 - Run `git diff` to review ALL uncommitted changes (accumulated fixes from multiple iterations)
 - Commit all fixes with message: "fix: address codex review findings"

--- a/pkg/config/defaults/prompts/custom_eval.txt
+++ b/pkg/config/defaults/prompts/custom_eval.txt
@@ -40,6 +40,12 @@ Do NOT reject issues just because they existed before this branch - fix them any
 - Do NOT commit yet - more review iterations may follow
 - STOP and let the external loop run the review tool again
 
+**If you dismissed ALL findings as invalid** (review tool reported issues but none are actionable):
+- Explain why each finding is invalid
+- Do NOT commit anything
+- Do NOT output any signal
+- STOP here — the loop will re-run the external tool with your explanations for context
+
 **If the review tool reports NO actionable issues** (empty output, "no issues found", "NO ISSUES FOUND"):
 - Run `git diff` to review ALL uncommitted changes (accumulated fixes from multiple iterations)
 - Commit all fixes with message: "fix: address external review findings"

--- a/pkg/config/defaults/prompts/review_first.txt
+++ b/pkg/config/defaults/prompts/review_first.txt
@@ -27,6 +27,8 @@ Launch all agents using the Task tool with run_in_background=true (all in one re
 Then immediately call TaskOutput(task_id, block=true) for EACH agent to wait for its completion.
 Collect ALL results before proceeding.
 
+CRITICAL: Do NOT proceed to Step 3 until ALL 5 agents have returned results. Wait for every TaskOutput call to complete. Do not start evaluating findings or deciding on signals based on partial results.
+
 Agents to launch:
 {{agent:quality}}
 {{agent:implementation}}
@@ -67,6 +69,8 @@ Do NOT reject issues just because they existed before this branch - fix them any
 ## Step 4: Signal Completion
 
 SIGNAL LOGIC - READ CAREFULLY:
+
+IMPORTANT: Do not decide on a signal path until you have completed Steps 1-3 in full — all agents finished, all results collected, all findings verified and acted on.
 
 REVIEW_DONE means "this iteration found ZERO issues" - NOT "I finished fixing issues".
 

--- a/pkg/config/defaults/prompts/review_second.txt
+++ b/pkg/config/defaults/prompts/review_second.txt
@@ -27,6 +27,8 @@ Launch both agents using the Task tool with run_in_background=true (both in one 
 Then immediately call TaskOutput(task_id, block=true) for EACH agent to wait for its completion.
 Collect ALL results before proceeding.
 
+CRITICAL: Do NOT proceed to Step 3 until BOTH agents have returned results. Wait for every TaskOutput call to complete. Do not start evaluating findings or deciding on signals based on partial results.
+
 Agents to launch:
 {{agent:quality}}
 {{agent:implementation}}
@@ -47,6 +49,8 @@ IMPORTANT: Pre-existing issues (linter errors, failed tests) should also be fixe
 Do NOT reject issues just because they existed before this branch - fix them anyway.
 
 SIGNAL LOGIC - READ CAREFULLY:
+
+IMPORTANT: Do not decide on a signal path until you have completed Steps 1-3 in full — all agents finished, all results collected, all findings verified and acted on.
 
 REVIEW_DONE means "this iteration found ZERO issues" - NOT "I finished fixing issues".
 


### PR DESCRIPTION
Addresses two related review signal issues:

**#93 — REVIEW_DONE emitted multiple times during review phases**
Review prompts now explicitly require waiting for ALL agents to complete before proceeding to evaluation or signal decision. Added guard in both `review_first.txt` (5 agents) and `review_second.txt` (2 agents) to prevent premature signal emission based on partial results.

**#92 — CODEX_REVIEW_DONE emitted when all findings dismissed as invalid**
Added explicit third state in `codex.txt` and `custom_eval.txt`: when Claude dismisses all external tool findings as invalid, no signal is emitted and no commit is made. The loop re-runs the external tool with the explanations for context, rather than incorrectly signaling completion.

*Files changed: `pkg/config/defaults/prompts/review_first.txt`, `review_second.txt`, `codex.txt`, `custom_eval.txt`*

Related to #92, Related to #93