### PR TITLE
add recovery hints when external review (codex) fails

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"syscall"
 	"time"
 
@@ -369,6 +370,7 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 			Duration: baseLog.Elapsed(),
 			Error:    runErr.Error(),
 		})
+		printExternalReviewHint(runErr, req.Mode, req.PlanFile, req.Colors)
 		return fmt.Errorf("runner: %w", runErr)
 	}
 
@@ -764,4 +766,42 @@ func ensureRepoHasCommits(ctx context.Context, gitSvc *git.Service, stdin io.Rea
 		fmt.Fprintln(stdout, "created initial commit")
 	}
 	return nil
+}
+
+// printExternalReviewHint prints actionable recovery suggestions when external review (codex) fails.
+// detects codex/custom review failures by matching known error message substrings.
+func printExternalReviewHint(err error, mode processor.Mode, planFile string, colors *progress.Colors) {
+	// don't show hints for user cancellations or timeouts
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	errStr := err.Error()
+
+	// only show hints for external review failures (codex or custom review).
+	// "codex execution" = actual codex tool failed, "custom execution" = custom review script failed,
+	// "codex loop" = outer wrapper present for both (used as fallback).
+	isCodexErr := strings.Contains(errStr, "codex execution")
+	isCustomErr := strings.Contains(errStr, "custom execution")
+	isExternalErr := isCodexErr || isCustomErr || strings.Contains(errStr, "codex loop")
+	if !isExternalErr {
+		return
+	}
+
+	planArg := ""
+	if planFile != "" {
+		planArg = " " + toRelPath(planFile)
+	}
+
+	w := colors.Warn()
+	w.Println()
+	w.Println("hint: external review failed. to recover:")
+	w.Println("  - check configuration: https://ralphex.com/docs/#configuration-options")
+	if isCodexErr {
+		w.Println("  - verify codex binary works: codex exec \"hello\"")
+	}
+	w.Printf("  - re-run from this step: ralphex --codex-only%s\n", planArg)
+	if mode == processor.ModeCodexOnly {
+		w.Printf("  - skip external review, run claude review only: ralphex --review%s\n", planArg)
+	}
 }

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1148,5 +1151,75 @@ func TestResolveVersion(t *testing.T) {
 		// but VCS info should be available from the git repo
 		v := resolveVersion()
 		assert.NotEmpty(t, v)
+	})
+}
+
+func TestPrintExternalReviewHint(t *testing.T) {
+	// capture color output for assertions
+	captureOutput := func(fn func()) string {
+		var buf bytes.Buffer
+		orig := color.Output
+		color.Output = &buf
+		defer func() { color.Output = orig }()
+		fn()
+		return buf.String()
+	}
+
+	colors := testColors()
+
+	t.Run("codex_error_full_mode_no_review_hint", func(t *testing.T) {
+		err := errors.New("codex loop: codex execution: codex exited with error: exit status 1")
+		out := captureOutput(func() {
+			printExternalReviewHint(err, processor.ModeFull, "/tmp/project/docs/plans/feature.md", colors)
+		})
+		assert.Contains(t, out, "hint: external review failed")
+		assert.Contains(t, out, "https://ralphex.com/docs/#configuration-options")
+		assert.Contains(t, out, "codex exec \"hello\"")
+		assert.Contains(t, out, "ralphex --codex-only")
+		assert.NotContains(t, out, "ralphex --review")
+	})
+
+	t.Run("codex_error_review_mode_no_review_hint", func(t *testing.T) {
+		err := errors.New("codex loop: codex execution: codex exited with error: exit status 1")
+		out := captureOutput(func() {
+			printExternalReviewHint(err, processor.ModeReview, "", colors)
+		})
+		assert.Contains(t, out, "ralphex --codex-only\n")
+		assert.NotContains(t, out, "ralphex --review")
+	})
+
+	t.Run("codex_only_mode_shows_review_alternative", func(t *testing.T) {
+		err := errors.New("codex loop: codex execution: codex exited with error: exit status 1")
+		out := captureOutput(func() {
+			printExternalReviewHint(err, processor.ModeCodexOnly, "", colors)
+		})
+		assert.Contains(t, out, "ralphex --codex-only")
+		assert.Contains(t, out, "ralphex --review")
+	})
+
+	t.Run("custom_review_error", func(t *testing.T) {
+		err := errors.New("codex loop: custom execution: script exited with error")
+		out := captureOutput(func() {
+			printExternalReviewHint(err, processor.ModeFull, "", colors)
+		})
+		assert.Contains(t, out, "hint: external review failed")
+		assert.NotContains(t, out, "codex exec")
+		assert.Contains(t, out, "ralphex --codex-only")
+	})
+
+	t.Run("non_codex_error_no_output", func(t *testing.T) {
+		err := errors.New("task phase: claude execution: something broke")
+		out := captureOutput(func() {
+			printExternalReviewHint(err, processor.ModeFull, "", colors)
+		})
+		assert.Empty(t, out)
+	})
+
+	t.Run("context_canceled_no_output", func(t *testing.T) {
+		err := fmt.Errorf("codex loop: %w", context.Canceled)
+		out := captureOutput(func() {
+			printExternalReviewHint(err, processor.ModeCodexOnly, "", colors)
+		})
+		assert.Empty(t, out)
 	})
 }


