### PR TITLE
fix: prevent custom review output duplication in progress log

### DIFF
--- a/pkg/processor/runner.go
+++ b/pkg/processor/runner.go
@@ -600,7 +600,7 @@ func (r *Runner) runCodexLoop(ctx context.Context) error {
 			runReview:       func(ctx context.Context, prompt string) executor.Result { return r.custom.Run(ctx, prompt) },
 			buildPrompt:     r.buildCustomReviewPrompt,
 			buildEvalPrompt: r.buildCustomEvaluationPrompt,
-			showSummary:     r.showCustomSummary,
+			showSummary:     func(string) {}, // no-op: custom output already streamed via OutputHandler
 			makeSection:     status.NewCustomIterationSection,
 		})
 	}
@@ -853,11 +853,6 @@ func (r *Runner) nextPlanTaskPosition() int {
 // extracts text until first code block or maxCodexSummaryLen chars, whichever is shorter.
 func (r *Runner) showCodexSummary(output string) {
 	r.showExternalReviewSummary("codex", output)
-}
-
-// showCustomSummary displays a condensed summary of custom review output before Claude evaluation.
-func (r *Runner) showCustomSummary(output string) {
-	r.showExternalReviewSummary("custom", output)
 }
 
 // showExternalReviewSummary displays a condensed summary of external review output.

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -1839,6 +1839,47 @@ func TestRunner_ExternalReviewTool_Custom_Success(t *testing.T) {
 	assert.Len(t, claude.RunCalls(), 2, "claude should be called for evaluation and post-review")
 }
 
+func TestRunner_ExternalReviewTool_Custom_NoDuplicateOutput(t *testing.T) {
+	var printAlignedCalls []string
+	log := newMockLogger("progress.txt")
+	log.PrintAlignedFunc = func(text string) { printAlignedCalls = append(printAlignedCalls, text) }
+
+	claude := newMockExecutor([]executor.Result{
+		{Output: "done", Signal: processor.SignalCodexDone},
+		{Output: "review done", Signal: processor.SignalReviewDone},
+	})
+	codex := newMockExecutor(nil)
+
+	appCfg := testAppConfig(t)
+	appCfg.ExternalReviewTool = "custom"
+	appCfg.CustomReviewScript = "/path/to/script.sh"
+
+	customExec := &executor.CustomExecutor{
+		Script:        appCfg.CustomReviewScript,
+		OutputHandler: func(text string) { log.PrintAligned(text) },
+	}
+	customResultIdx := 0
+	mockCustomRunner := &mockCustomRunnerImpl{
+		results: []executor.Result{{Output: "issue in foo.go:10\n"}},
+		idx:     &customResultIdx,
+	}
+	customExec.SetRunner(mockCustomRunner)
+
+	cfg := processor.Config{Mode: processor.ModeCodexOnly, MaxIterations: 50, CodexEnabled: true, AppConfig: appCfg}
+	r := processor.NewWithExecutors(cfg, log, claude, codex, customExec, &status.PhaseHolder{})
+	err := r.Run(t.Context())
+	require.NoError(t, err)
+
+	// count how many times the custom output line appears in PrintAligned calls
+	count := 0
+	for _, call := range printAlignedCalls {
+		if strings.Contains(call, "issue in foo.go:10") {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "custom review output should appear exactly once (streamed), not duplicated by summary")
+}
+
 func TestRunner_ExternalReviewTool_Custom_NotConfigured(t *testing.T) {
 	log := newMockLogger("progress.txt")
 	claude := newMockExecutor(nil)


### PR DESCRIPTION
Fixes #197

When using `external_review_tool = custom`, the script's output appeared twice in the progress log: first streamed in real-time via `OutputHandler`, then reprinted by `showCustomSummary`. This happened because the custom executor merges stderr into stdout (`cmd.Stderr = cmd.Stdout`), so both callbacks received the same content.

**Fix:** replace `showCustomSummary` with a no-op for the custom path — the output is already visible from real-time streaming. The codex path is unaffected since it separates stderr (progress) from stdout (findings).

**Changes:**
- `pkg/processor/runner.go` — use no-op `showSummary` for custom review, remove unused `showCustomSummary` method
- `pkg/processor/runner_test.go` — add `TestRunner_ExternalReviewTool_Custom_NoDuplicateOutput` verifying output appears exactly once
