### PR TITLE
Fix Windows command-line length limits problem for codex execution

### DIFF
--- a/docs/plans/long-lines-plan.md
+++ b/docs/plans/long-lines-plan.md
@@ -22,21 +22,21 @@ Windows has an 8191-character command-line limit (cmd.exe). The ClaudeExecutor a
 
 The codex CLI's `exec` subcommand reads prompt from stdin when no positional prompt argument is given. Mirror the ClaudeExecutor pattern:
 
-- [ ] Add `stdin io.Reader` field to `execCodexRunner` struct
-- [ ] Set `cmd.Stdin = r.stdin` in `execCodexRunner.Run()` when stdin is non-nil
-- [ ] In `CodexExecutor.Run()`, remove `args = append(args, prompt)` (line 128)
-- [ ] In `CodexExecutor.Run()`, create `stdinReader := strings.NewReader(prompt)` and pass it to `execCodexRunner`
-- [ ] Update `CodexRunner` interface if needed (or keep stdin as internal detail of `execCodexRunner`)
-- [ ] Update tests in `codex_test.go`: verify prompt is NOT in args, add test for stdin piping
+- [x] Add `stdin io.Reader` field to `execCodexRunner` struct
+- [x] Set `cmd.Stdin = r.stdin` in `execCodexRunner.Run()` when stdin is non-nil
+- [x] In `CodexExecutor.Run()`, remove `args = append(args, prompt)` (line 128)
+- [x] In `CodexExecutor.Run()`, create `stdinReader := strings.NewReader(prompt)` and pass it to `execCodexRunner`
+- [x] Update `CodexRunner` interface if needed (or keep stdin as internal detail of `execCodexRunner`)
+- [x] Update tests in `codex_test.go`: verify prompt is NOT in args, add test for stdin piping
 - [ ] Run `make test` and `make lint`
 
 ### Task 2: Fix codex-as-claude.sh to pipe prompt via stdin
 
 The script reads prompt from stdin (or `-p` flag), then passes it as a CLI argument to codex. Instead, pipe it to codex's stdin.
 
-- [ ] Remove `"$prompt"` from `codex_args` array in `codex-as-claude.sh`
-- [ ] Pipe prompt to codex via stdin (e.g., `echo "$prompt" | codex ...` or heredoc)
-- [ ] Verify script still works with both `-p` and stdin prompt sources
+- [x] Remove `"$prompt"` from `codex_args` array in `codex-as-claude.sh`
+- [x] Pipe prompt to codex via stdin (`printf '%s' "$prompt" | codex ...`)
+- [ ] Verify script still works with both `-p` and stdin prompt sources (requires jq)
 - [ ] Update tests in `codex-as-claude_test.sh` if they verify args
 
 ### Task 3: Fix gemini-as-claude.sh to pipe prompt via stdin