### PR DESCRIPTION
## Summary

- When codex/custom review fails, print actionable recovery hints instead of just a raw error
- Hints include: config docs link, codex verification command, and re-run flags (`--codex-only`, `--review`)
- Contextual: only shows for external review errors, adapts suggestions based on current mode and plan file
- Skips hints on context cancellation (Ctrl+C) — no misleading suggestions on user abort

## Example output

When codex fails (e.g. model not available) in `--codex-only` mode:

```
ralphex v0.0.0-20260217195044-c6fdc2b24e63+dirty
starting ralphex loop (max 50 iterations) (codex-only mode)
plan: docs/plans/test-hint.md
branch: codex-error-hints
progress log: .ralphex/progress/progress-test-hint-codex.txt


--- codex external review ---

--- codex iteration 1 ---
[26-02-17 21:13:07] --------
[26-02-17 21:13:07] workdir: /Users/dmitry/code/tmp/ralphex
[26-02-17 21:13:07] model: gpt-5.3-codex
[26-02-17 21:13:07] provider: openai
[26-02-17 21:13:07] approval: never
[26-02-17 21:13:07] sandbox: read-only
[26-02-17 21:13:07] reasoning effort: xhigh
[26-02-17 21:13:07] reasoning summaries: auto
[26-02-17 21:13:07] session id: 019c6d73-21ca-7160-b661-60848a075ea5
[26-02-17 21:13:07] --------

hint: external review failed. to recover:
  - check configuration: https://ralphex.com/docs/#configuration-options
  - verify codex binary works: codex exec "hello"
  - re-run from this step: ralphex --codex-only docs/plans/test-hint.md
  - skip external review, run claude review only: ralphex --review docs/plans/test-hint.md
error: runner: codex loop: codex execution: codex exited with error: command wait: exit status 1
stderr: Reconnecting... 2/5 (stream disconnected before completion: The model `gpt-5.3-codex` does not exist or you do not have access to it.)
Reconnecting... 3/5 (stream disconnected before completion: The model `gpt-5.3-codex` does not exist or you do not have access to it.)
Reconnecting... 4/5 (stream disconnected before completion: The model `gpt-5.3-codex` does not exist or you do not have access to it.)
Reconnecting... 5/5 (stream disconnected before completion: The model `gpt-5.3-codex` does not exist or you do not have access to it.)
ERROR: stream disconnected before completion: The model `gpt-5.3-codex` does not exist or you do not have access to it.
```

Note: the `--review` alternative is only shown in `--codex-only` mode. When running in full or review mode, it is omitted (codex comes after review in the pipeline, so re-running `--review` would hit the same failure).