### PR TITLE
Use verbose completions for zsh and fish descriptions

### DIFF
--- a/completions/ralphex.bash
+++ b/completions/ralphex.bash
@@ -1,8 +1,7 @@
 # bash completion for ralphex (generated via go-flags)
 _ralphex() {
     local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
-    local IFS=$'\n'
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    mapfile -t COMPREPLY < <(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null)
     return 0
 }
 complete -o default -F _ralphex ralphex

--- a/completions/ralphex.fish
+++ b/completions/ralphex.fish
@@ -1,2 +1,2 @@
 # fish completion for ralphex (generated via go-flags)
-complete -c ralphex -a '(GO_FLAGS_COMPLETION=1 ralphex (commandline -cop) 2>/dev/null)'
+complete -c ralphex -a '(GO_FLAGS_COMPLETION=verbose ralphex (commandline -cop) 2>/dev/null | string replace -r "\\s+# " "\t")'

--- a/completions/ralphex.zsh
+++ b/completions/ralphex.zsh
@@ -2,11 +2,24 @@
 
 # zsh completion for ralphex (generated via go-flags)
 _ralphex() {
-    local IFS=$'\n'
-    local -a completions
-    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
-    if (( ${#completions} )); then
-        compadd -- "${completions[@]}"
+    local -a lines
+    lines=(${(f)"$(GO_FLAGS_COMPLETION=verbose "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null)"})
+    if (( ${#lines} )); then
+        local -a descr
+        local line item desc
+        for line in "${lines[@]}"; do
+            if [[ "$line" = *'  # '* ]]; then
+                item="${line%%  *}"
+                desc="${line#*  \# }"
+                descr+=("${item//:/\\:}:${desc}")
+            else
+                item="${line%%  *}"
+                [[ -z "$item" ]] && item="$line"
+                [[ "$item" = *" "* ]] && continue
+                descr+=("${item//:/\\:}")
+            fi
+        done
+        _describe 'command' descr
     else
         _files
     fi


### PR DESCRIPTION
## Summary

- Switch zsh and fish completion scripts from `GO_FLAGS_COMPLETION=1` (bare items) to `GO_FLAGS_COMPLETION=verbose`, which includes flag descriptions
- zsh now uses `_describe` to show descriptions inline
- fish uses `string replace` to convert the verbose format to tab-separated pairs

### Before (plain completions)

```
--base-ref        --codex-only      --config-dir
--debug           --dump-defaults   --external-only
--help            --max-iterations  --no-color
```

### After (verbose completions with descriptions)

```
--base-ref        -- override default branch for review diffs (branch name or co
--codex-only      -- alias for --external-only (deprecated)
--config-dir      -- custom config directory
--debug           -- enable debug logging
--dump-defaults   -- extract raw embedded defaults to specified directory
--external-only   -- skip tasks and first review, run only external review loop
--max-iterations  -- maximum task iterations
```

Bash completions remain unchanged — bash doesn't support inline descriptions natively.