### PR TITLE
fix: case-insensitive path handling for worktree plan commits on macOS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,10 +200,11 @@ Key files:
 - Worktree auto-removed on completion, failure, or SIGINT; branch preserved for PR
 - Only active for `ModeFull` and `ModeTasksOnly` (review/plan/external modes skip worktree)
 - `runWithWorktree()` in `cmd/ralphex/main.go` encapsulates the full lifecycle
+- Case-insensitive path handling: `CreateBranchForPlan()`, `CreateWorktreeForPlan()`, and `CommitPlanFile()` resolve plan file paths to actual on-disk case via `resolveFilesystemCase()` to handle macOS APFS case-insensitive filesystems. `hasChangesOtherThan()` uses case-insensitive comparison for plan file exclusion
 
 Key files:
 - `cmd/ralphex/main.go` - `runWithWorktree()`, `selectAndExecutePlan()`, interrupt cleanup
-- `pkg/git/service.go` - `CreateWorktreeForPlan()`, `CommitPlanFile()`, `RemoveWorktree()`
+- `pkg/git/service.go` - `CreateWorktreeForPlan()`, `CommitPlanFile()`, `RemoveWorktree()`, `resolveFilesystemCase()`
 - `pkg/git/external.go` - `addWorktree()`, `removeWorktree()`, `pruneWorktrees()` (unexported backend methods)
 
 ### Plan Creation Mode

