### PR TITLE
style: show progress log path at completion

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -484,7 +484,6 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 			fmt.Fprintf(os.Stderr, "warning: failed to move plan to completed: %v\n", moveErr)
 		}
 	}
-	req.Colors.Info().Printf("progress log in %s\n", baseLog.Path())
 
 	// display completion with stats
 	if stats.Files > 0 {
@@ -494,6 +493,17 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 	} else {
 		req.Colors.Info().Printf("\ncompleted in %s\n", elapsed)
 	}
+
+	// show paths for easy copy-paste after completion summary
+	if req.PlanFile != "" {
+		planFile := req.PlanFile
+		if req.MainPlanFile != "" {
+			planFile = req.MainPlanFile
+		}
+		completedPlanPath := filepath.Join(filepath.Dir(planFile), "completed", filepath.Base(planFile))
+		req.Colors.Info().Printf("  plan: %s\n", completedPlanPath)
+	}
+	req.Colors.Info().Printf("  progress: %s\n", baseLog.Path())
 
 	// keep web dashboard running after execution completes
 	if o.Serve {


### PR DESCRIPTION
## Summary
  - Print progress log path adjacent to the "moved plan to" line at execution completion
  - Makes it easy to copy both paths for post-execution review, e.g., feeding plan + progress log to an agent for deviation analysis

  ## Before
```text
  moved plan to docs/plans/completed/fix-issues.md

  completed in 1m25s (2 files, +10/-12 lines)
```  
  ## After
  ```text
  moved plan to /tmp/ralphex-test/docs/plans/completed/fix-issues.md
  progress log in /tmp/ralphex-test/.ralphex/progress/progress-fix-issues.txt

  completed in 1m19s (2 files, +10/-12 lines)
```
  ## Test plan
  - [x] Manual e2e test with a trivial project (`--tasks-only`)
  - [x] Unit tests pass (`make test`) with one unrelated pre-existing test failure
 