### PR TITLE
fix: strip leading meta-comment blocks from loaded prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ project/
 - **Auto-update**: files with only comments/whitespace are safe to overwrite on updates - users get new defaults automatically
 - **User customization**: uncommenting any line marks the file as customized - it will be preserved and never overwritten
 - **Fallback loading**: when loading config/prompts/agents, if file content is all-commented (no actual values), embedded defaults are used
-- **Comment preservation**: comment lines (`# ...`) in prompt and agent files are preserved in loaded content; stripping is only used for emptiness detection to trigger fallback
+- **Comment handling**: leading meta-comment block (2+ contiguous `# ...` lines at top of file) is stripped when loading prompts and embedded defaults; a single `# Title` at the top is preserved (treated as markdown header, not meta-comment). Full `stripComments` is only used for emptiness detection to trigger fallback
 - **scalars/colors**: per-field fallback to embedded defaults if missing
 - `*Set` flags (e.g., `CodexEnabledSet`) distinguish explicit `false`/`0` from "not set"
 

--- a/README.md
+++ b/README.md
@@ -530,12 +530,12 @@ The entire system is designed for customization - both task execution and review
 - `finalize.txt` - optional finalize step prompt (disabled by default)
 
 **Comment lines and markdown headers:**
-Lines starting with `#` are preserved in prompt and agent files. Use them freely for markdown headers, documentation comments, or any other purpose:
+A leading block of 2+ contiguous comment lines (starting with `#`) at the top of a file is treated as a meta-comment and stripped when loading. A single `# Title` at the top is preserved (treated as a markdown header). Comment lines appearing later in the file body are always preserved:
 
 ```txt
-# security agent - checks for vulnerabilities
-# updated: 2024-01-15
+# This single title line is preserved as a markdown header
 check for SQL injection
+# this mid-body comment is also preserved
 check for XSS
 ```
 

--- a/pkg/config/agents.go
+++ b/pkg/config/agents.go
@@ -164,14 +164,14 @@ func (al *agentLoader) loadAllFromEmbedFS() ([]CustomAgent, error) {
 
 // buildAgent parses frontmatter options from prompt and builds a CustomAgent.
 // if parseOptions produces no body, the raw prompt is used with default options.
-// leading comment lines are stripped before frontmatter parsing so that
-// comments before "---" don't prevent frontmatter detection.
+// leading comment lines (any count, including single) are stripped before
+// frontmatter parsing so that comment lines before "---" don't prevent frontmatter detection.
 func (al *agentLoader) buildAgent(name, prompt string) CustomAgent {
 	// try frontmatter on raw content first, then with leading comments stripped
 	opts, body := parseOptions(prompt)
 	if opts == (Options{}) && body == prompt {
-		// no frontmatter found in raw content, try after stripping leading comments
-		if stripped := stripLeadingComments(prompt); stripped != prompt {
+		// no frontmatter found in raw content, try after stripping leading comment lines
+		if stripped := stripLeadingCommentLines(prompt); stripped != prompt {
 			opts, body = parseOptions(stripped)
 			if opts == (Options{}) {
 				// still no frontmatter, use original prompt


### PR DESCRIPTION
When loading prompts (both user files and embedded defaults), Claude would see meta-comment headers like `# finalize prompt` / `# available variables: ...` and interpret them as template documentation rather than executable instructions.

**Changes:**
- **`stripLeadingComments()`** — only strips when 2+ contiguous `#` lines at top (meta-comment block); a single `# Title` is preserved as markdown header
- **`loadPromptFile()`** and **`loadPromptFromEmbedFS()`** — apply `stripLeadingComments` so prompts load without meta-comment noise
- Tests updated with new threshold behavior, added finalize.txt and make_plan.txt embed verification
- CLAUDE.md updated to document the 2+ contiguous lines threshold