### PR TITLE
fix: commit pending changes after external review loop early exit

### DIFF
--- a/pkg/processor/runner.go
+++ b/pkg/processor/runner.go
@@ -323,10 +323,21 @@ func (r *Runner) runCodexAndPostReview(ctx context.Context) error {
 		return fmt.Errorf("codex loop: %w", err)
 	}
 
-	// claude review loop (critical/major) after codex
+	// claude review loop (critical/major) after codex.
+	// prepend commit-pending instruction only when external review actually ran,
+	// because the loop may exit early (max iterations, stalemate, manual break)
+	// leaving uncommitted fixes in the worktree.
 	r.phaseHolder.Set(status.PhaseReview)
 
-	if err := r.runClaudeReviewLoop(ctx); err != nil {
+	var commitPrefix string
+	if r.externalReviewTool() != "none" {
+		commitPrefix = "IMPORTANT: Before starting the review, run `git status`. " +
+			"If there are uncommitted changes from previous review phases, " +
+			"stage and commit them with message: " +
+			"`fix: address code review findings`\n" +
+			"Then continue with the sequence below.\n\n"
+	}
+	if err := r.runClaudeReviewLoop(ctx, commitPrefix); err != nil {
 		return fmt.Errorf("post-codex review loop: %w", err)
 	}
 
@@ -433,9 +444,15 @@ func (r *Runner) runClaudeReview(ctx context.Context, prompt string) error {
 }
 
 // runClaudeReviewLoop runs claude review iterations using second review prompt.
-func (r *Runner) runClaudeReviewLoop(ctx context.Context) error {
+// optional promptPrefix is prepended to the review prompt (used for commit-pending instruction after codex).
+func (r *Runner) runClaudeReviewLoop(ctx context.Context, promptPrefix ...string) error {
 	// review iterations = 10% of max_iterations
 	maxReviewIterations := max(minReviewIterations, r.cfg.MaxIterations/reviewIterationDivisor)
+
+	prefix := ""
+	if len(promptPrefix) > 0 {
+		prefix = promptPrefix[0]
+	}
 
 	for i := 1; i <= maxReviewIterations; i++ {
 		select {
@@ -450,7 +467,7 @@ func (r *Runner) runClaudeReviewLoop(ctx context.Context) error {
 		headBefore := r.headHash()
 
 		result := r.runWithLimitRetry(ctx, r.claude.Run,
-			r.replacePromptVariables(r.cfg.AppConfig.ReviewSecondPrompt), "claude")
+			prefix+r.replacePromptVariables(r.cfg.AppConfig.ReviewSecondPrompt), "claude")
 		if result.Error != nil {
 			if err := r.handlePatternMatchError(result.Error, "claude"); err != nil {
 				return err

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -1642,6 +1642,58 @@ func TestRunner_CodexAndPostReview_PipelineOrder(t *testing.T) {
 	}
 }
 
+func TestRunner_CodexAndPostReview_CommitPendingPrefix(t *testing.T) {
+	t.Run("prefix applied when external review enabled", func(t *testing.T) {
+		log := newMockLogger("progress.txt")
+
+		var capturedPrompts []string
+		claude := &mocks.ExecutorMock{
+			RunFunc: func(_ context.Context, prompt string) executor.Result {
+				capturedPrompts = append(capturedPrompts, prompt)
+				switch len(capturedPrompts) {
+				case 1: // codex evaluation
+					return executor.Result{Output: "done", Signal: status.CodexDone}
+				case 2: // post-codex review loop
+					return executor.Result{Output: "review done", Signal: status.ReviewDone}
+				default:
+					return executor.Result{Error: errors.New("unexpected call")}
+				}
+			},
+		}
+		codex := newMockExecutor([]executor.Result{{Output: "found issue"}})
+
+		cfg := processor.Config{Mode: processor.ModeCodexOnly, MaxIterations: 50, CodexEnabled: true, AppConfig: testAppConfig(t)}
+		r := processor.NewWithExecutors(cfg, log, claude, codex, nil, &status.PhaseHolder{})
+		err := r.Run(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, capturedPrompts, 2)
+		assert.Contains(t, capturedPrompts[1], "IMPORTANT: Before starting the review, run `git status`")
+		assert.Contains(t, capturedPrompts[1], "fix: address code review findings")
+	})
+
+	t.Run("no prefix when external review disabled", func(t *testing.T) {
+		log := newMockLogger("progress.txt")
+
+		var capturedPrompts []string
+		claude := &mocks.ExecutorMock{
+			RunFunc: func(_ context.Context, prompt string) executor.Result {
+				capturedPrompts = append(capturedPrompts, prompt)
+				return executor.Result{Output: "review done", Signal: status.ReviewDone}
+			},
+		}
+		codex := newMockExecutor(nil)
+
+		cfg := processor.Config{Mode: processor.ModeCodexOnly, MaxIterations: 50, CodexEnabled: false, AppConfig: testAppConfig(t)}
+		r := processor.NewWithExecutors(cfg, log, claude, codex, nil, &status.PhaseHolder{})
+		err := r.Run(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, capturedPrompts, 1)
+		assert.NotContains(t, capturedPrompts[0], "IMPORTANT: Before starting the review, run `git status`")
+	})
+}
+
 func TestRunner_Finalize_ContextCancellationPropagates(t *testing.T) {
 	log := newMockLogger("progress.txt")
 	claude := newMockExecutor([]executor.Result{


### PR DESCRIPTION
**Problem**

External review loop (codex/custom) prompts tell Claude "Do NOT commit yet" during fix iterations, deferring the commit to the final "no issues found" iteration. When the loop exits early (max iterations reached, stalemate detected via `--review-patience`, or manual break via Ctrl+\), that final commit never happens and fixes are left uncommitted in the worktree.

**Fix**

Prepend a commit-pending instruction to the post-codex claude review prompt so Claude checks `git status` and commits any pending changes before starting its review. The prefix is only applied when external review actually ran -- skipped when codex is disabled (`externalReviewTool() == "none"`).

**Changes**
- `runClaudeReviewLoop` accepts optional `promptPrefix` parameter (variadic string)
- `runCodexAndPostReview` passes the commit-pending prefix only when external review is enabled
- Added tests for both positive (prefix present) and negative (prefix absent when codex disabled) cases

Related to #185