--- a/docs/plans/completed/20260403-fix-worktree-plan-commit-case-mismatch.md
+++ b/docs/plans/completed/20260403-fix-worktree-plan-commit-case-mismatch.md
@@ -1,0 +1,133 @@
+# Fix worktree plan commit case mismatch (#265)
+
+## Overview
+
+When using `--plan` mode with `use_worktree = true`, if the plan's branch already exists from a previous attempt, ralphex fails to commit the plan file. The root cause is a filename case mismatch on macOS case-insensitive APFS: the previous commit tracked the file with one case (e.g., uppercase B), but the new plan file path uses different case (lowercase b). `git add` receives the wrong-case path and silently fails to stage the file, causing `git commit` to fail with "no changes added to commit".
+
+Related: [GitHub Issue #265](https://github.com/umputun/ralphex/issues/265)
+
+## Context
+
+- `pkg/git/service.go` — `CommitPlanFile` (line 315): computes `localPlan` from main repo path, preserving caller's case
+- `pkg/git/service.go` — `copyToWorktree` (line 347): writes plan to worktree using main repo's case; on case-insensitive FS, overwrites existing file but directory entry retains original case
+- `pkg/git/external.go` — `add()` (line 298): passes path to `git add` without case canonicalization
+- `pkg/git/external.go` — `hasChangesOtherThan()` (line 289): uses exact `==` comparison to exclude plan file from dirty list — case mismatch causes false positives
+- `pkg/git/external.go` — `toRelative()` (line 478): preserves caller's basename case (only resolves symlinks on directory portion)
+- `cmd/ralphex/main.go` — `runWithWorktree()` (line 693): calls `CommitPlanFile(req.PlanFile, ...)` using main repo path
+
+## Solution Overview
+
+Add a `resolveFilesystemCase` helper that reads the parent directory to find the actual filename case on disk, then apply it in `CommitPlanFile` and `CreateBranchForPlan` before calling `git add`. Additionally, fix `hasChangesOtherThan` to use case-insensitive comparison when excluding the plan file.
+
+This is the minimal fix that addresses the reported bug, the same bug class in the non-worktree path (`CreateBranchForPlan`), and the adjacent case-sensitivity issue in dirty-file detection. No changes to `CommitPlanFile` signature or `copyToWorktree` are needed.
+
+## Technical Details
+
+**`resolveFilesystemCase(path string) string`** — standalone unexported function in `pkg/git/external.go`. Reads `os.ReadDir(dir)` and finds a case-insensitive match for the basename via `strings.EqualFold`. Returns the path with the actual on-disk case. Falls back to the original path if directory can't be read or no match is found. This is a standalone function (not on `backend` interface) because it's pure filesystem logic with no git operations.
+
+Note: the `os.ReadDir` + `EqualFold` approach works identically on both case-sensitive (Linux) and case-insensitive (macOS) filesystems — it always scans directory entries and matches by fold, regardless of OS behavior.
+
+**`CommitPlanFile`** — after computing `localPlan`, call `resolveFilesystemCase` to canonicalize the path before passing to `add()`.
+
+**`CreateBranchForPlan`** — same fix: call `resolveFilesystemCase(planFile)` before `s.repo.add(planFile)` at line 248. Same bug class, different code path (non-worktree mode with existing branch).
+
+**`hasChangesOtherThan`** — replace `filePath == rel` with `strings.EqualFold(filePath, rel)` to handle case-insensitive plan file exclusion.
+
+## Development Approach
+
+- **testing approach**: TDD (tests first)
+- complete each task fully before moving to the next
+- make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+- **CRITICAL: all tests must pass before starting next task**
+- run tests after each change
+
+## Testing Strategy
+
+- **unit tests**: required for every task
+- tests use real git repos via `setupExternalTestRepo` helper (not mocks)
+- test the case-mismatch scenario by creating files with specific case, committing, then operating with different case
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+
+## Implementation Steps
+
+### Task 1: Add resolveFilesystemCase helper with tests (TDD)
+
+**Files:**
+- Modify: `pkg/git/external.go`
+- Modify: `pkg/git/external_test.go`
+
+- [x] write test `Test_resolveFilesystemCase` in `pkg/git/external_test.go` (table-driven):
+  - case "returns actual case when basename differs": create file `Foo-Bar.md`, call with `foo-bar.md`, expect path ending in `Foo-Bar.md`
+  - case "returns original path when no match": call with nonexistent file, expect unchanged path
+  - case "returns original path when file matches exactly": create `exact.md`, call with `exact.md`, expect `exact.md`
+  - case "returns original path when directory unreadable": call with path in nonexistent dir
+  - note: all tests work on both case-sensitive and case-insensitive FS because the function scans dir entries with `EqualFold`
+- [x] run tests — new tests must FAIL (red phase)
+- [x] implement standalone unexported `resolveFilesystemCase(path string) string` in `pkg/git/external.go`:
+  - `os.ReadDir(filepath.Dir(path))` to list directory entries
+  - `strings.EqualFold(entry.Name(), filepath.Base(path))` to find match
+  - return `filepath.Join(dir, entry.Name())` on match, original path on fallback
+- [x] run tests — must PASS (green phase)
+- [x] run `go test ./pkg/git/...` — all tests must pass
+
+### Task 2: Fix CommitPlanFile and CreateBranchForPlan to resolve filesystem case (TDD)
+
+**Files:**
+- Modify: `pkg/git/service.go`
+- Modify: `pkg/git/service_test.go`
+
+- [x] write test `TestService_CommitPlanFile` subtest "commits plan file with case-mismatched path" in `pkg/git/service_test.go`:
+  - create plan file `docs/plans/Case-Test.md` on master
+  - create worktree from master (new branch)
+  - in worktree, call `CommitPlanFile` with lowercase path `docs/plans/case-test.md` (different case)
+  - verify commit succeeds and plan is committed on feature branch
+  - cleanup worktree
+- [x] write test `TestService_CreateBranchForPlan` subtest "commits plan file with case-mismatched path" in `pkg/git/service_test.go`:
+  - create plan file `docs/plans/Branch-Case.md` on master
+  - call `CreateBranchForPlan` with lowercase path `docs/plans/branch-case.md`
+  - verify branch created and plan committed
+- [x] run tests — new tests must FAIL (red phase)
+- [x] in `CommitPlanFile` (`pkg/git/service.go`), add `localPlan = resolveFilesystemCase(localPlan)` before `s.repo.add(localPlan)` (standalone function, not via backend interface)
+- [x] in `CreateBranchForPlan` (`pkg/git/service.go`), add `planFile = resolveFilesystemCase(planFile)` before `s.repo.add(planFile)` in the `planHasChanges` block
+- [x] run tests — must PASS (green phase)
+- [x] run `go test ./pkg/git/...` — all tests must pass
+
+### Task 3: Fix hasChangesOtherThan case-insensitive comparison (TDD)
+
+**Files:**
+- Modify: `pkg/git/external.go`
+- Modify: `pkg/git/external_test.go`
+
+- [x] write test `TestExternalBackend_hasChangesOtherThan` subtest "excludes plan file with different case" in `pkg/git/external_test.go`:
+  - create a test repo, add and commit a file `docs/plans/My-Plan.md`
+  - modify the file (make it dirty)
+  - call `hasChangesOtherThan` with lowercase path `docs/plans/my-plan.md`
+  - verify the file is excluded from the dirty list (empty result)
+- [x] run tests — new test must FAIL (red phase)
+- [x] in `hasChangesOtherThan` (`pkg/git/external.go:289`), replace `filePath == rel` with `strings.EqualFold(filePath, rel)`
+- [x] run tests — must PASS (green phase)
+- [x] run `go test ./pkg/git/...` — all tests must pass
+
+### Task 4: Verify acceptance criteria
+
+- [x] verify the full case-mismatch scenario: worktree + existing branch + different case plan file → commit succeeds
+- [x] run full unit test suite: `go test ./...`
+- [x] run linter: `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0`
+- [x] run formatters: `~/.claude/format.sh`
+- [x] verify test coverage for changed files meets 80%+
+
+### Task 5: [Final] Finalize
+
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification:**
+- test on macOS with case-insensitive APFS (the reported environment)
+- create a plan, abort, re-create with different case, verify worktree commit succeeds

--- a/pkg/git/external.go
+++ b/pkg/git/external.go
@@ -260,7 +260,7 @@ func (e *externalBackend) fileHasChanges(path string) (bool, error) {
 	return out != "", nil
 }
 
-// hasChangesOtherThan returns the list of dirty file paths (excluding the given file).
+// hasChangesOtherThan returns the list of dirty file paths (excluding the given file, case-insensitive).
 // this includes modified/deleted tracked files, staged changes, and untracked files (excluding gitignored).
 // an empty slice means no other changes.
 func (e *externalBackend) hasChangesOtherThan(path string) ([]string, error) {
@@ -286,7 +286,7 @@ func (e *externalBackend) hasChangesOtherThan(path string) ([]string, error) {
 		}
 		// extract file path from porcelain output: "XY path" or "XY path -> newpath"
 		filePath := e.extractPathFromPorcelain(line)
-		if filePath == rel {
+		if strings.EqualFold(filePath, rel) {
 			continue
 		}
 		dirty = append(dirty, filePath)

--- a/pkg/git/external_test.go
+++ b/pkg/git/external_test.go
@@ -523,6 +523,28 @@ func TestExternalBackend_HasChangesOtherThan(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"README.md"}, dirty)
 	})
