### PR TITLE
fix: prevent false positive pattern matching on clean codex/custom exit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,8 +274,8 @@ Configurable patterns detect rate limit and quota errors in claude/codex output:
 - `codex_error_patterns`: comma-separated patterns for codex (default: "Rate limit,quota exceeded")
 - Matching is case-insensitive substring search
 - Whitespace is trimmed from each pattern
-- For claude: patterns checked unconditionally on all output
-- For codex and custom executors: patterns checked only when process exits with non-zero status (avoids false positives from review findings mentioning rate limits)
+- For claude: patterns checked on all output during normal execution (context cancellation paths bypass pattern checks)
+- For codex and custom executors: patterns checked only when process exits with non-zero status and context is not canceled (avoids false positives from review findings and cancellation masking)
 - On match, ralphex exits gracefully with pattern info and help command suggestion
 
 Limit patterns for wait+retry behavior:

--- a/pkg/executor/codex.go
+++ b/pkg/executor/codex.go
@@ -179,7 +179,8 @@ func (e *CodexExecutor) Run(ctx context.Context, prompt string) Result {
 	// only check error/limit patterns when the process failed (non-zero exit or stream error).
 	// when codex exits cleanly, pattern matches in output are false positives from findings
 	// (e.g., reviewing code that handles rate limits).
-	if finalErr != nil {
+	// skip pattern checks on context cancellation — cancellation must propagate as-is.
+	if finalErr != nil && ctx.Err() == nil {
 		// check limit patterns first (higher priority)
 		if pattern := matchPattern(stdoutContent, e.LimitPatterns); pattern != "" {
 			return Result{

--- a/pkg/executor/codex_test.go
+++ b/pkg/executor/codex_test.go
@@ -917,3 +917,28 @@ func TestCodexExecutor_Run_LimitPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexExecutor_Run_LimitPattern_ContextCanceled(t *testing.T) {
+	// context cancellation must not be masked by pattern matching
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mock := &mockCodexRunner{
+		runFunc: func(_ context.Context, _ string, _ ...string) (CodexStreams, func() error, error) {
+			return mockStreams("", "Rate limit exceeded"), mockWaitError(context.Canceled), nil
+		},
+	}
+	e := &CodexExecutor{
+		runner:        mock,
+		LimitPatterns: []string{"rate limit"},
+		ErrorPatterns: []string{"rate limit"},
+	}
+
+	result := e.Run(ctx, "analyze code")
+
+	require.ErrorIs(t, result.Error, context.Canceled, "cancellation must not be masked by pattern match")
+	var limitErr *LimitPatternError
+	assert.NotErrorAs(t, result.Error, &limitErr, "should not return LimitPatternError on cancellation")
+	var patternErr *PatternMatchError
+	assert.NotErrorAs(t, result.Error, &patternErr, "should not return PatternMatchError on cancellation")
+}

--- a/pkg/executor/custom.go
+++ b/pkg/executor/custom.go
@@ -117,7 +117,8 @@ func (e *CustomExecutor) Run(ctx context.Context, promptContent string) Result {
 
 	// only check error/limit patterns when the process failed (non-zero exit or stream error).
 	// when script exits cleanly, pattern matches in output are false positives from findings.
-	if finalErr != nil {
+	// skip pattern checks on context cancellation — cancellation must propagate as-is.
+	if finalErr != nil && ctx.Err() == nil {
 		// check limit patterns first (higher priority)
 		if pattern := matchPattern(output, e.LimitPatterns); pattern != "" {
 			return Result{

--- a/pkg/executor/custom_test.go
+++ b/pkg/executor/custom_test.go
@@ -444,3 +444,29 @@ func TestCustomExecutor_Run_LimitPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomExecutor_Run_LimitPattern_ContextCanceled(t *testing.T) {
+	// context cancellation must not be masked by pattern matching
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mock := &mockCustomRunner{
+		runFunc: func(_ context.Context, _, _ string) (io.Reader, func() error, error) {
+			return strings.NewReader("Rate limit exceeded"), func() error { return context.Canceled }, nil
+		},
+	}
+	e := &CustomExecutor{
+		Script:        "/path/to/script.sh",
+		runner:        mock,
+		LimitPatterns: []string{"rate limit"},
+		ErrorPatterns: []string{"rate limit"},
+	}
+
+	result := e.Run(ctx, "prompt")
+
+	require.ErrorIs(t, result.Error, context.Canceled, "cancellation must not be masked by pattern match")
+	var limitErr *LimitPatternError
+	assert.NotErrorAs(t, result.Error, &limitErr, "should not return LimitPatternError on cancellation")
+	var patternErr *PatternMatchError
+	assert.NotErrorAs(t, result.Error, &patternErr, "should not return PatternMatchError on cancellation")
+}


### PR DESCRIPTION
**Problem:** error/limit pattern matching (`"Rate limit"`, `"quota exceeded"`) ran against the full output of codex and custom executors regardless of exit code. When codex reviewed code that *handles* rate limits, its findings triggered a false positive — ralphex treated the review output as an actual rate limit error.

**Fix:** only check error/limit patterns when the process exits with non-zero status. Confirmed via codex source (`codex-rs/exec/tests/suite/server_error_exit.rs`) that rate limits cause exit code 1. Claude executor pattern matching is intentionally unchanged — its patterns (`"You've hit your limit"`) are specific UI messages unlikely to appear in code review findings.

**Changes:**
- `pkg/executor/codex.go` — guard pattern checks behind `finalErr != nil`
- `pkg/executor/custom.go` — same guard
- Tests updated with non-zero exit simulation and "pattern ignored on clean exit" cases
- `CLAUDE.md` updated to document the claude vs codex/custom pattern matching asymmetry