### PR TITLE
fix: detect completed progress files and start fresh on reuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ docs/plans/         # plan files location
 - Streaming output with timestamps
 - Progress logging to files
 - Progress file locking (flock) for active session detection
+- Progress file fresh start: completed files (with `Completed:` footer) are truncated on reuse instead of appending
 - Multiple execution modes: full, tasks-only, review-only, external-only/codex-only, plan creation
 - `--base-ref` flag overrides default branch for review diffs (branch name or commit hash)
 - `--skip-finalize` flag disables finalize step for a single run

--- a/docs/plans/completed/20260218-progress-fresh-start.md
+++ b/docs/plans/completed/20260218-progress-fresh-start.md
@@ -47,8 +47,8 @@ When a progress file already has a "Completed:" footer (written by `Close()`), i
 
 ### Task 3: Update documentation
 
-- [ ] update CLAUDE.md if needed (progress file behavior description)
-- [ ] move this plan to `docs/plans/completed/`
+- [x] update CLAUDE.md if needed (progress file behavior description)
+- [x] move this plan to `docs/plans/completed/`
 
 ## Technical Details
 

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -133,8 +133,9 @@ type Config struct {
 }
 
 // NewLogger creates a logger writing to both a progress file and stdout.
-// if the progress file already exists with content, existing log is preserved
-// and a restart separator is written instead of a full header.
+// if the progress file already exists with a completion footer, it is truncated
+// and a fresh header is written. if the file exists without a completion footer
+// (interrupted run), existing log is preserved and a restart separator is written.
 // colors must be provided (created via NewColors from config).
 // holder is the shared PhaseHolder for reading the current execution phase.
 func NewLogger(cfg Config, colors *Colors, holder *status.PhaseHolder) (*Logger, error) {
@@ -152,7 +153,7 @@ func NewLogger(cfg Config, colors *Colors, holder *status.PhaseHolder) (*Logger,
 		}
 	}
 
