### PR TITLE
fix: prevent indefinite hang on Windows when child processes hold pipes open

### DIFF
--- a/pkg/executor/linereader.go
+++ b/pkg/executor/linereader.go
@@ -12,24 +12,44 @@ import (
 // uses bufio.Reader internally, so there is no line length limit.
 // strips trailing \n and \r\n from lines before passing to handler (matching bufio.ScanLines behavior).
 // returns nil on EOF, or a wrapped error on context cancellation or read failure.
+//
+// each blocking ReadString call runs in a goroutine so that context cancellation
+// is detected even while the pipe read is in progress (important on Windows where
+// child processes may hold the pipe open after the parent exits, causing ReadString
+// to block indefinitely until the process is explicitly killed).
 func readLines(ctx context.Context, r io.Reader, handler func(string)) error {
+	type readResult struct {
+		line string
+		err  error
+	}
+
 	reader := bufio.NewReader(r)
+	ch := make(chan readResult, 1) // buffered: lets abandoned goroutine exit after kill
+
+	doRead := func() {
+		line, err := reader.ReadString('\n')
+		ch <- readResult{line, err}
+	}
+
+	go doRead()
+
 	for {
 		select {
 		case <-ctx.Done():
+			// goroutine is still blocked on ReadString; it will unblock when the process
+			// is killed (killProcess fires on context cancel) and drain into the buffered ch.
 			return fmt.Errorf("read lines: %w", ctx.Err())
-		default:
-		}
-		line, err := reader.ReadString('\n')
-		if line != "" {
-			line = trimLineEnding(line)
-			handler(line)
-		}
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil
+		case res := <-ch:
+			if res.line != "" {
+				handler(trimLineEnding(res.line))
 			}
-			return fmt.Errorf("read lines: %w", err)
+			if res.err != nil {
+				if errors.Is(res.err, io.EOF) {
+					return nil
+				}
+				return fmt.Errorf("read lines: %w", res.err)
+			}
+			go doRead()
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `readLines()` to run `ReadString` in a goroutine with `select` on context, so cancellation (idle/session timeout) can interrupt a blocked pipe read
- On Windows, Claude CLI child processes (Node.js, MCP servers) inherit stdout/stderr handles and keep pipes open after the parent exits, causing `ReadString` to block indefinitely
- Without this fix, the only way to unblock is manually killing processes via Task Manager

## Root cause

On Unix, `killProcess` sends `SIGKILL` to the entire process group, closing all inherited handles. On Windows, `process.Kill()` only terminates the direct process — child processes survive, pipes stay open, `ReadString` never returns, and `ctx.Done()` was never checked during the blocking read.

## What changed

`readLines()` in `pkg/executor/linereader.go`:

**Before:** synchronous `ReadString` in a loop with `select { case <-ctx.Done() / default }` — the `default` branch called `ReadString` which blocked, making context cancellation unreachable.

**After:** `ReadString` runs in a goroutine, result arrives via buffered channel. `select` listens on both the channel and `ctx.Done()`, so cancellation takes effect immediately even while the read is blocked.

## Recommendation for Windows users

Set `idle_timeout = 5m` in config (`~/.config/ralphex/config`). Without a timeout, no one cancels the context, and the pipe hangs forever. 5 minutes of silence is never normal during active task execution.

Long-term fix: Job Objects (`CreateJobObject` + `TerminateJobObject`) in `procgroup_windows.go` to kill the entire process tree, making pipes close immediately without relying on timeouts.

## Test plan

- [x] `go test ./pkg/executor/` passes
- [x] `go build ./...` compiles
- [x] Verified on Windows 10: idle timeout fires after silence, `Kill()` succeeds, `Wait()` returns, task loop continues to next task

