### PR TITLE
Fix: use plans_dir from config in make_plan prompt

### DIFF
--- a/pkg/config/defaults/prompts/make_plan.txt
+++ b/pkg/config/defaults/prompts/make_plan.txt
@@ -6,6 +6,7 @@
 #   {{PLAN_DESCRIPTION}} - user's original request for what to implement
 #   {{PROGRESS_FILE}} - path to progress file with Q&A history
 #   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
+#   {{PLANS_DIR}} - plans directory (default: docs/plans)
 
 You are helping create an implementation plan for: {{PLAN_DESCRIPTION}}
 
@@ -15,7 +16,7 @@ IMPORTANT: Read the progress file first to see any questions you already asked a
 
 ## Step 0: Check for Existing Plan
 
-FIRST, check if a plan file already exists in docs/plans/ matching this request.
+FIRST, check if a plan file already exists in {{PLANS_DIR}}/ matching this request.
 If a plan file for this feature already exists:
 - Output <<<RALPHEX:PLAN_READY>>> immediately
 - Do NOT modify the existing plan
@@ -103,7 +104,7 @@ This step executes ONLY after the user accepts your draft (progress file contain
 
 Write the accepted plan to disk:
 
-1. Create a plan file at docs/plans/YYYY-MM-DD-<slug>.md where <slug> is derived from the description
+1. Create a plan file at {{PLANS_DIR}}/YYYY-MM-DD-<slug>.md where <slug> is derived from the description
 2. Use this structure:
 
 ---

--- a/pkg/processor/prompts.go
+++ b/pkg/processor/prompts.go
@@ -65,7 +65,7 @@ func (r *Runner) getProgressFileRef() string {
 }
 
 // replaceBaseVariables replaces common template variables in prompts.
-// supported: {{PLAN_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}
+// supported: {{PLAN_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}, {{PLANS_DIR}}
 // this is the core replacement function used by all prompt builders.
 func (r *Runner) replaceBaseVariables(prompt string) string {
 	result := prompt
@@ -73,6 +73,7 @@ func (r *Runner) replaceBaseVariables(prompt string) string {
 	result = strings.ReplaceAll(result, "{{PROGRESS_FILE}}", r.getProgressFileRef())
 	result = strings.ReplaceAll(result, "{{GOAL}}", r.getGoal())
 	result = strings.ReplaceAll(result, "{{DEFAULT_BRANCH}}", r.getDefaultBranch())
+	result = strings.ReplaceAll(result, "{{PLANS_DIR}}", r.getPlansDir())
 	return result
 }
 
@@ -166,6 +167,14 @@ func (r *Runner) getDefaultBranch() string {
 		return "master"
 	}
 	return r.cfg.DefaultBranch
+}
+
+// getPlansDir returns the plans directory or "docs/plans" as fallback.
+func (r *Runner) getPlansDir() string {
+	if r.cfg.AppConfig == nil || r.cfg.AppConfig.PlansDir == "" {
+		return "docs/plans"
+	}
+	return r.cfg.AppConfig.PlansDir
 }
 
 // buildCodexEvaluationPrompt creates the prompt for claude to evaluate codex review output.

--- a/pkg/processor/prompts_test.go
+++ b/pkg/processor/prompts_test.go
@@ -658,6 +658,21 @@ func TestRunner_buildPlanPrompt(t *testing.T) {
 		assert.Contains(t, prompt, "(no progress file available)")
 	})
 
+	t.Run("uses custom plans dir from config", func(t *testing.T) {
+		appCfg := testAppConfig(t)
+		appCfg.PlansDir = "custom/plans"
+		r := &Runner{cfg: Config{
+			PlanDescription: "test plan",
+			ProgressPath:    "progress.txt",
+			AppConfig:       appCfg,
+		}, log: newMockLogger("")}
+
+		prompt := r.buildPlanPrompt()
+
+		assert.Contains(t, prompt, "custom/plans/")
+		assert.NotContains(t, prompt, "{{PLANS_DIR}}")
+	})
+
 	t.Run("preserves prompt structure", func(t *testing.T) {
 		appCfg := testAppConfig(t)
 		r := &Runner{cfg: Config{


### PR DESCRIPTION
Just found out that plan creation ignores plans_dir config value