### PR TITLE
fix: progress output text wrapping and code smells

### DIFF
--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -318,14 +318,27 @@ func (l *Logger) getTerminalWidth() int {
 
 // wrapText wraps text to specified width, breaking on word boundaries.
 // words longer than width are placed on their own line (terminal may wrap them).
+// leading whitespace is preserved on the first line and subtracted from available width.
 func (l *Logger) wrapText(text string, width int) string {
 	if width <= 0 || len(text) <= width {
 		return text
 	}
 
+	// preserve leading whitespace
+	trimmed := strings.TrimLeft(text, " \t")
+	indent := text[:len(text)-len(trimmed)]
+	effectiveWidth := width - len(indent)
+	if effectiveWidth <= 0 {
+		return text
+	}
+
 	var result strings.Builder
-	words := strings.Fields(text)
+	words := strings.Fields(trimmed)
 	lineLen := 0
+
+	if indent != "" {
+		result.WriteString(indent)
+	}
 
 	for i, word := range words {
 		wordLen := len(word)
@@ -337,7 +350,7 @@ func (l *Logger) wrapText(text string, width int) string {
 		}
 
 		// check if word fits on current line
-		if lineLen+1+wordLen <= width {
+		if lineLen+1+wordLen <= effectiveWidth {
 			result.WriteString(" ")
 			result.WriteString(word)
 			lineLen += 1 + wordLen

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -252,6 +252,40 @@ func TestLogger_PrintAligned(t *testing.T) {
 	assert.True(t, strings.HasSuffix(output, "\n"), "output should end with newline")
 }
 
+func TestLogger_PrintAligned_WrapsLongListItem(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	holder := &status.PhaseHolder{}
+	l, err := NewLogger(Config{Mode: "full", Branch: "test", NoColor: true}, testColors(), holder)
+	require.NoError(t, err)
+	defer func() { _ = l.Close() }()
+
+	var buf bytes.Buffer
+	l.stdout = &buf
+	t.Setenv("COLUMNS", "50") // narrow terminal to force wrapping
+
+	// long list item that should wrap, indent preserved on first line
+	l.PrintAligned("- this is a very long list item that should be wrapped properly")
+
+	content, err := os.ReadFile(l.Path())
+	require.NoError(t, err)
+	fileStr := string(content)
+	// first line should have the indent preserved
+	assert.Contains(t, fileStr, "]   - this is a very long list")
+	// continuation should be on a new line
+	lines := strings.Split(fileStr, "\n")
+	var contentLines []string
+	for _, line := range lines {
+		if strings.Contains(line, "- this") || strings.Contains(line, "wrapped") {
+			contentLines = append(contentLines, line)
+		}
+	}
+	assert.Greater(t, len(contentLines), 1, "long list item should be wrapped into multiple lines")
+}
+
 func TestLogger_PrintAligned_Empty(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
@@ -644,6 +678,24 @@ func TestWrapText(t *testing.T) {
 			text:  "exact fit",
 			width: 9,
 			want:  "exact fit",
+		},
+		{
+			name:  "preserves leading whitespace",
+			text:  "  1. indented list item text here",
+			width: 20,
+			want:  "  1. indented list\nitem text here",
+		},
+		{
+			name:  "preserves tab indent",
+			text:  "\tindented text that wraps",
+			width: 15,
+			want:  "\tindented text\nthat wraps",
+		},
+		{
+			name:  "indent wider than width returns original",
+			text:  "          short",
+			width: 5,
+			want:  "          short",
 		},
 	}
 


### PR DESCRIPTION
fixes terminal mid-word wrapping in progress output. `formatListItem` was adding 2-char indent after `wrapText` already wrapped to width, causing lines to overflow by 2 chars. also increased prefix reserve from 20 to 22 for safety margin. `wrapText` now preserves leading whitespace on first line.

also addressed code smells in the package: converted standalone functions to Logger methods, extracted cleanup closure in `NewLogger`, extracted `writeTimestamped` to deduplicate Print/Error/Warn/LogAnswer, extracted `writeHeader`, replaced dash-collapsing loop with compiled regex.