### PR TITLE
ci: harden workflows, upgrade actions, fix caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,24 @@ on:
     tags:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: set up go 1.26
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v6
 
       - name: build and test
         run: |
@@ -28,7 +33,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: "v2.11.1"
 
       - name: submit coverage
         uses: codecov/codecov-action@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,10 +42,10 @@ jobs:
           persist-credentials: false
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: build and push base image by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -78,7 +78,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: upload digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-base-${{ matrix.artifact }}
           path: /tmp/digests/*
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-base-*
@@ -113,10 +113,10 @@ jobs:
           echo "All $expected digests present"
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -176,10 +176,10 @@ jobs:
           persist-credentials: false
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -197,7 +197,7 @@ jobs:
 
       - name: build and push go image by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-go
@@ -213,7 +213,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: upload digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-go-${{ matrix.artifact }}
           path: /tmp/digests/*
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-go-*
@@ -248,10 +248,10 @@ jobs:
           echo "All $expected digests present"
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,19 +3,24 @@ name: e2e
 on:
   workflow_dispatch:  # manual trigger only
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: set up go 1.26
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v6
 
       - name: install playwright browsers
         run: go run github.com/playwright-community/playwright-go/cmd/playwright@latest install --with-deps chromium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version: stable


### PR DESCRIPTION
- reorder checkout before setup-go for proper dependency caching (ci.yml, e2e.yml)
- upgrade GitHub Actions to latest versions (buildx v4, login v4, build-push v7, upload-artifact v7, download-artifact v8)
- add `permissions: contents: read` for least-privilege security
- add `persist-credentials: false` to checkout steps