### PR TITLE
fix(config): add "Not logged in" to default Claude error patterns

### DIFF
--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -183,8 +183,8 @@ vcs_command = git
 # claude_error_patterns: patterns to detect in claude output indicating errors
 # comma-separated list of substrings (case-insensitive matching)
 # when detected, ralphex exits gracefully with an informative message
-# default: You've hit your limit,API Error:,cannot be launched inside another Claude Code session
-claude_error_patterns = You've hit your limit,API Error:,cannot be launched inside another Claude Code session
+# default: You've hit your limit,API Error:,cannot be launched inside another Claude Code session,Not logged in
+claude_error_patterns = You've hit your limit,API Error:,cannot be launched inside another Claude Code session,Not logged in
 
 # codex_error_patterns: patterns to detect in codex output indicating errors
 # comma-separated list of substrings (case-insensitive matching)

--- a/pkg/config/values_test.go
+++ b/pkg/config/values_test.go
@@ -66,7 +66,7 @@ func TestValuesLoader_Load_EmbeddedOnly(t *testing.T) {
 	assert.Equal(t, "docs/plans", values.PlansDir)
 	assert.Equal(t, "git", values.VcsCommand)
 	assert.Empty(t, values.CommitTrailer)
-	assert.Equal(t, []string{"You've hit your limit", "API Error:", "cannot be launched inside another Claude Code session"}, values.ClaudeErrorPatterns)
+	assert.Equal(t, []string{"You've hit your limit", "API Error:", "cannot be launched inside another Claude Code session", "Not logged in"}, values.ClaudeErrorPatterns)
 	assert.Equal(t, []string{"Rate limit", "quota exceeded"}, values.CodexErrorPatterns)
 	assert.Equal(t, []string{"You've hit your limit"}, values.ClaudeLimitPatterns)
 	assert.Equal(t, []string{"Rate limit", "quota exceeded"}, values.CodexLimitPatterns)

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -585,6 +585,7 @@ func TestMatchPattern(t *testing.T) {
 		{name: "whitespace in pattern", output: "rate  limit", patterns: []string{"rate  limit"}, want: "rate  limit"},
 		{name: "multiline output", output: "line1\nYou've hit your limit\nline3", patterns: []string{"hit your limit"}, want: "hit your limit"},
 		{name: "api error 500", output: `API Error: 500 {"type":"error","error":{"type":"api_error","message":"Internal server error"}}`, patterns: []string{"API Error:"}, want: "API Error:"},
+		{name: "not logged in", output: "Not logged in · Please run /login", patterns: []string{"Not logged in"}, want: "Not logged in"},
 	}
 
 	for _, tc := range tests {
@@ -645,6 +646,15 @@ func TestClaudeExecutor_Run_ErrorPattern(t *testing.T) {
 			wantPattern: "rate limit",
 			wantHelpCmd: "claude /usage",
 			wantOutput:  "rate limit and quota exceeded",
+		},
+		{
+			name:        "not logged in detected as error",
+			output:      "Not logged in \u00b7 Please run /login\n",
+			patterns:    []string{"Not logged in"},
+			wantError:   true,
+			wantPattern: "Not logged in",
+			wantHelpCmd: "claude /usage",
+			wantOutput:  "Not logged in \u00b7 Please run /login\n",
 		},
 	}
 

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -956,12 +956,26 @@ def run_docker(image: str, port: str, volumes: list[str], env_vars: list[str], b
         try:
             proc.terminate()
         except ProcessLookupError:
-            pass
+            return
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
     try:
         proc.wait()
     except KeyboardInterrupt:
         _terminate_proc()
-        proc.wait()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            proc.wait()
     finally:
         run_docker._active_proc = None  # type: ignore[attr-defined]
     return proc.returncode
@@ -1075,6 +1089,14 @@ def main() -> int:
                 proc.terminate()
             except ProcessLookupError:
                 pass
+            else:
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
         _cleanup_creds()
         sys.exit(128 + signum)
 

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -1097,6 +1097,11 @@ def main() -> int:
                         proc.kill()
                     except ProcessLookupError:
                         pass
+                    else:
+                        try:
+                            proc.wait(timeout=1)
+                        except (subprocess.TimeoutExpired, ProcessLookupError):
+                            pass
         _cleanup_creds()
         sys.exit(128 + signum)
 


### PR DESCRIPTION
## Summary
- Add "Not logged in" to default `claude_error_patterns` so ralphex exits gracefully instead of retrying indefinitely when Claude outputs this message inside Docker containers.
- Escalate to SIGKILL in the Docker wrapper when the docker process does not respond to SIGTERM within 5 seconds on Ctrl+C or SIGTERM.