### PR TITLE
Add "Other" option for custom answers in plan creation questions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ The `--plan "description"` flag enables interactive plan creation:
 
 - Claude explores codebase and asks clarifying questions
 - Questions use QUESTION signal with JSON: `{"question": "...", "options": [...]}`
-- User answers via fzf picker (or numbered fallback)
+- User answers via fzf picker (or numbered fallback); an "Other" option allows typing a custom answer
 - Q&A history stored in progress file for context
 - When ready, Claude emits PLAN_DRAFT signal with full plan content for user review
 - User can Accept, Revise (with feedback), or Reject the draft

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ QUESTION: Which cache backend?
   > Redis
     In-memory
     File-based
+    Other (type your own answer)
 
 [10:30:45] ANSWER: Redis
 [10:31:00] continuing plan creation...

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
-	"strings"
 	"syscall"
 	"time"
 
@@ -628,18 +627,7 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest) error {
 	}
 
 	// ask user if they want to continue with plan implementation
-	answer, askErr := collector.AskQuestion(ctx, "Continue with plan implementation?",
-		[]string{"Yes, execute plan", "No, exit"})
-	if askErr != nil {
-		// user canceled or error - treat as exit (context canceled is expected)
-		if ctx.Err() == nil {
-			fmt.Fprintf(os.Stderr, "warning: input error: %v\n", askErr)
-		}
-		return nil
-	}
-
-	// check if user wants to continue
-	if !strings.HasPrefix(answer, "Yes") {
+	if !input.AskYesNo(ctx, "Continue with plan implementation?", os.Stdin, os.Stdout) {
 		return nil
 	}
 


### PR DESCRIPTION
Related to #102

During `ralphex --plan`, when Claude asks a QUESTION with options, the user could only pick from predefined choices. Typing in fzf returned exit code 1 (no match) and crashed the session.

**Changes:**
- Append "Other (type your own answer)" to every QUESTION option list automatically
- Handle fzf exit code 1 (no match) by falling back to free-text input instead of erroring
- Support custom answer input in both fzf and numbered selection paths
- Filter duplicate sentinel value if model-generated options happen to contain it
- Add `noFzf` field to `TerminalCollector` for testable `AskQuestion` flow
- Update README example and CLAUDE.md to reflect the new behavior