### PR TITLE
Fix default colors for light terminal readability

### DIFF
--- a/pkg/config/colors_test.go
+++ b/pkg/config/colors_test.go
@@ -20,15 +20,15 @@ func TestColorLoader_Load_EmbeddedOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// all colors should have expected default values
-	assert.Equal(t, "0,255,0", colors.Task, "task color should be green (#00ff00)")
-	assert.Equal(t, "0,255,255", colors.Review, "review color should be cyan (#00ffff)")
-	assert.Equal(t, "208,150,217", colors.Codex, "codex color should be light magenta (#d096d9)")
-	assert.Equal(t, "189,214,255", colors.ClaudeEval, "claude_eval color should be light blue (#bdd6ff)")
-	assert.Equal(t, "255,197,109", colors.Warn, "warn color should be orange (#ffc56d)")
-	assert.Equal(t, "255,0,0", colors.Error, "error color should be red (#ff0000)")
-	assert.Equal(t, "210,82,82", colors.Signal, "signal color should be muted red (#d25252)")
-	assert.Equal(t, "138,138,138", colors.Timestamp, "timestamp color should be gray (#8a8a8a)")
-	assert.Equal(t, "180,180,180", colors.Info, "info color should be light gray (#b4b4b4)")
+	assert.Equal(t, "46,139,87", colors.Task, "task color should be sea green (#2e8b57)")
+	assert.Equal(t, "26,158,158", colors.Review, "review color should be teal (#1a9e9e)")
+	assert.Equal(t, "155,89,182", colors.Codex, "codex color should be purple (#9b59b6)")
+	assert.Equal(t, "91,141,217", colors.ClaudeEval, "claude_eval color should be blue (#5b8dd9)")
+	assert.Equal(t, "212,147,13", colors.Warn, "warn color should be amber (#d4930d)")
+	assert.Equal(t, "204,0,0", colors.Error, "error color should be red (#cc0000)")
+	assert.Equal(t, "210,82,82", colors.Signal, "signal color should be red (#d25252)")
+	assert.Equal(t, "112,112,112", colors.Timestamp, "timestamp color should be gray (#707070)")
+	assert.Equal(t, "128,128,128", colors.Info, "info color should be gray (#808080)")
 }
 
 func TestColorLoader_Load_GlobalConfigOverridesEmbedded(t *testing.T) {
@@ -50,8 +50,8 @@ color_error = #00ff00
 	assert.Equal(t, "0,255,0", colors.Error)
 
 	// missing colors from embedded defaults
-	assert.Equal(t, "0,255,255", colors.Review)
-	assert.Equal(t, "208,150,217", colors.Codex)
+	assert.Equal(t, "26,158,158", colors.Review)
+	assert.Equal(t, "155,89,182", colors.Codex)
 }
 
 func TestColorLoader_Load_LocalOverridesGlobal(t *testing.T) {
@@ -81,7 +81,7 @@ color_task = #0000ff
 	assert.Equal(t, "0,255,0", colors.Error)
 
 	// embedded defaults for unset colors
-	assert.Equal(t, "0,255,255", colors.Review)
+	assert.Equal(t, "26,158,158", colors.Review)
 }
 
 func TestColorLoader_Load_NonExistentFiles(t *testing.T) {
@@ -90,8 +90,8 @@ func TestColorLoader_Load_NonExistentFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	// should fall back to embedded defaults
-	assert.Equal(t, "0,255,0", colors.Task)
-	assert.Equal(t, "255,0,0", colors.Error)
+	assert.Equal(t, "46,139,87", colors.Task)
+	assert.Equal(t, "204,0,0", colors.Error)
 }
 
 func TestColorLoader_Load_InvalidColor(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,15 +166,15 @@ func TestEmbeddedDefaultsColorValues(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify all 9 colors have expected default values (from defaults/config)
-	assert.Equal(t, "0,255,0", cfg.Colors.Task, "task color should be green (#00ff00)")
-	assert.Equal(t, "0,255,255", cfg.Colors.Review, "review color should be cyan (#00ffff)")
-	assert.Equal(t, "208,150,217", cfg.Colors.Codex, "codex color should be light magenta (#d096d9)")
-	assert.Equal(t, "189,214,255", cfg.Colors.ClaudeEval, "claude_eval color should be light blue (#bdd6ff)")
-	assert.Equal(t, "255,197,109", cfg.Colors.Warn, "warn color should be orange (#ffc56d)")
-	assert.Equal(t, "255,0,0", cfg.Colors.Error, "error color should be red (#ff0000)")
-	assert.Equal(t, "210,82,82", cfg.Colors.Signal, "signal color should be muted red (#d25252)")
-	assert.Equal(t, "138,138,138", cfg.Colors.Timestamp, "timestamp color should be gray (#8a8a8a)")
-	assert.Equal(t, "180,180,180", cfg.Colors.Info, "info color should be light gray (#b4b4b4)")
+	assert.Equal(t, "46,139,87", cfg.Colors.Task, "task color should be sea green (#2e8b57)")
+	assert.Equal(t, "26,158,158", cfg.Colors.Review, "review color should be teal (#1a9e9e)")
+	assert.Equal(t, "155,89,182", cfg.Colors.Codex, "codex color should be purple (#9b59b6)")
+	assert.Equal(t, "91,141,217", cfg.Colors.ClaudeEval, "claude_eval color should be blue (#5b8dd9)")
+	assert.Equal(t, "212,147,13", cfg.Colors.Warn, "warn color should be amber (#d4930d)")
+	assert.Equal(t, "204,0,0", cfg.Colors.Error, "error color should be red (#cc0000)")
+	assert.Equal(t, "210,82,82", cfg.Colors.Signal, "signal color should be red (#d25252)")
+	assert.Equal(t, "112,112,112", cfg.Colors.Timestamp, "timestamp color should be gray (#707070)")
+	assert.Equal(t, "128,128,128", cfg.Colors.Info, "info color should be gray (#808080)")
 }
 
 func TestLoad_PartialConfig(t *testing.T) {
@@ -697,7 +697,7 @@ color_task = #0000ff
 	// global preserved
 	assert.Equal(t, "0,255,0", cfg.Colors.Error, "global green should be preserved")
 	// embedded defaults
-	assert.Equal(t, "0,255,255", cfg.Colors.Review, "embedded cyan should be used")
+	assert.Equal(t, "26,158,158", cfg.Colors.Review, "embedded teal should be used")
 
 	// --- verify prompts merge chain: local → global → embedded ---
 	// local override

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -283,28 +283,28 @@ codex_limit_patterns = Rate limit,quota exceeded
 # ------------------------------------------------------------------------------
 
 # color_task: task execution phase (green)
-color_task = #00ff00
+color_task = #2e8b57
 
-# color_review: review phase (cyan)
-color_review = #00ffff
+# color_review: review phase (teal)
+color_review = #1a9e9e
 
-# color_codex: codex external review (magenta)
-color_codex = #d096d9
+# color_codex: codex external review (purple)
+color_codex = #9b59b6
 
-# color_claude_eval: claude evaluation of codex output (light blue)
-color_claude_eval = #bdd6ff
+# color_claude_eval: claude evaluation of codex output (blue)
+color_claude_eval = #5b8dd9
 
-# color_warn: warning messages (yellow)
-color_warn = #ffc56d
+# color_warn: warning messages (amber)
+color_warn = #d4930d
 
 # color_error: error messages (red)
-color_error = #ff0000
+color_error = #cc0000
 
-# color_signal: completion/failure signals (light red)
+# color_signal: completion/failure signals (red)
 color_signal = #d25252
 
 # color_timestamp: timestamp prefix (gray)
-color_timestamp = #8a8a8a
+color_timestamp = #707070
 
-# color_info: informational messages (light gray)
-color_info = #b4b4b4
+# color_info: informational messages (gray)
+color_info = #808080

--- a/pkg/executor/procgroup_test.go
+++ b/pkg/executor/procgroup_test.go
@@ -56,7 +56,7 @@ func TestExecClaudeRunner_KillsProcessGroup(t *testing.T) {
 func TestExecClaudeRunner_KillsOrphansOnNormalExit(t *testing.T) {
 	// verifies that when the parent process exits normally (not via cancellation),
 	// orphaned descendants are still killed by the post-Wait killProcessGroup call.
-	// Setsid: true + background sleep keeps the child in the same process group
+	// setsid: true + background sleep keeps the child in the same process group
 	// as the parent, so -pgid kill reaches it even after the parent exits.
 
 	ctx := t.Context()


### PR DESCRIPTION
Replace default colors with mid-tone alternatives readable on both dark and light terminal backgrounds.

**Changes:**
- *task*: `#00ff00` → `#2e8b57` (pure green → sea green)
- *review*: `#00ffff` → `#1a9e9e` (pure cyan → teal)
- *codex*: `#d096d9` → `#9b59b6` (light purple → medium purple)
- *claude_eval*: `#bdd6ff` → `#5b8dd9` (very light blue → medium blue)
- *warn*: `#ffc56d` → `#d4930d` (light orange → darker amber)
- *error*: `#ff0000` → `#cc0000` (slightly darker red)
- *signal*: `#d25252` — unchanged
- *timestamp*: `#8a8a8a` → `#707070` (slightly darker gray)
- *info*: `#b4b4b4` → `#808080` (light gray → medium gray)

Closes #236