### PR TITLE
Move progress files to .ralphex/progress/ directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,8 +29,7 @@ Thumbs.db
 site/
 docs/
 
-# progress files
-progress*.txt
-
-# local config (should be mounted, not built into image)
+# local config and progress files (should be mounted, not built into image)
 .ralphex/
+progress.txt
+progress-*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,9 @@ dist/
 __debug_bin*
 
 # ralphex progress logs
-progress*.txt
+.ralphex/progress/
+/progress.txt
+/progress-*.txt
 !e2e/testdata/progress-test.txt
 !e2e/testdata/progress-full-events.txt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,10 +318,10 @@ go run <ralphex-project-root>/cmd/ralphex --codex-only
 
 ```bash
 # live stream (use actual filename from ralphex output)
-tail -f progress-fix-issues.txt
+tail -f .ralphex/progress/progress-fix-issues.txt
 
 # recent activity
-tail -50 progress-*.txt
+tail -50 .ralphex/progress/progress-*.txt
 ```
 
 ## Development Workflow
@@ -331,7 +331,7 @@ tail -50 progress-*.txt
 1. Run unit tests: `make test`
 2. Run linter: `make lint`
 3. **MUST** run end-to-end test with toy project (see above)
-4. Monitor `tail -f progress-*.txt` to verify output streaming works
+4. Monitor `tail -f .ralphex/progress/progress-*.txt` to verify output streaming works
 
 Unit tests don't verify actual codex/claude integration or output formatting. The toy project test is the only way to verify streaming output works correctly.
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Continue with plan implementation?
     No, exit
 ```
 
-After plan creation, you can choose to continue with immediate execution or exit to run ralphex later. Progress is logged to `progress-plan-<name>.txt`.
+After plan creation, you can choose to continue with immediate execution or exit to run ralphex later. Progress is logged to `.ralphex/progress/progress-plan-<name>.txt`.
 
 ## Installation
 
@@ -494,7 +494,7 @@ Custom prompt files support variable expansion. All variables use the `{{VARIABL
 | Variable | Description | Example value |
 |----------|-------------|---------------|
 | `{{PLAN_FILE}}` | Path to the plan file being executed | `docs/plans/feature.md` |
-| `{{PROGRESS_FILE}}` | Path to the progress log file | `progress-feature.txt` |
+| `{{PROGRESS_FILE}}` | Path to the progress log file | `.ralphex/progress/progress-feature.txt` |
 | `{{GOAL}}` | Human-readable goal description | `implementation of plan at docs/plans/feature.md` |
 | `{{DEFAULT_BRANCH}}` | Default branch name (detected from repo) | `main`, `master`, `origin/main` |
 | `{{agent:name}}` | Expands to Task tool instructions for the named agent | (see below) |
@@ -792,7 +792,7 @@ Yes, two approaches depending on the situation:
 
 **What's the difference between progress file and plan file?**
 
-Progress file (`progress-*.txt`) is a real-time execution log—tail it to monitor. Plan file tracks task state (`[ ]` vs `[x]`). To resume, re-run ralphex on the plan file; it finds incomplete tasks automatically.
+Progress file (`.ralphex/progress/progress-*.txt`) is a real-time execution log—tail it to monitor. Plan file tracks task state (`[ ]` vs `[x]`). To resume, re-run ralphex on the plan file; it finds incomplete tasks automatically.
 
 **Do I need to commit changes before running ralphex?**
 

--- a/assets/claude/skills/ralphex/SKILL.md
+++ b/assets/claude/skills/ralphex/SKILL.md
@@ -90,12 +90,12 @@ ralphex \
 Run using Bash tool with `run_in_background: true`. **Save the task_id from the response** - needed for status checks later.
 
 **Determine progress filename** based on mode and plan selection:
-- Full mode + plan: `progress-{plan-stem}.txt`
-- Review mode + plan: `progress-{plan-stem}-review.txt`
-- Codex-only + plan: `progress-{plan-stem}-codex.txt`
-- Full mode + no plan: `progress.txt`
-- Review mode + no plan: `progress-review.txt`
-- Codex-only + no plan: `progress-codex.txt`
+- Full mode + plan: `.ralphex/progress/progress-{plan-stem}.txt`
+- Review mode + plan: `.ralphex/progress/progress-{plan-stem}-review.txt`
+- Codex-only + plan: `.ralphex/progress/progress-{plan-stem}-codex.txt`
+- Full mode + no plan: `.ralphex/progress/progress.txt`
+- Review mode + no plan: `.ralphex/progress/progress-review.txt`
+- Codex-only + no plan: `.ralphex/progress/progress-codex.txt`
 
 Where `{plan-stem}` is the plan filename without extension (e.g., `fix-bugs` from `fix-bugs.md`).
 

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -252,7 +252,7 @@ func run(ctx context.Context, o opts) error {
 			return fmt.Errorf("create branch for plan: %w", err)
 		}
 	}
-	if err := gitSvc.EnsureIgnored("progress*.txt", "progress-test.txt"); err != nil {
+	if err := gitSvc.EnsureIgnored(".ralphex/progress/", ".ralphex/progress/progress-test.txt"); err != nil {
 		return fmt.Errorf("ensure gitignore: %w", err)
 	}
 
@@ -547,7 +547,7 @@ func printStartupInfo(info startupInfo, colors *progress.Colors) {
 // after plan creation, prompts user to continue with implementation or exit.
 func runPlanMode(ctx context.Context, o opts, req executePlanRequest) error {
 	// ensure gitignore has progress files
-	if err := req.GitSvc.EnsureIgnored("progress*.txt", "progress-test.txt"); err != nil {
+	if err := req.GitSvc.EnsureIgnored(".ralphex/progress/", ".ralphex/progress/progress-test.txt"); err != nil {
 		return fmt.Errorf("ensure gitignore: %w", err)
 	}
 

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -386,6 +386,12 @@ func TestCheckClaudeDep(t *testing.T) {
 
 func TestCreateRunner(t *testing.T) {
 	t.Run("creates_runner_without_panic", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		oldWd, wdErr := os.Getwd()
+		require.NoError(t, wdErr)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
 		cfg := &config.Config{IterationDelayMs: 5000, TaskRetryCount: 3, CodexEnabled: false}
 		o := opts{MaxIterations: 100, Debug: true, NoColor: true}
 
@@ -401,6 +407,12 @@ func TestCreateRunner(t *testing.T) {
 	})
 
 	t.Run("codex_only_mode_creates_runner_without_panic", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		oldWd, wdErr := os.Getwd()
+		require.NoError(t, wdErr)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
 		cfg := &config.Config{CodexEnabled: false} // explicitly disabled in config
 		o := opts{MaxIterations: 50}
 

--- a/docs/plans/completed/20260214-progress-files-location.md
+++ b/docs/plans/completed/20260214-progress-files-location.md
@@ -1,0 +1,118 @@
+# Move progress files to .ralphex/progress/
+
+## Overview
+- Move progress files from project root to `.ralphex/progress/` subdirectory
+- Eliminates visual clutter and IDE search interference (GitHub issue #105)
+- Breaking change for file creation — new progress files always go to `.ralphex/progress/`
+- Web dashboard retains backward compat — discovers files in both old (root) and new locations
+- `.ralphex/` already exists as the project-local config directory, so progress is a natural fit
+
+## Context (from discovery)
+- `progressFilename()` in `pkg/progress/progress.go:520` is the single source of truth for path construction
+- `NewLogger` already calls `MkdirAll` on parent dir (line 147), so `.ralphex/progress/` creation is automatic
+- `{{PROGRESS_FILE}}` template variable uses `logger.Path()` which returns `file.Name()` — auto-adjusts
+- `isProgressFile()` in `pkg/web/watcher.go:237` uses `filepath.Base()` — unaffected by directory change
+- Watcher already recurses into subdirs, `.ralphex` is not in `skipDirs` — picks up both locations
+- File locking works on file handle, path-independent — unaffected
+
+## Development Approach
+- **testing approach**: regular (code first, then tests)
+- complete each task fully before moving to the next
+- make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests**
+- **CRITICAL: all tests must pass before starting next task**
+- run tests after each change
+
+## Implementation Steps
+
+### Task 1: Change progress file path construction
+
+**Files:**
+- Modify: `pkg/progress/progress.go`
+- Modify: `pkg/progress/progress_test.go`
+
+- [x] add `progressDir` constant `.ralphex/progress` at package level in `progress.go`
+- [x] update `progressFilename()` to prefix all returned paths with `filepath.Join(progressDir, ...)`
+- [x] update tests in `progress_test.go` for `progressFilename()` to expect `.ralphex/progress/` prefix
+- [x] update any tests for `NewLogger` that check file paths
+- [x] run `go test ./pkg/progress/...` — must pass before next task
+
+### Task 2: Update gitignore pattern
+
+**Files:**
+- Modify: `cmd/ralphex/main.go`
+- Modify: `cmd/ralphex/main_test.go`
+- Modify: `pkg/git/service_test.go`
+
+- [x] change `EnsureIgnored("progress*.txt", "progress-test.txt")` to `EnsureIgnored(".ralphex/progress/", ".ralphex/progress/progress-test.txt")` at lines 255 and 550
+- [x] update tests in `main_test.go` that reference progress gitignore patterns
+- [x] update tests in `service_test.go` that reference progress gitignore patterns
+- [x] run `go test ./cmd/ralphex/... ./pkg/git/...` — must pass before next task
+
+### Task 3: Verify web dashboard backward compat (no code changes needed)
+
+The watcher (`pkg/web/watcher.go`) already recurses into subdirs via `DiscoverRecursive` and `isProgressFile()` uses `filepath.Base()`, so it naturally picks up files in both old (root) and new (`.ralphex/progress/`) locations without code changes.
+
+`Discover(dir)` is always called with the specific directory containing the file (via `filepath.Dir(path)`), so it correctly globs `progress-*.txt` in whichever directory the file lives in.
+
+**Files:**
+- Modify: `pkg/web/session_manager_test.go`
+
+- [x] add test for discovering files in `.ralphex/progress/` subdirectory
+- [x] add test for discovering files in both old (root) and new locations simultaneously
+- [x] run `go test ./pkg/web/...` — must pass before next task
+
+### Task 4: Update project .gitignore and documentation
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+- [x] replace `progress*.txt` with `.ralphex/progress/` in `.gitignore`
+- [x] keep e2e testdata exceptions (`!e2e/testdata/progress-*.txt`)
+- [x] update CLAUDE.md references to progress file location
+- [x] update README.md if it mentions progress file location
+- [x] update any `tail -f progress-*.txt` examples in docs to use `.ralphex/progress/`
+
+### Task 5: Verify acceptance criteria
+
+- [x] run full unit test suite: `go test ./...`
+- [x] run linter: `golangci-lint run`
+- [x] verify `.ralphex/progress/` directory is created on execution
+- [x] verify progress files appear in `.ralphex/progress/` not project root
+- [x] verify web dashboard discovers files in both old and new locations
+
+### Task 6: [Final] Update documentation
+
+- [x] respond to GitHub issue #105 with the change
+- [x] move this plan to `docs/plans/completed/`
+
+## Technical Details
+
+**Path construction change:**
+```
+before: progress-my-plan.txt
+after:  .ralphex/progress/progress-my-plan.txt
+```
+
+**Gitignore change:**
+```
+before: progress*.txt
+after:  .ralphex/progress/
+```
+
+**Discovery (backward compat):**
+```
+before: <dir>/progress-*.txt
+after:  <dir>/progress-*.txt + <dir>/.ralphex/progress/progress-*.txt
+```
+
+**Watcher:** no changes needed — already recurses into `.ralphex/progress/` and `isProgressFile()` matches by `filepath.Base()`
+
+## Post-Completion
+
+**Manual verification:**
+- run e2e test with toy project to verify progress files land in `.ralphex/progress/`
+- verify `--serve` web dashboard picks up files from both old and new locations
+- verify `tail -f .ralphex/progress/progress-*.txt` works for monitoring

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -516,35 +516,38 @@ func (l *Logger) writeStdout(format string, args ...any) {
 	fmt.Fprintf(l.stdout, format, args...)
 }
 
-// getProgressFilename returns progress file path based on plan and mode.
+// progressDir is the directory for progress files within the project.
+const progressDir = ".ralphex/progress"
+
+// progressFilename returns progress file path based on plan and mode.
 func progressFilename(planFile, planDescription, mode string) string {
 	// plan mode uses sanitized plan description
 	if mode == "plan" && planDescription != "" {
 		sanitized := sanitizePlanName(planDescription)
-		return fmt.Sprintf("progress-plan-%s.txt", sanitized)
+		return filepath.Join(progressDir, fmt.Sprintf("progress-plan-%s.txt", sanitized))
 	}
 
 	if planFile != "" {
 		stem := strings.TrimSuffix(filepath.Base(planFile), ".md")
 		switch mode {
 		case "codex-only":
-			return fmt.Sprintf("progress-%s-codex.txt", stem)
+			return filepath.Join(progressDir, fmt.Sprintf("progress-%s-codex.txt", stem))
 		case "review":
-			return fmt.Sprintf("progress-%s-review.txt", stem)
+			return filepath.Join(progressDir, fmt.Sprintf("progress-%s-review.txt", stem))
 		default:
-			return fmt.Sprintf("progress-%s.txt", stem)
+			return filepath.Join(progressDir, fmt.Sprintf("progress-%s.txt", stem))
 		}
 	}
 
 	switch mode {
 	case "codex-only":
-		return "progress-codex.txt"
+		return filepath.Join(progressDir, "progress-codex.txt")
 	case "review":
-		return "progress-review.txt"
+		return filepath.Join(progressDir, "progress-review.txt")
 	case "plan":
-		return "progress-plan.txt"
+		return filepath.Join(progressDir, "progress-plan.txt")
 	default:
-		return "progress.txt"
+		return filepath.Join(progressDir, "progress.txt")
 	}
 }
 

--- a/pkg/web/dashboard_test.go
+++ b/pkg/web/dashboard_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -36,6 +37,11 @@ func TestNewDashboard(t *testing.T) {
 
 func TestDashboard_Start_SingleSession(t *testing.T) {
 	tmpDir := t.TempDir()
+	oldWd, wdErr := os.Getwd()
+	require.NoError(t, wdErr)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
 	progressPath := filepath.Join(tmpDir, "progress.txt")
 
 	// create mock base logger
@@ -75,6 +81,11 @@ func TestDashboard_Start_SingleSession(t *testing.T) {
 
 func TestDashboard_Start_MultiSession(t *testing.T) {
 	tmpDir := t.TempDir()
+	oldWd, wdErr := os.Getwd()
+	require.NoError(t, wdErr)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
 	progressPath := filepath.Join(tmpDir, "progress.txt")
 
 	// create mock base logger

--- a/scripts/prep-review-test.sh
+++ b/scripts/prep-review-test.sh
@@ -115,7 +115,7 @@ EOF
 
 echo "creating .gitignore..."
 cat > .gitignore << 'EOF'
-progress-*.txt
+.ralphex/progress/
 .bin/
 EOF
 

--- a/scripts/prep-toy-test.sh
+++ b/scripts/prep-toy-test.sh
@@ -45,7 +45,7 @@ EOF
 
 echo "creating .gitignore..."
 cat > .gitignore << 'EOF'
-progress-*.txt
+.ralphex/progress/
 .bin/
 EOF
 


### PR DESCRIPTION
Move progress files from project root to `.ralphex/progress/` subdirectory to reduce clutter and avoid IDE search interference.

Related to #105

**What changed:**
- Progress files now created in `.ralphex/progress/` instead of project root
- `.gitignore` updated to ignore new location + legacy root-level files
- Web dashboard retains backward compat — discovers files in both old (root) and new locations via recursive directory walking
- Updated docs (README, CLAUDE.md), skill definitions, and test scripts

**Backward compatibility:**
- *Web dashboard*: fully compatible — `DiscoverRecursive` walks into `.ralphex/progress/` automatically, `isProgressFile()` matches by basename regardless of directory
- *Gitignore*: covers both old (`/progress.txt`, `/progress-*.txt`) and new (`.ralphex/progress/`) patterns
- *Monitoring*: `tail -f` path changes from `progress-*.txt` to `.ralphex/progress/progress-*.txt`