### PR TITLE
feat: add --config-dir flag and RALPHEX_CONFIG_DIR env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ GOOS=windows GOARCH=amd64 go build ./...
 
 ## Configuration
 
-- Global config location: `~/.config/ralphex/`
+- Global config location: `~/.config/ralphex/` (override with `--config-dir` or `RALPHEX_CONFIG_DIR`)
 - Local config location: `.ralphex/` (per-project, optional)
 - Config file format: INI (using gopkg.in/ini.v1)
 - Embedded defaults in `pkg/config/defaults/`

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Then use `ralphex` as usual - it runs in a container with Claude Code and Codex 
 **Environment variables:**
 - `RALPHEX_IMAGE` - Docker image to use (default: `ghcr.io/umputun/ralphex-go:latest`)
 - `RALPHEX_PORT` - Port for web dashboard when using `--serve` (default: `8080`)
+- `RALPHEX_CONFIG_DIR` - Custom config directory (default: `~/.config/ralphex`). Overrides global config location for prompts, agents, and settings
 - `CLAUDE_CONFIG_DIR` - Claude config directory (default: `~/.claude`). Use for alternate Claude installations (e.g., `~/.claude2`). Works both with Docker wrapper (volume mounts and keychain derivation) and non-Docker usage (passed through to Claude Code directly). Keychain service name is derived automatically from the path.
 
 **Updating:**
@@ -413,6 +414,7 @@ ralphex --serve --port 3000 docs/plans/feature.md
 | `-d, --debug` | Enable debug logging | false |
 | `--no-color` | Disable color output | false |
 | `--reset` | Interactively reset global config to embedded defaults | - |
+| `--config-dir` | Custom config directory (env: `RALPHEX_CONFIG_DIR`) | `~/.config/ralphex` |
 
 ## Plan File Format
 
@@ -566,7 +568,7 @@ Agents to launch:
 
 ## Configuration
 
-ralphex uses a configuration directory at `~/.config/ralphex/` with the following structure:
+ralphex uses a configuration directory at `~/.config/ralphex/` (override with `--config-dir` or `RALPHEX_CONFIG_DIR`) with the following structure:
 
 ```
 ~/.config/ralphex/
@@ -600,6 +602,8 @@ project/
 ```
 
 **Priority:** CLI flags > local `.ralphex/` > global `~/.config/ralphex/` > embedded defaults
+
+Use `--config-dir` or `RALPHEX_CONFIG_DIR` to override the global config location. This is useful for maintaining separate agent/prompt sets for different workflows.
 
 **Merge behavior:**
 - **Config file**: per-field override (local values override global, missing fields fall back)

--- a/llms.txt
+++ b/llms.txt
@@ -44,6 +44,10 @@ ralphex --plan "add user authentication"
 
 # reset global config to defaults (interactive)
 ralphex --reset
+
+# use custom config directory
+ralphex --config-dir ~/my-config docs/plans/feature.md
+RALPHEX_CONFIG_DIR=~/my-config ralphex docs/plans/feature.md
 ```
 
 ## Requirements
@@ -54,7 +58,7 @@ ralphex --reset
 
 ## Customization
 
-Configuration directory: `~/.config/ralphex/`
+Configuration directory: `~/.config/ralphex/` (override with `--config-dir` or `RALPHEX_CONFIG_DIR`)
 
 **Prompt files** (`~/.config/ralphex/prompts/`): `task.txt`, `review_first.txt`, `review_second.txt`, `codex.txt`, `custom_review.txt`, `custom_eval.txt`, `make_plan.txt`, `finalize.txt`
 
@@ -96,6 +100,7 @@ export RALPHEX_IMAGE=ghcr.io/umputun/ralphex:latest
 **Environment variables:**
 - `RALPHEX_IMAGE` - Docker image (default: `ghcr.io/umputun/ralphex-go:latest`)
 - `RALPHEX_PORT` - Web dashboard port with `--serve` (default: `8080`)
+- `RALPHEX_CONFIG_DIR` - Custom config directory (default: `~/.config/ralphex`). Overrides global config location for prompts, agents, and settings
 - `CLAUDE_CONFIG_DIR` - Claude config directory (default: `~/.claude`). Use for alternate Claude installations (e.g., `~/.claude2`). Works with both Docker wrapper and non-Docker usage.
 
 **Creating custom images for other languages:**

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -527,9 +527,12 @@ func (d *defaultsInstaller) overwriteEmbeddedFiles(destDir, embedPath string) er
 	return nil
 }
 
-// Reset is a package-level function that creates a defaultsInstaller and calls Reset.
-// this is the public API for resetting configuration.
+// Reset interactively restores configuration files to embedded defaults.
+// if configDir is empty, uses DefaultConfigDir().
 func Reset(configDir string, stdin io.Reader, stdout io.Writer) (ResetResult, error) {
+	if configDir == "" {
+		configDir = DefaultConfigDir()
+	}
 	installer := newDefaultsInstaller(defaultsFS)
 	return installer.Reset(configDir, stdin, stdout)
 }


### PR DESCRIPTION
Adds `--config-dir` CLI flag and `RALPHEX_CONFIG_DIR` environment variable to override the default `~/.config/ralphex/` config location. This enables maintaining separate agent/prompt sets for different workflows (e.g. analysis vs implementation phases).

**Changes:**
- New `--config-dir` flag on `opts` struct with `RALPHEX_CONFIG_DIR` env binding
- `config.Load()` and `config.Reset()` accept custom dir, falling back to `DefaultConfigDir()` when empty
- `runReset()` refactored to accept `io.Reader`/`io.Writer` for testability
- Documentation updated in README, llms.txt, and CLAUDE.md
- Tests for custom config dir loading, reset, and empty-dir fallback

Related to #97