+
+	t.Run("excludes plan file with different case", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		eb, err := newExternalBackend(dir, "git")
+		require.NoError(t, err)
+
+		// create and commit plan file with specific case
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "My-Plan.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan\n"), 0o600))
+		runGit(t, dir, "add", "docs/plans/My-Plan.md")
+		runGit(t, dir, "commit", "-m", "add plan")
+
+		// modify the plan file to make it dirty
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan\nupdated content\n"), 0o600))
+
+		// call with lowercase path — should still exclude it
+		dirty, err := eb.hasChangesOtherThan(filepath.Join("docs", "plans", "my-plan.md"))
+		require.NoError(t, err)
+		assert.Empty(t, dirty, "plan file with different case should be excluded")
+	})
 }
 
 func TestExternalBackend_Add(t *testing.T) {

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -221,6 +221,7 @@ func (s *Service) preparePlanBranch(planFile string, requireDefault bool, defaul
 // If plan file has uncommitted changes and is the only dirty file, auto-commits it.
 // defaultBranch is the resolved default branch name (e.g. "main", "develop").
 func (s *Service) CreateBranchForPlan(planFile, defaultBranch string) error {
+	planFile = s.resolveFilesystemCase(planFile)
 	branchName, planHasChanges, err := s.preparePlanBranch(planFile, false, defaultBranch)
 	if err != nil {
 		return err
@@ -264,6 +265,8 @@ func (s *Service) CreateBranchForPlan(planFile, defaultBranch string) error {
 // git service) so the commit lands on the feature branch rather than the default branch.
 // defaultBranch is the resolved default branch name (e.g. "main", "develop").
 func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch string) (string, bool, error) {
+	planFile = s.resolveFilesystemCase(planFile)
+
 	// check worktree existence early, before preparePlanBranch runs hasChangesOtherThan
 	// (an existing worktree dir would show up as untracked and fail the dirty check)
 	earlyBranch := plan.ExtractBranchName(planFile)
@@ -312,6 +315,8 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch string) (string,
 // CommitPlanFile stages and commits a plan file on the current branch.
 // mainRepoRoot is the root of the main repository, used to compute the plan file's
 // relative path when the service operates inside a worktree.
+// the plan file path is resolved to actual on-disk case before staging
+// to handle case-insensitive filesystems (macOS APFS).
 func (s *Service) CommitPlanFile(planFile, mainRepoRoot string) error {
 	branchName := plan.ExtractBranchName(planFile)
 	s.log.Printf("committing plan file: %s\n", filepath.Base(planFile))
@@ -332,6 +337,7 @@ func (s *Service) CommitPlanFile(planFile, mainRepoRoot string) error {
 		return fmt.Errorf("relative plan path: %w", err)
 	}
 	localPlan := filepath.Join(s.repo.root(), relPlan)
+	localPlan = s.resolveFilesystemCase(localPlan)
 
 	if err := s.repo.add(localPlan); err != nil {
 		return fmt.Errorf("stage plan file: %w", err)
@@ -380,6 +386,35 @@ func (s *Service) copyToWorktree(srcPath, wtPath string) error {
 		return fmt.Errorf("copy file: %w", err)
 	}
 	return nil
+}
+
+// resolveFilesystemCase returns the path with the actual on-disk filename case.
+// reads the parent directory and finds a case-insensitive match for the basename.
+// falls back to the original path if the directory can't be read or no match is found.
+// this handles macOS APFS case-insensitive filesystems where git tracks one case
+// but the caller may provide a different case.
+func (s *Service) resolveFilesystemCase(path string) string {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return path
+	}
+
+	var foldMatch string
+	for _, entry := range entries {
+		if entry.Name() == base {
+			return path // exact match, no case resolution needed
+		}
+		if foldMatch == "" && strings.EqualFold(entry.Name(), base) {
+			foldMatch = filepath.Join(dir, entry.Name())
+		}
+	}
+	if foldMatch != "" {
+		return foldMatch
+	}
+	return path
 }
 
 // RemoveWorktree removes a git worktree at the given path.

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -395,6 +395,34 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, log.logs) // no branch created
 	})
+
+	t.Run("commits plan file with case-mismatched path", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		log := &mockLogger{}
+		svc, err := NewService(dir, log)
+		require.NoError(t, err)
+
+		// create plan file with specific case
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "Branch-Case.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Branch Case Plan"), 0o600))
+
+		// call CreateBranchForPlan with lowercase path (different case)
+		lowercasePlan := filepath.Join(plansDir, "branch-case.md")
+		err = svc.CreateBranchForPlan(lowercasePlan, "master")
+		require.NoError(t, err, "should succeed despite case mismatch in plan file path")
+
+		// verify branch created (name derived from resolved on-disk case)
+		branch, err := svc.CurrentBranch()
+		require.NoError(t, err)
+		assert.Equal(t, "Branch-Case", branch)
+
+		// verify plan was committed (no uncommitted changes)
+		hasChanges, err := svc.repo.fileHasChanges(planFile)
+		require.NoError(t, err)
+		assert.False(t, hasChanges, "plan file should be committed")
+	})
 }
 
 func TestService_MovePlanToCompleted(t *testing.T) {
@@ -1134,6 +1162,39 @@ func TestService_CommitPlanFile(t *testing.T) {
 		// cleanup
 		require.NoError(t, svc.RemoveWorktree(wtPath))
 	})
