### PR TITLE
fix: adapt review prompts for codex multi-agent flow

### DIFF
--- a/scripts/codex-as-claude.sh
+++ b/scripts/codex-as-claude.sh
@@ -13,8 +13,6 @@
 #   CODEX_MODEL          - codex model to use (default: codex default)
 #   CODEX_SANDBOX        - sandbox mode (default: danger-full-access)
 #   CODEX_VERBOSE        - set to 1 to include command execution output (default: 0)
-#   CODEX_MULTI_AGENT    - enable codex multi-agent tools for review prompts (default: 1)
-#   CODEX_REVIEW_ADAPTER - inject review adapter text for codex (default: 1)
 
 set -euo pipefail
 
@@ -39,25 +37,13 @@ fi
 # configurable via environment
 CODEX_MODEL="${CODEX_MODEL:-}"
 CODEX_SANDBOX="${CODEX_SANDBOX:-danger-full-access}"
-CODEX_MULTI_AGENT="${CODEX_MULTI_AGENT:-1}"
-CODEX_REVIEW_ADAPTER="${CODEX_REVIEW_ADAPTER:-1}"
-
-if [[ "$CODEX_MULTI_AGENT" != "0" && "$CODEX_MULTI_AGENT" != "1" ]]; then
-    echo "warning: CODEX_MULTI_AGENT must be 0 or 1, got '$CODEX_MULTI_AGENT', defaulting to 1" >&2
-    CODEX_MULTI_AGENT=1
-fi
-
-if [[ "$CODEX_REVIEW_ADAPTER" != "0" && "$CODEX_REVIEW_ADAPTER" != "1" ]]; then
-    echo "warning: CODEX_REVIEW_ADAPTER must be 0 or 1, got '$CODEX_REVIEW_ADAPTER', defaulting to 1" >&2
-    CODEX_REVIEW_ADAPTER=1
-fi
 
 is_review_prompt=0
 if [[ "$prompt" == *"<<<RALPHEX:REVIEW_DONE>>>"* ]]; then
     is_review_prompt=1
 fi
 
-if [[ "$CODEX_REVIEW_ADAPTER" == "1" && "$is_review_prompt" == "1" ]]; then
+if [[ "$is_review_prompt" == "1" ]]; then
     adapter_text=$'Ralphex review adapter for Codex:\n- Interpret review "Task tool" instructions using codex collaboration tools: spawn_agent, send_input, wait, close_agent.\n- Launch all requested review agents in parallel in one turn.\n- Wait for all spawned review agents before collecting findings and applying fixes.\n- Keep original review workflow and all <<<RALPHEX:...>>> signals unchanged.'
     prompt="$adapter_text"$'\n\n'"$prompt"
 fi
@@ -65,7 +51,7 @@ fi
 # build codex arguments
 codex_args=(exec --json --dangerously-bypass-approvals-and-sandbox -s "$CODEX_SANDBOX")
 [[ -n "$CODEX_MODEL" ]] && codex_args+=(-m "$CODEX_MODEL")
-if [[ "$CODEX_MULTI_AGENT" == "1" && "$is_review_prompt" == "1" ]]; then
+if [[ "$is_review_prompt" == "1" ]]; then
     codex_args+=(-c "features.multi_agent=true")
 fi
 codex_args+=("$prompt")


### PR DESCRIPTION
## Summary
- update `scripts/codex-as-claude.sh` to detect review prompts by `<<<RALPHEX:REVIEW_DONE>>>`
- inject a small review-only adapter so Codex maps ralphex Task-tool review instructions to `spawn_agent/send_input/wait/close_agent`
- enable `features.multi_agent=true` only for review prompts, keeping task phase behavior sequential
- add env toggles `CODEX_MULTI_AGENT` and `CODEX_REVIEW_ADAPTER` (both default to `1`)

## Why
Ralphex review prompts depend on parallel review agents, but Codex multi-agent tools are disabled by default. This caused fast/empty review passes when using Codex as a Claude replacement. The change enables multi-agent mode only where needed (review phases) and preserves existing task-phase semantics.

## Evidence (Codex docs/source)
- Codex docs list `multi_agent` as an optional feature, default `false`: https://developers.openai.com/codex/config-basic#supported-features
- Codex source defines `Feature::Collab` (`multi_agent`) with `default_enabled: false`: https://github.com/openai/codex/blob/main/codex-rs/core/src/features.rs#L574-L582
- Codex source registers `spawn_agent/send_input/resume_agent/wait/close_agent` only when `config.collab_tools` is enabled: https://github.com/openai/codex/blob/main/codex-rs/core/src/tools/spec.rs#L1600-L1611

## Validation
- `bash -n scripts/codex-as-claude.sh`
- `scripts/codex-as-claude.sh -p "List exact tool names available right now."` (no collab tools in non-review prompt)
- `scripts/codex-as-claude.sh -p "<<<RALPHEX:REVIEW_DONE>>> List exact tool names available right now."` (collab tools present in review prompt)

## Scope
Single-file change, no new dependencies, no prompt file rewrites.