### PR TITLE
Make it possible to specify default branch to compare for code review

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -199,8 +199,11 @@ func run(ctx context.Context, o opts) error {
 		return ensureErr
 	}
 
-	// detect default branch for prompt templates
-	defaultBranch := gitSvc.GetDefaultBranch()
+	// use configured default branch, or auto-detect from git
+	defaultBranch := cfg.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = gitSvc.GetDefaultBranch()
+	}
 
 	mode := determineMode(o)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,8 +60,9 @@ type Config struct {
 	FinalizeEnabled    bool `json:"finalize_enabled"`
 	FinalizeEnabledSet bool `json:"-"` // tracks if finalize_enabled was explicitly set in config
 
-	PlansDir  string   `json:"plans_dir"`
-	WatchDirs []string `json:"watch_dirs"` // directories to watch for progress files
+	PlansDir      string   `json:"plans_dir"`
+	WatchDirs     []string `json:"watch_dirs"`     // directories to watch for progress files
+	DefaultBranch string   `json:"default_branch"` // override auto-detected default branch
 
 	// error patterns to detect in executor output (e.g., rate limit messages)
 	ClaudeErrorPatterns []string `json:"claude_error_patterns"`
@@ -240,6 +241,7 @@ func loadConfigFromDirs(globalDir, localDir string) (*Config, error) {
 		FinalizeEnabled:      values.FinalizeEnabled,
 		FinalizeEnabledSet:   values.FinalizeEnabledSet,
 		PlansDir:             values.PlansDir,
+		DefaultBranch:        values.DefaultBranch,
 		WatchDirs:            values.WatchDirs,
 		ClaudeErrorPatterns:  values.ClaudeErrorPatterns,
 		CodexErrorPatterns:   values.CodexErrorPatterns,

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -108,6 +108,11 @@ task_retry_count = 1
 # default: docs/plans
 plans_dir = docs/plans
 
+# default_branch: override the auto-detected default branch used for code review
+# by default, ralphex detects the default branch from origin/HEAD or fallbacks to main/master,
+# set this to override for projects using non-standard branch names or Git flow
+# default_branch = dev
+
 # watch_dirs: directories to watch for progress files in dashboard mode
 # comma-separated list of paths, relative paths resolved from project root
 # if not specified, defaults to current working directory

--- a/pkg/config/values.go
+++ b/pkg/config/values.go
@@ -35,6 +35,7 @@ type Values struct {
 	FinalizeEnabled      bool
 	FinalizeEnabledSet   bool // tracks if finalize_enabled was explicitly set
 	PlansDir             string
+	DefaultBranch        string   // override auto-detected default branch
 	WatchDirs            []string // directories to watch for progress files
 
 	// notification settings
@@ -241,6 +242,9 @@ func (vl *valuesLoader) parseValuesFromBytes(data []byte) (Values, error) {
 	if key, err := section.GetKey("plans_dir"); err == nil {
 		values.PlansDir = key.String()
 	}
+	if key, err := section.GetKey("default_branch"); err == nil {
+		values.DefaultBranch = strings.TrimSpace(key.String())
+	}
 
 	// watch directories (comma-separated)
 	if key, err := section.GetKey("watch_dirs"); err == nil {
@@ -332,6 +336,9 @@ func (dst *Values) mergeFrom(src *Values) {
 	}
 	if src.PlansDir != "" {
 		dst.PlansDir = src.PlansDir
+	}
+	if src.DefaultBranch != "" {
+		dst.DefaultBranch = src.DefaultBranch
 	}
 	if len(src.WatchDirs) > 0 {
 		dst.WatchDirs = src.WatchDirs


### PR DESCRIPTION
Currently during the code review ralphex would compare feature branch to main or master branch to define code diff to review. This works for Github flow (when feature branch is created from master) but not for Git flow (where feature branch is created from dev).

This PR adds a config option to specify the branch that will be used for code review as the "main" branch to facilitate this. If config option is not specified auto detection (current approach) would be used as default.