+
+	t.Run("commits plan file with case-mismatched path", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		log := &mockLogger{}
+		svc, err := NewService(dir, log)
+		require.NoError(t, err)
+
+		// create plan file with specific case on master
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "Case-Test.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Case Test Plan"), 0o600))
+
+		// create worktree from master (plan is copied in with original case)
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		require.NoError(t, err)
+		assert.True(t, planNeedsCommit)
+
+		// open worktree git service and commit plan with lowercase path (different case)
+		wtSvc, err := NewService(wtPath, log)
+		require.NoError(t, err)
+		lowercasePlan := filepath.Join(plansDir, "case-test.md")
+		err = wtSvc.CommitPlanFile(lowercasePlan, svc.Root())
+		require.NoError(t, err, "commit should succeed despite case mismatch")
+
+		// verify commit succeeded on the feature branch (branch name derived from original-case plan file)
+		wtBranch, err := wtSvc.CurrentBranch()
+		require.NoError(t, err)
+		assert.Equal(t, "Case-Test", wtBranch)
+
+		// cleanup
+		require.NoError(t, svc.RemoveWorktree(wtPath))
+	})
 }
 
 func TestService_RemoveWorktree(t *testing.T) {
@@ -1402,4 +1463,40 @@ func TestService_CommitWithTrailer(t *testing.T) {
 		assert.Contains(t, out, "move completed plan: move-trailer.md")
 		assert.Contains(t, out, "Signed-off-by: test")
 	})