-	f, err := os.OpenFile(progressPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // path derived from plan filename
+	f, err := os.OpenFile(progressPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // path derived from plan filename
 	if err != nil {
 		return nil, fmt.Errorf("open progress file: %w", err)
 	}
@@ -181,7 +182,8 @@ func NewLogger(cfg Config, colors *Colors, holder *status.PhaseHolder) (*Logger,
 
 	// if the file has a completion footer from a previous run, truncate and start fresh.
 	// this prevents mixing unrelated content when the same plan filename is reused.
-	if restart && isProgressCompleted(progressPath) {
+	// reads from the locked fd directly to avoid TOCTOU path-vs-inode mismatch.
+	if restart && isProgressCompleted(f, fi.Size()) {
 		if tErr := f.Truncate(0); tErr != nil {
 			_ = unlockFile(f)
 			unregisterActiveLock(f.Name())
@@ -550,23 +552,18 @@ func (l *Logger) writeStdout(format string, args ...any) {
 }
 
 // isProgressCompleted checks if a progress file has a completion footer written by Close().
-// opens the file read-only, reads the last ~256 bytes, and checks for "Completed:" substring.
-// returns false for empty, nonexistent, or incomplete files.
-func isProgressCompleted(path string) bool {
-	f, err := os.Open(path) //nolint:gosec // path derived from plan filename, not user input
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	fi, err := f.Stat()
-	if err != nil || fi.Size() == 0 {
+// reads the last ~256 bytes from the provided file descriptor and checks for the dash separator
+// followed by "Completed:" — the exact pattern Close() writes.
+// uses the already-locked fd to avoid TOCTOU path-vs-inode mismatch.
+// returns false for zero-size files or read errors.
+func isProgressCompleted(f *os.File, size int64) bool {
+	if size == 0 {
 		return false
 	}
 
 	// read the last 256 bytes (or less if file is smaller)
 	const tailSize int64 = 256
-	offset := max(0, fi.Size()-tailSize)
+	offset := max(0, size-tailSize)
 
 	buf := make([]byte, tailSize)
 	n, err := f.ReadAt(buf, offset)
@@ -574,7 +571,9 @@ func isProgressCompleted(path string) bool {
 		return false
 	}
 
-	return strings.Contains(string(buf[:n]), "Completed:")
+	// match the exact pattern written by Close(): 60-dash separator followed by "Completed:".
+	// a plain "Completed:" check would false-positive on Claude output containing that text.
+	return strings.Contains(string(buf[:n]), strings.Repeat("-", 60)+"\nCompleted:")
 }
 
 // progressDir is the directory for progress files within the project.

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -465,29 +465,36 @@ func TestLogger_LogDiffStats_ZeroFiles(t *testing.T) {
 func TestIsProgressCompleted(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	sep := strings.Repeat("-", 60)
 	tests := []struct {
 		name    string
 		content string
 		want    bool
 	}{
-		{"file with footer", "some content\n----\nCompleted: 2026-01-15 10:30:00 (5m30s)\n", true},
+		{"file with footer", "some content\n" + sep + "\nCompleted: 2026-01-15 10:30:00 (5m30s)\n", true},
 		{"file without footer", "some content\n--- restarted at 2026-01-15 10:30:00 ---\nmore content\n", false},
 		{"empty file", "", false},
-		{"footer in middle but also at end", "Completed: old\nmore content\n----\nCompleted: 2026-01-15 11:00:00 (2m)\n", true},
-		{"partial match", "some Completed text without colon format", false},
-		{"completed with colon", "log line\nCompleted: now\n", true},
+		{"footer in middle and end", "Completed: old\nmore\n" + sep + "\nCompleted: 2026-01-15 11:00:00 (2m)\n", true},
+		{"completed without dash separator", "log line\nCompleted: now\n", false},
+		{"completed in log output", "[ts] task said: Completed: the migration\nmore work\n", false},
+		{"no completed substring", "some text without the keyword", false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			path := filepath.Join(tmpDir, tc.name+".txt")
 			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o600))
-			assert.Equal(t, tc.want, isProgressCompleted(path))
+			f, err := os.Open(path) //nolint:gosec // test file path from t.TempDir
+			require.NoError(t, err)
+			defer f.Close()
+			fi, err := f.Stat()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, isProgressCompleted(f, fi.Size()))
 		})
 	}
 
-	t.Run("nonexistent file", func(t *testing.T) {
-		assert.False(t, isProgressCompleted(filepath.Join(tmpDir, "nonexistent.txt")))
+	t.Run("zero size", func(t *testing.T) {
+		assert.False(t, isProgressCompleted(nil, 0))
 	})
 }
 
@@ -517,6 +524,7 @@ func TestNewLogger_FreshStartAfterCompleted(t *testing.T) {
 	// create second logger with same config — should truncate and start fresh
 	l2, err := NewLogger(cfg, colors, holder)
 	require.NoError(t, err)
+	assert.Equal(t, progressPath, l2.Path()) // verify both loggers use the same file
 	l2.Print("second session output")
 	require.NoError(t, l2.Close())
 


### PR DESCRIPTION
Fixes a regression from #130 (append on restart): when the same plan filename is reused for an unrelated run (e.g. two different `bug-fix.md` plans over time), the new session appended to the old completed progress file, mixing unrelated content.

**Change:** after acquiring the file lock, `NewLogger` reads the tail of the existing file. If it finds the `Completed:` footer (written by `Close()`), it truncates the file and writes a fresh header. Files without a footer (interrupted/crashed runs) still get the restart separator as before.

**Details:**
- `isProgressCompleted()` reads last 256 bytes via `ReadAt` on the locked fd, checks for the 60-dash separator + `Completed:` pattern to avoid false positives on Claude output
- File opened with `O_RDWR` instead of `O_WRONLY` to support the read check
- `TestNewLogger_AppendOnRestart` updated to simulate an interrupted run (no footer) by releasing lock/closing without calling `Close()`
- New tests: `TestIsProgressCompleted` (7 cases), `TestNewLogger_FreshStartAfterCompleted`

Related to #129