### PR TITLE
Fix Windows comment to reference Setsid instead of Setpgid

### DIFF
--- a/pkg/executor/procgroup_windows.go
+++ b/pkg/executor/procgroup_windows.go
@@ -19,7 +19,7 @@ type processGroupCleanup struct {
 
 // setupProcessGroup is a no-op on Windows since process groups work differently.
 func setupProcessGroup(_ *exec.Cmd) {
-	// windows doesn't support Setpgid, process groups are handled differently
+	// windows doesn't support unix session/process group APIs, handled differently
 }
 
 // newProcessGroupCleanup creates a cleanup handler for the given command.


### PR DESCRIPTION
## Summary

- Address review feedback from #110 — update the Windows stub comment in `procgroup_windows.go` to reference unix session/process group APIs instead of the now-replaced `Setpgid`