+}
+
+func TestService_resolveFilesystemCase(t *testing.T) {
+	dir := setupExternalTestRepo(t)
+	svc, err := NewService(dir, noopServiceLogger())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, dir string) string // returns input path
+		wantBase string                                // expected basename in result
+	}{
+		{name: "returns actual case when basename differs", setup: func(t *testing.T, dir string) string {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "Foo-Bar.md"), []byte("x"), 0o600))
+			return filepath.Join(dir, "foo-bar.md") // different case
+		}, wantBase: "Foo-Bar.md"},
+		{name: "returns original path when no match", setup: func(_ *testing.T, dir string) string {
+			return filepath.Join(dir, "nonexistent.md")
+		}, wantBase: "nonexistent.md"},
+		{name: "returns original path when file matches exactly", setup: func(t *testing.T, dir string) string {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "exact.md"), []byte("x"), 0o600))
+			return filepath.Join(dir, "exact.md")
+		}, wantBase: "exact.md"},
+		{name: "returns original path when directory unreadable", setup: func(_ *testing.T, _ string) string {
+			return "/nonexistent-dir-abc123/file.md"
+		}, wantBase: "file.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			input := tt.setup(t, tmpDir)
+			got := svc.resolveFilesystemCase(input)
+			assert.Equal(t, tt.wantBase, filepath.Base(got))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #265

On macOS case-insensitive APFS, when a plan branch already exists from a previous attempt, the plan file may be tracked in git index with different case than the path ralphex computes. git add receives the wrong-case path and silently fails to stage, causing git commit to fail with "no changes added to commit".

**Root cause:** CommitPlanFile computes localPlan from the main repo plan file path, preserving the caller case. When the worktree git index tracks the file with different case (from a previous commit), git add with the mismatched case does not stage the file.

**Fix:**
- Add resolveFilesystemCase() method that reads the parent directory and finds the actual on-disk filename case via os.ReadDir + strings.EqualFold
- Apply it in CommitPlanFile, CreateBranchForPlan, and CreateWorktreeForPlan before staging
- Change hasChangesOtherThan to use strings.EqualFold instead of == for plan file exclusion, preventing false "uncommitted changes" errors with case mismatches

The os.ReadDir + EqualFold approach works identically on both case-sensitive (Linux) and case-insensitive (macOS) filesystems.