### PR TITLE
fix: retry invalid selections in plan draft review

### DIFF
--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -52,11 +52,13 @@ func ReadLineWithContext(ctx context.Context, reader *bufio.Reader) (string, err
 type Collector interface {
 	// AskQuestion presents a question with options and returns the selected answer.
 	// An "Other" option is appended automatically; if chosen, the user types a free-text answer.
-	// Returns the selected or typed text, or error if selection fails.
+	// Returns the selected or typed text, or error if selection fails (including invalid input).
 	AskQuestion(ctx context.Context, question string, options []string) (string, error)
 
 	// AskDraftReview presents a plan draft for review with Accept/Revise/Interactive review/Reject options.
 	// Returns the selected action ("accept", "revise", or "reject") and feedback text (empty for accept/reject).
+	// Invalid selections (bad number, out of range) are retried with a warning;
+	// only fatal errors (EOF, context cancellation) return an error.
 	AskDraftReview(ctx context.Context, question string, planContent string) (action string, feedback string, err error)
 }
 
@@ -285,7 +287,13 @@ func (c *TerminalCollector) AskDraftReview(ctx context.Context, question, planCo
 	for {
 		action, selectErr := c.selectWithNumbers(ctx, question, options, reader)
 		if selectErr != nil {
-			return "", "", fmt.Errorf("select action: %w", selectErr)
+			// fatal errors: EOF or context cancellation can't be retried
+			if errors.Is(selectErr, io.EOF) || ctx.Err() != nil {
+				return "", "", fmt.Errorf("select action: %w", selectErr)
+			}
+			// retriable error (invalid number, out of range, etc.) — warn and reprompt
+			log.Printf("[WARN] invalid selection, please try again: %v", selectErr)
+			continue
 		}
 
 		actionLower := strings.ToLower(action)

--- a/pkg/input/input_test.go
+++ b/pkg/input/input_test.go
@@ -419,8 +419,52 @@ func TestTerminalCollector_AskDraftReview(t *testing.T) {
 		assert.Contains(t, err.Error(), "feedback cannot be empty")
 	})
 
-	t.Run("invalid selection returns error", func(t *testing.T) {
+	t.Run("invalid selection retries then accepts", func(t *testing.T) {
 		var stdout bytes.Buffer
+		// first "5" is out of range, then "1" is valid (Accept)
+		reader := &sequentialLineReader{lines: []string{"5", "1"}}
+		c := &TerminalCollector{stdin: reader, stdout: &stdout, noColor: true}
+
+		action, feedback, err := c.AskDraftReview(context.Background(), "Review the plan", planContent)
+
+		require.NoError(t, err)
+		assert.Equal(t, ActionAccept, action)
+		assert.Empty(t, feedback)
+	})
+
+	t.Run("multiple invalid selections retry then accepts", func(t *testing.T) {
+		var stdout bytes.Buffer
+		// "abc" is not a number, "0" is out of range, "-1" is out of range, then "4" is valid (Reject)
+		reader := &sequentialLineReader{lines: []string{"abc", "0", "-1", "4"}}
+		c := &TerminalCollector{stdin: reader, stdout: &stdout, noColor: true}
+
+		action, feedback, err := c.AskDraftReview(context.Background(), "Review the plan", planContent)
+
+		require.NoError(t, err)
+		assert.Equal(t, ActionReject, action)
+		assert.Empty(t, feedback)
+	})
+
+	t.Run("invalid selection then context canceled returns error", func(t *testing.T) {
+		var stdout bytes.Buffer
+		ctx, cancel := context.WithCancel(context.Background())
+		// "5" is out of range causing retry, then context is canceled before second read
+		reader := &sequentialLineReader{lines: []string{"5"}, afterRead: func(i int) {
+			if i == 0 { // cancel after first (invalid) read
+				cancel()
+			}
+		}}
+		c := &TerminalCollector{stdin: reader, stdout: &stdout, noColor: true}
+
+		_, _, err := c.AskDraftReview(ctx, "Review the plan", planContent)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "select action")
+	})
+
+	t.Run("invalid selection then EOF returns error", func(t *testing.T) {
+		var stdout bytes.Buffer
+		// "5" is out of range, then EOF on retry
 		c := &TerminalCollector{stdin: strings.NewReader("5\n"), stdout: &stdout, noColor: true}
 
 		_, _, err := c.AskDraftReview(context.Background(), "Review the plan", planContent)
@@ -560,8 +604,9 @@ func (r *eofAfterReader) Read(p []byte) (n int, err error) {
 // sequentialLineReader returns lines one at a time, each ending with newline.
 // this allows simulating multiple sequential reads (selection + feedback).
 type sequentialLineReader struct {
-	lines []string
-	index int
+	lines     []string
+	index     int
+	afterRead func(i int) // optional callback after each read, receives the line index just read
 }
 
 func (r *sequentialLineReader) Read(p []byte) (n int, err error) {
@@ -569,8 +614,13 @@ func (r *sequentialLineReader) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 	line := r.lines[r.index] + "\n"
+	idx := r.index
 	r.index++
-	return copy(p, line), nil
+	n = copy(p, line)
+	if r.afterRead != nil {
+		r.afterRead(idx)
+	}
+	return n, nil
 }
 
 func TestTerminalCollector_computeDiff(t *testing.T) {


### PR DESCRIPTION
Invalid input (out-of-range number, non-numeric text) in `AskDraftReview` now warns and reprompts instead of exiting with an error. Only fatal errors (EOF, context cancellation) terminate the selection loop.

**Changes:**
- `pkg/input/input.go` — classify errors in `AskDraftReview` loop: retriable (invalid number, out of range) vs fatal (EOF, context cancel). Updated interface and method godoc
- `pkg/input/input_test.go` — added tests for retry-then-accept, multiple-retries, retry-then-EOF, retry-then-context-cancel. Extended `sequentialLineReader` with optional `afterRead` callback

Related to #201