### PR TITLE
fix: prevent false positive pattern matching on claude analysis text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,7 @@ Configurable patterns detect rate limit and quota errors in claude/codex output:
 - `codex_error_patterns`: comma-separated patterns for codex (default: "Rate limit,quota exceeded")
 - Matching is case-insensitive substring search
 - Whitespace is trimmed from each pattern
-- For claude: patterns checked on all output during normal execution (context cancellation paths bypass pattern checks)
+- For claude: patterns checked against the last 10 text blocks (not full output) to avoid false positives when analysis text mentions rate limit phrases. Context cancellation paths bypass pattern checks
 - For codex and custom executors: patterns checked only when process exits with non-zero status and context is not canceled (avoids false positives from review findings and cancellation masking)
 - On match, ralphex exits gracefully with pattern info and help command suggestion
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -20,10 +20,13 @@ import (
 // Result holds execution result with output and detected signal.
 type Result struct {
 	Output       string // accumulated text output
+	RecentText   string // last 10 text blocks joined, used for pattern matching to avoid false positives
 	Signal       string // detected signal (COMPLETED, FAILED, etc.) or empty
 	Error        error  // execution error if any
 	IdleTimedOut bool   // true when idle timeout fired (derived context canceled, parent alive)
 }
+
+const recentBlockCount = 10 // number of recent text blocks to keep for pattern matching
 
 // PatternMatchError is returned when a configured error pattern is detected in output.
 type PatternMatchError struct {
@@ -256,17 +259,17 @@ func (e *ClaudeExecutor) Run(ctx context.Context, prompt string) Result {
 	if e.IdleTimeout > 0 && execCtx.Err() != nil && ctx.Err() == nil {
 		// check limit patterns first — idle timeout may have fired after a rate-limit message,
 		// and the caller needs LimitPatternError to trigger wait-and-retry logic.
-		if pattern := matchPattern(result.Output, e.LimitPatterns); pattern != "" {
+		if pattern := matchPattern(result.RecentText, e.LimitPatterns); pattern != "" {
 			return Result{
-				Output: result.Output,
+				Output: result.Output, RecentText: result.RecentText,
 				Signal: result.Signal,
 				Error:  &LimitPatternError{Pattern: pattern, HelpCmd: "claude /usage"},
 			}
 		}
 		// check for error patterns in output
-		if pattern := matchPattern(result.Output, e.ErrorPatterns); pattern != "" {
+		if pattern := matchPattern(result.RecentText, e.ErrorPatterns); pattern != "" {
 			return Result{
-				Output: result.Output,
+				Output: result.Output, RecentText: result.RecentText,
 				Signal: result.Signal,
 				Error:  &PatternMatchError{Pattern: pattern, HelpCmd: "claude /usage"},
 			}
@@ -279,7 +282,7 @@ func (e *ClaudeExecutor) Run(ctx context.Context, prompt string) Result {
 	if waitErr != nil {
 		// check if it was context cancellation
 		if ctx.Err() != nil {
-			return Result{Output: result.Output, Signal: result.Signal, Error: ctx.Err()}
+			return Result{Output: result.Output, RecentText: result.RecentText, Signal: result.Signal, Error: ctx.Err()}
 		}
 		if result.Output == "" {
 			return Result{Error: fmt.Errorf("claude exited with error: %w", waitErr)}
@@ -292,18 +295,18 @@ func (e *ClaudeExecutor) Run(ctx context.Context, prompt string) Result {
 	}
 
 	// check limit patterns first (higher priority)
-	if pattern := matchPattern(result.Output, e.LimitPatterns); pattern != "" {
+	if pattern := matchPattern(result.RecentText, e.LimitPatterns); pattern != "" {
 		return Result{
-			Output: result.Output,
+			Output: result.Output, RecentText: result.RecentText,
 			Signal: result.Signal,
 			Error:  &LimitPatternError{Pattern: pattern, HelpCmd: "claude /usage"},
 		}
 	}
 
 	// check for error patterns in output
-	if pattern := matchPattern(result.Output, e.ErrorPatterns); pattern != "" {
+	if pattern := matchPattern(result.RecentText, e.ErrorPatterns); pattern != "" {
 		return Result{
-			Output: result.Output,
+			Output: result.Output, RecentText: result.RecentText,
 			Signal: result.Signal,
 			Error:  &PatternMatchError{Pattern: pattern, HelpCmd: "claude /usage"},
 		}
@@ -319,6 +322,8 @@ func (e *ClaudeExecutor) Run(ctx context.Context, prompt string) Result {
 func (e *ClaudeExecutor) parseStream(ctx context.Context, r io.Reader, idleTouch func()) Result {
 	var output strings.Builder
 	var signal string
+	var recentBlocks [recentBlockCount]string
+	var blockIdx int
 
 	err := readLines(ctx, r, func(line string) {
 		idleTouch() // reset idle timer on every line of pipe activity
@@ -334,6 +339,8 @@ func (e *ClaudeExecutor) parseStream(ctx context.Context, r io.Reader, idleTouch
 			}
 			output.WriteString(line)
 			output.WriteString("\n")
+			recentBlocks[blockIdx%recentBlockCount] = line
+			blockIdx++
 			if e.OutputHandler != nil {
 				e.OutputHandler(line + "\n")
 			}
@@ -347,6 +354,10 @@ func (e *ClaudeExecutor) parseStream(ctx context.Context, r io.Reader, idleTouch
 				e.OutputHandler(text)
 			}
 
+			// track recent blocks for pattern matching (avoids false positives on full output)
+			recentBlocks[blockIdx%recentBlockCount] = text
+			blockIdx++
+
 			// check for signals in text
 			if sig := detectSignal(text); sig != "" {
 				signal = sig
@@ -354,11 +365,24 @@ func (e *ClaudeExecutor) parseStream(ctx context.Context, r io.Reader, idleTouch
 		}
 	})
 
-	if err != nil {
-		return Result{Output: output.String(), Signal: signal, Error: fmt.Errorf("stream read: %w", err)}
+	// join recent blocks in chronological order for pattern matching.
+	// iterate from the oldest slot forward to preserve order after wrap-around.
+	var recent strings.Builder
+	start := blockIdx % recentBlockCount
+	for i := range recentBlockCount {
+		b := recentBlocks[(start+i)%recentBlockCount]
+		if b != "" {
+			recent.WriteString(b)
+			recent.WriteString("\n")
+		}
 	}
 
-	return Result{Output: output.String(), Signal: signal}
+	if err != nil {
+		return Result{Output: output.String(), RecentText: recent.String(), Signal: signal,
+			Error: fmt.Errorf("stream read: %w", err)}
+	}
+
+	return Result{Output: output.String(), RecentText: recent.String(), Signal: signal}
 }
 
 // extractText extracts text content from various event types.

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -1124,3 +1124,69 @@ func TestClaudeExecutor_Run_LimitPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestClaudeExecutor_Run_PatternFalsePositive_InAnalysisText(t *testing.T) {
+	// pattern appears in early output (analysis text) but is followed by many blocks of real work.
+	// should NOT trigger pattern match because the pattern falls outside the recent blocks window.
+	lines := make([]string, 0, recentBlockCount+2)
+	// block 1: analysis text containing the pattern
+	lines = append(lines, `{"type":"content_block_delta","delta":{"type":"text_delta","text":"the error message says You've hit your limit when rate limited"}}`)
+	// blocks 2-5: normal work output (pushes pattern out of the recentBlockCount window)
+	for i := range recentBlockCount + 1 {
+		lines = append(lines, fmt.Sprintf(`{"type":"content_block_delta","delta":{"type":"text_delta","text":"normal work output block %d"}}`, i))
+	}
+	jsonStream := strings.Join(lines, "\n")
+
+	mock := &mocks.CommandRunnerMock{
+		RunFunc: func(_ context.Context, _ string, _ ...string) (io.Reader, func() error, error) {
+			return strings.NewReader(jsonStream), func() error { return nil }, nil
+		},
+	}
+	e := &ClaudeExecutor{cmdRunner: mock, LimitPatterns: []string{"You've hit your limit"}, ErrorPatterns: []string{"hit your limit"}}
+
+	result := e.Run(context.Background(), "test prompt")
+
+	require.NoError(t, result.Error, "should not detect pattern in old analysis text")
+	assert.Contains(t, result.Output, "You've hit your limit", "full output still has the text")
+	assert.NotContains(t, result.RecentText, "You've hit your limit", "recent blocks should not contain old text")
+}
+
+func TestClaudeExecutor_Run_PatternInRecentBlock(t *testing.T) {
+	// pattern in the last block (real rate limit) — should be detected
+	jsonStream := `{"type":"content_block_delta","delta":{"type":"text_delta","text":"some work done"}}
+{"type":"content_block_delta","delta":{"type":"text_delta","text":"You've hit your limit · resets 5pm"}}`
+
+	mock := &mocks.CommandRunnerMock{
+		RunFunc: func(_ context.Context, _ string, _ ...string) (io.Reader, func() error, error) {
+			return strings.NewReader(jsonStream), func() error { return nil }, nil
+		},
+	}
+	e := &ClaudeExecutor{cmdRunner: mock, LimitPatterns: []string{"You've hit your limit"}}
+
+	result := e.Run(context.Background(), "test prompt")
+
+	require.Error(t, result.Error)
+	var limitErr *LimitPatternError
+	require.ErrorAs(t, result.Error, &limitErr)
+	assert.Equal(t, "You've hit your limit", limitErr.Pattern)
+}
+
+func TestClaudeExecutor_Run_PatternInSecondToLastBlock(t *testing.T) {
+	// pattern in second-to-last block, one more short block after (e.g., reset info) — still in window
+	jsonStream := `{"type":"content_block_delta","delta":{"type":"text_delta","text":"You've hit your limit"}}
+{"type":"content_block_delta","delta":{"type":"text_delta","text":"resets at 5pm (Europe/Vilnius)"}}`
+
+	mock := &mocks.CommandRunnerMock{
+		RunFunc: func(_ context.Context, _ string, _ ...string) (io.Reader, func() error, error) {
+			return strings.NewReader(jsonStream), func() error { return nil }, nil
+		},
+	}
+	e := &ClaudeExecutor{cmdRunner: mock, LimitPatterns: []string{"You've hit your limit"}}
+
+	result := e.Run(context.Background(), "test prompt")
+
+	require.Error(t, result.Error)
+	var limitErr *LimitPatternError
+	require.ErrorAs(t, result.Error, &limitErr)
+	assert.Equal(t, "You've hit your limit", limitErr.Pattern)
+}


### PR DESCRIPTION
When codex review findings discuss rate limit patterns by name (e.g., "You've hit your limit"), Claude echoes that text in its output. The pattern matcher previously scanned the full accumulated output and flagged it as a real rate limit, aborting the run. Same class of bug as #200 (fixed for codex/custom), but Claude exits 0 on real rate limits too so the exit-code guard doesn't apply.

**Fix:** match limit/error patterns against the last 10 text blocks (chronological ring buffer with newline separators) instead of full output. Real rate limit messages appear in the final blocks. Analysis text from earlier in the session is pushed out of the window by subsequent output.

**Changes:**
- `recentBlockCount = 10` ring buffer in `parseStream`, tracks both JSON text blocks and non-JSON lines
- chronological readout with `\n` separators (prevents phantom cross-block matches)
- `RecentText` field on `Result`, used by all `matchPattern` calls in `Run()`
- 3 new tests: false positive prevention, recent block match, second-to-last block match

Related to #200
