### PR TITLE
Load env vars from ~/.config/ralphex/env on startup

### DIFF
--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -458,6 +458,34 @@ def merge_env_flags(args_env: list[str]) -> list[str]:
     return result
 
 
+def load_env_files() -> None:
+    """load env vars from ~/.config/ralphex/env if it exists.
+
+    does not override existing os.environ values.
+    lines starting with # and empty lines are skipped.
+    """
+    env_files = [
+        Path.home() / ".config" / "ralphex" / "env",
+    ]
+    for env_file in env_files:
+        if not env_file.is_file():
+            continue
+        try:
+            for line in env_file.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip()
+                if key and key not in os.environ:
+                    os.environ[key] = value
+        except OSError:
+            pass
+
+
 def merge_volume_flags(args_volume: list[str]) -> list[str]:
     """merge RALPHEX_EXTRA_VOLUMES with CLI -v flags, validate entries.
 
@@ -848,6 +876,9 @@ def main() -> int:
     if parsed.test:
         run_tests()
         return 0
+
+    # load env vars from ~/.config/ralphex/env (does not override existing)
+    load_env_files()
 
     image = os.environ.get("RALPHEX_IMAGE", DEFAULT_IMAGE)
     port = os.environ.get("RALPHEX_PORT", DEFAULT_PORT)


### PR DESCRIPTION
## Summary

- Add `load_env_files()` that reads `KEY=VALUE` pairs from `~/.config/ralphex/env` on wrapper startup
- Existing env vars are not overridden (env/CLI always take precedence)
- Supports comments (`#`) and blank lines

## Motivation

Currently, persistent wrapper-level env vars like `RALPHEX_EXTRA_VOLUMES` or `RALPHEX_IMAGE` must be set in shell profiles (`.bashrc`, `.zshrc`). This adds a dedicated env file at `~/.config/ralphex/env` — the same directory where the config file already lives — so users can configure wrapper env vars without modifying shell profiles.

### Use case

Pre-commit hooks installed by `pre-commit install` hardcode the absolute path to the Python interpreter (e.g., `/opt/project/venv/bin/python3.14`). Inside the ralphex container, the workspace is mounted at `/workspace`, so this path doesn't exist and `git commit` fails with `pre-commit not found`. By setting `RALPHEX_EXTRA_VOLUMES` in `~/.config/ralphex/env`, users can mount the venv at the original path:

```
RALPHEX_EXTRA_VOLUMES=/opt/project/venv:/opt/project/venv:ro
```

## Example `~/.config/ralphex/env`

```bash
# persistent wrapper env vars
RALPHEX_EXTRA_VOLUMES=/opt/project/venv:/opt/project/venv:ro
RALPHEX_IMAGE=ghcr.io/umputun/ralphex:latest
```

## Test plan

- [ ] Verify wrapper reads env file and applies vars
- [ ] Verify existing env vars are not overridden
- [ ] Verify missing env file is silently ignored
- [ ] Verify comments and blank lines are skipped