--- a/pkg/executor/codex.go
+++ b/pkg/executor/codex.go
@@ -24,7 +24,11 @@ type CodexRunner interface {
 
 // execCodexRunner is the default command runner using os/exec for codex.
 // codex outputs streaming progress to stderr, final response to stdout.
-type execCodexRunner struct{}
+// when stdin is non-nil, it is connected to the child process's stdin (used to pass
+// the prompt via pipe instead of a CLI argument to avoid Windows 8191-char cmd limit).
+type execCodexRunner struct {
+	stdin io.Reader
+}
 
 func (r *execCodexRunner) Run(ctx context.Context, name string, args ...string) (CodexStreams, func() error, error) {
 	// check context before starting to avoid spawning a process that will be immediately killed
@@ -35,6 +39,11 @@ func (r *execCodexRunner) Run(ctx context.Context, name string, args ...string) 
 	// use exec.Command (not CommandContext) because we handle cancellation ourselves
 	// to ensure the entire process group is killed, not just the direct child
 	cmd := exec.Command(name, args...) //nolint:noctx // intentional: we handle context cancellation via process group kill
+
+	// pass prompt via stdin when set (avoids Windows 8191-char command-line limit)
+	if r.stdin != nil {
+		cmd.Stdin = r.stdin
+	}
 
 	// create new process group so we can kill all descendants on cleanup
 	setupProcessGroup(cmd)
@@ -125,11 +134,12 @@ func (e *CodexExecutor) Run(ctx context.Context, prompt string) Result {
 		args = append(args, "-c", fmt.Sprintf("project_doc=%q", e.ProjectDoc))
 	}
 
-	args = append(args, prompt)
-
+	// pass prompt via stdin to avoid Windows 8191-char command-line limit;
+	// codex reads from stdin when no positional prompt argument is given
+	stdinReader := strings.NewReader(prompt)
 	runner := e.runner
 	if runner == nil {
-		runner = &execCodexRunner{}
+		runner = &execCodexRunner{stdin: stdinReader}
 	}
 
 	streams, wait, err := runner.Run(ctx, cmd, args...)

--- a/pkg/executor/codex_test.go
+++ b/pkg/executor/codex_test.go
@@ -222,6 +222,9 @@ func TestCodexExecutor_Run_DefaultSettings(t *testing.T) {
 	assert.Contains(t, argsStr, "model_reasoning_effort=xhigh")
 	assert.Contains(t, argsStr, "stream_idle_timeout_ms=3600000")
 	assert.Contains(t, argsStr, "--sandbox read-only")
+
+	// prompt must not appear in CLI args (passed via stdin to avoid Windows 8191-char limit)
+	assert.NotContains(t, capturedArgs, "test prompt", "prompt should be passed via stdin, not as CLI arg")
 }
 
 func TestCodexExecutor_Run_CustomSettings(t *testing.T) {
@@ -261,6 +264,9 @@ func TestCodexExecutor_Run_CustomSettings(t *testing.T) {
 	assert.Contains(t, argsStr, "stream_idle_timeout_ms=1000")
 	assert.Contains(t, argsStr, "--sandbox off")
 	assert.Contains(t, argsStr, `project_doc="/path/to/doc.md"`)
+
+	// prompt must not appear in CLI args (passed via stdin to avoid Windows 8191-char limit)
+	assert.NotContains(t, capturedArgs, "test", "prompt should be passed via stdin, not as CLI arg")
 }
 
 func TestCodexExecutor_shouldDisplay_headerBlock(t *testing.T) {
@@ -473,6 +479,25 @@ func TestExecCodexRunner_Run(t *testing.T) {
 	assert.Contains(t, string(data), "hello")
 
 	// wait should complete successfully
+	err = wait()
+	require.NoError(t, err)
+}
+
+func TestExecCodexRunner_Run_Stdin(t *testing.T) {
+	// test that stdin is piped to the child process (prompt via stdin for Windows compat)
+	prompt := "hello from stdin"
+	runner := &execCodexRunner{stdin: strings.NewReader(prompt)}
+
+	// use cat which reads stdin and writes to stdout
+	streams, wait, err := runner.Run(context.Background(), "cat")
+
+	require.NoError(t, err)
+	require.NotNil(t, streams.Stdout)
+
+	data, readErr := io.ReadAll(streams.Stdout)
+	require.NoError(t, readErr)
+	assert.Equal(t, prompt, string(data))
+
 	err = wait()
 	require.NoError(t, err)
 }

--- a/scripts/codex-as-claude/codex-as-claude.sh
+++ b/scripts/codex-as-claude/codex-as-claude.sh
@@ -63,7 +63,8 @@ codex_args=(exec --json --dangerously-bypass-approvals-and-sandbox -s "$CODEX_SA
 if [[ "$is_review_prompt" == "1" ]]; then
     codex_args+=(-c "features.multi_agent=true")
 fi
-codex_args+=("$prompt")
+# prompt is passed via stdin to codex (not as CLI arg) to avoid command-line length limits.
+# codex reads from stdin when no positional prompt argument is given.
 
 # run codex with JSON output, translate events to claude stream-json format.
 # only agent messages are emitted — command executions and file reads produce
@@ -83,7 +84,7 @@ if [[ "$CODEX_VERBOSE" != "0" && "$CODEX_VERBOSE" != "1" ]]; then
     CODEX_VERBOSE=0
 fi
 
-codex "${codex_args[@]}" 2>/dev/null | while IFS= read -r line; do
+printf '%s' "$prompt" | codex "${codex_args[@]}" 2>/dev/null | while IFS= read -r line; do
     echo "$line" | jq -c --argjson verbose "$CODEX_VERBOSE" '
         if .type == "item.completed" then
             if .item.type == "agent_message" then


### PR DESCRIPTION
# Summary

- Fix Windows 8191-char command-line limit for CodexExecutor (Go) and codex-as-claude wrapper script
- Prompts are now passed via stdin instead of CLI arguments, matching the existing ClaudeExecutor approach
- CustomExecutor already uses temp files — no change needed

## Changes

**`pkg/executor/codex.go`** — CodexExecutor passes prompt via stdin:
- Added `stdin io.Reader` field to `execCodexRunner` (mirrors `execClaudeRunner`)
- Removed `args = append(args, prompt)` — codex reads from stdin when no positional prompt is given
- No interface changes — stdin is internal to `execCodexRunner`

**`pkg/executor/codex_test.go`** — Updated and new tests:
- Existing tests assert prompt is NOT in captured args
- New `TestExecCodexRunner_Run_Stdin` verifies stdin piping via `cat`

**`scripts/codex-as-claude/codex-as-claude.sh`** — Wrapper script:
- Replaced `codex_args+=("$prompt")` with `printf '%s' "$prompt" | codex ...`

## Partial completion — help wanted

This PR fixes the two codex-related components (Go executor + wrapper script), which covers the primary Claude + Codex workflow. The remaining wrapper scripts need the same treatment but require tools I don't have installed to test:

| Script | Status | Requires |
|--------|--------|----------|
| `scripts/gemini-as-claude/gemini-as-claude.sh` | not started | gemini CLI |
| `scripts/opencode/opencode-as-claude.sh` | not started | opencode CLI |
| `scripts/opencode/opencode-review.sh` | not started | opencode CLI |

See `docs/plans/long-lines-plan.md` (included) for the full plan with remaining tasks.

## Test plan

- [x] `go test ./pkg/executor/` — all tests pass
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — cross-compiles cleanly
- [ ] `bash scripts/codex-as-claude/codex-as-claude_test.sh` — requires jq (not available on dev machine)
- [ ] E2e test with codex using a prompt exceeding 8KB on Windows
- [ ] Wrapper script tests for gemini-as-claude, opencode (require respective CLIs)
