### PR TITLE
fix: prevent non-automatable checkboxes in plan Task sections

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ralphex",
       "source": "./",
       "description": "Autonomous plan execution with Claude Code - task execution, monitoring, and plan creation",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphex",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Autonomous plan execution with Claude Code - task execution, monitoring, and plan creation",
   "author": {
     "name": "umputun",

--- a/assets/claude/skills/ralphex-plan/SKILL.md
+++ b/assets/claude/skills/ralphex-plan/SKILL.md
@@ -224,6 +224,8 @@ Example (NOTICE: tests are separate checklist items):
 - [ ] run linter - all issues must be fixed
 - [ ] verify test coverage meets project standard (80%+)
 
+*Note: manual testing, deployment verification, and external checks go in Post-Completion (no checkboxes). Task section checkboxes must be automatable by the agent.*
+
 ### Task N: [Final] Update documentation
 - [ ] update README.md if needed
 - [ ] update project knowledge docs if new patterns discovered

--- a/pkg/config/defaults/prompts/make_plan.txt
+++ b/pkg/config/defaults/prompts/make_plan.txt
@@ -145,7 +145,6 @@ Write the accepted plan to disk:
 
 ### Task N: Verify acceptance criteria
 
-- [ ] manual test: <key user-facing test>
 - [ ] run full test suite (use project-specific command)
 - [ ] run linter (use project-specific command)
 - [ ] verify test coverage meets 80%+
@@ -171,6 +170,7 @@ Before emitting PLAN_DRAFT in Step 3.5, verify the plan against these criteria:
 - [ ] All requirements from the original description are addressed
 - [ ] Each task specifies file paths where known (use patterns for discovery tasks)
 - [ ] Each task that modifies code includes test items
+- [ ] Task section checkboxes are automatable by the agent (no manual testing, deployment, or external verification items as `- [ ]` inside Task sections; those go in Post-Completion)
 
 **Simplicity (YAGNI):**
 - [ ] No unnecessary abstractions

--- a/pkg/config/defaults/prompts/task.txt
+++ b/pkg/config/defaults/prompts/task.txt
@@ -11,6 +11,8 @@ Read the plan file at {{PLAN_FILE}}. Find the FIRST Task section (### Task N: or
 
 If NO Task section has [ ] but ## Success criteria, ## Overview, or ## Context still has [ ]: either satisfy those items and mark them [x] if actionable, or output <<<RALPHEX:ALL_TASKS_DONE>>> if they are verification-only (manual testing, deployment, etc.) — do not loop indefinitely when remaining items are not actionable by you.
 
+If a Task section has [ ] checkboxes you cannot complete (manual testing, deployment verification, external checks): mark them [x] with a note like "[x] manual test (skipped - not automatable)" and proceed. Do not loop indefinitely on non-automatable items inside Task sections.
+
 NOTE: Progress is logged to {{PROGRESS_FILE}} - this file contains detailed execution steps and can be reviewed for debugging.
 
 CRITICAL CONSTRAINT: Complete ONE Task section per iteration.


### PR DESCRIPTION
plan templates were generating `- [ ]` checkboxes for manual testing inside Task sections (e.g., "manual test: verify X in production"). the agent cannot complete those, so ralphex rejects the ALL_TASKS_DONE signal and loops until retry limit.

fixes:
- removed manual test checkbox from verify acceptance criteria template in `make_plan.txt`
- added validation rule: Task section checkboxes must be automatable
- `task.txt` now instructs the agent to skip non-automatable items inside Task sections
- updated `/ralphex-plan` skill template with note about checkbox placement
- bump plugin version to 0.18.0

Related to #221
