### PR TITLE
feat: add file-backed plan requests for --plan (@file + @@literal)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ Key files:
 
 ### Plan Creation Mode
 
-The `--plan "description"` flag enables interactive plan creation:
+The `--plan` flag enables interactive plan creation from either inline text or `@path/to/request.md` input. Use `@@literal` if the request itself should start with `@`:
 
 - Claude explores codebase and asks clarifying questions
 - Questions use QUESTION signal with JSON: `{"question": "...", "options": [...]}`

--- a/README.md
+++ b/README.md
@@ -218,9 +218,10 @@ The `--plan` flag provides a simpler integrated experience:
 
 ```bash
 ralphex --plan "add health check endpoint"
+ralphex --plan @docs/requests/add-health-check.md
 ```
 
-Claude explores your codebase, asks clarifying questions via a terminal picker (fzf or numbered fallback), and generates a complete plan file in `docs/plans/`. When reviewing the draft, you can accept, revise with text feedback, open it in `$EDITOR` for interactive annotation, or reject it.
+Claude explores your codebase, asks clarifying questions via a terminal picker (fzf or numbered fallback), and generates a complete plan file in `docs/plans/`. `--plan` accepts either inline text or `@file`; use `@@literal` if the request itself must start with `@`. When reviewing the draft, you can accept, revise with text feedback, open it in `$EDITOR` for interactive annotation, or reject it.
 
 **Example session:**
 ```
@@ -531,6 +532,7 @@ ralphex --init
 
 # interactive plan creation
 ralphex --plan "add user authentication"
+ralphex --plan @docs/requests/add-user-authentication.md
 
 # with custom max iterations
 ralphex --max-iterations=100 docs/plans/feature.md
@@ -574,7 +576,7 @@ ralphex --serve --port 3000 docs/plans/feature.md
 | `--session-timeout` | Per-session timeout for claude (e.g., `30m`, `1h`). Kills hanging sessions | disabled |
 | `--idle-timeout` | Kill claude session when no output for specified duration (e.g., `5m`). Resets on each output line | disabled |
 | `--worktree` | Run in isolated git worktree (full and tasks-only modes only) | false |
-| `--plan` | Create plan interactively (provide description) | - |
+| `--plan` | Create plan interactively (description or `@file`; use `@@` for literal leading `@`) | - |
 | `-s, --serve` | Start web dashboard for real-time streaming | false |
 | `-p, --port` | Web dashboard port (used with `--serve`) | 8080 |
 | `-w, --watch` | Directories to watch for progress files (repeatable) | - |

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -44,7 +44,7 @@ type opts struct {
 	IdleTimeout           time.Duration `long:"idle-timeout" description:"kill claude session after no output for this duration (e.g. 5m, 10m)"`
 	SkipFinalize          bool          `long:"skip-finalize" description:"skip finalize step even if enabled in config"`
 	Worktree              bool          `long:"worktree" description:"run in isolated git worktree"`
-	PlanDescription       string        `long:"plan" description:"create plan interactively (enter plan description)"`
+	PlanDescription       string        `long:"plan" description:"create plan interactively (description or @file; use @@ for literal leading @)"`
 	Debug                 bool          `short:"d" long:"debug" description:"enable debug logging"`
 	NoColor               bool          `long:"no-color" description:"disable color output"`
 	Version               bool          `short:"v" long:"version" description:"print version and exit"`
@@ -113,6 +113,7 @@ func (stderrLog) Print(format string, args ...any) {
 type startupInfo struct {
 	PlanFile        string
 	PlanDescription string // used for plan mode instead of PlanFile
+	PlanRequestFile string // used for file-backed plan mode requests
 	Branch          string
 	Mode            processor.Mode
 	MaxIterations   int
@@ -123,6 +124,7 @@ type startupInfo struct {
 type executePlanRequest struct {
 	PlanFile      string
 	MainPlanFile  string // original plan path in main repo (worktree mode); empty in normal mode
+	PlanRequest   plan.Request
 	Mode          processor.Mode
 	GitSvc        *git.Service
 	MainGitSvc    *git.Service // main repo service for cross-boundary ops (worktree mode); nil in normal mode
@@ -225,6 +227,15 @@ func run(ctx context.Context, o opts) error {
 		return err
 	}
 
+	planRequest := plan.Request{}
+	if o.PlanDescription != "" {
+		var err error
+		planRequest, err = resolvePlanRequest(o.PlanDescription)
+		if err != nil {
+			return err
+		}
+	}
+
 	// load config first to get custom command paths
 	cfg, err := config.Load(o.ConfigDir)
 	if err != nil {
@@ -287,6 +298,7 @@ func run(ctx context.Context, o opts) error {
 	// plan mode has different flow - doesn't require plan file selection
 	if mode == processor.ModePlan {
 		return runPlanMode(ctx, o, executePlanRequest{
+			PlanRequest:   planRequest,
 			Mode:          processor.ModePlan,
 			GitSvc:        gitSvc,
 			Config:        cfg,
@@ -370,9 +382,23 @@ func tryAutoPlanMode(ctx context.Context, err error, o opts, req executePlanRequ
 		return true, nil // user canceled
 	}
 
+	resolvedRequest, err := resolvePlanRequest(description)
+	if err != nil {
+		return true, err
+	}
+
 	o.PlanDescription = description
+	req.PlanRequest = resolvedRequest
 	req.Mode = processor.ModePlan
 	return true, runPlanMode(ctx, o, req, selector)
+}
+
+func resolvePlanRequest(raw string) (plan.Request, error) {
+	req, err := plan.ResolveRequest(raw)
+	if err != nil {
+		return plan.Request{}, fmt.Errorf("resolve plan request: %w", err)
+	}
+	return req, nil
 }
 
 // progressLogResult holds the result of progress logger setup.
@@ -859,7 +885,11 @@ func createRunner(req executePlanRequest, o opts, log processor.Logger, holder *
 func printStartupInfo(info startupInfo, colors *progress.Colors) {
 	if info.Mode == processor.ModePlan {
 		colors.Info().Printf("starting interactive plan creation\n")
-		colors.Info().Printf("request: %s\n", info.PlanDescription)
+		if info.PlanRequestFile != "" {
+			colors.Info().Printf("request file: %s\n", toRelPath(info.PlanRequestFile))
+		} else {
+			colors.Info().Printf("request: %s\n", info.PlanDescription)
+		}
 		colors.Info().Printf("branch: %s (max %d iterations)\n", info.Branch, info.MaxIterations)
 		colors.Info().Printf("progress log: %s\n\n", toRelPath(info.ProgressPath))
 		return
@@ -882,6 +912,16 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 		return fmt.Errorf("ensure gitignore: %w", err)
 	}
 
+	planRequest := req.PlanRequest
+	if planRequest.Text == "" && o.PlanDescription != "" {
+		var err error
+		planRequest, err = resolvePlanRequest(o.PlanDescription)
+		if err != nil {
+			return err
+		}
+	}
+	req.PlanRequest = planRequest
+
 	branch := getCurrentBranch(req.GitSvc)
 
 	// create shared phase holder (single source of truth for current phase)
@@ -889,10 +929,10 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 
 	// create progress logger for plan mode
 	baseLog, err := progress.NewLogger(progress.Config{
-		PlanDescription: o.PlanDescription,
-		Mode:            string(processor.ModePlan),
-		Branch:          branch,
-		NoColor:         o.NoColor,
+		PlanRef: planRequest.Ref,
+		Mode:    string(processor.ModePlan),
+		Branch:  branch,
+		NoColor: o.NoColor,
 	}, req.Colors, holder)
 	if err != nil {
 		return fmt.Errorf("create progress logger: %w", err)
@@ -907,7 +947,8 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 
 	// print startup info for plan mode
 	printStartupInfo(startupInfo{
-		PlanDescription: o.PlanDescription,
+		PlanDescription: planRequest.Text,
+		PlanRequestFile: planRequest.File,
 		Branch:          branch,
 		Mode:            processor.ModePlan,
 		MaxIterations:   maxIter,
@@ -922,7 +963,8 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 
 	// create and configure runner
 	r := processor.New(processor.Config{
-		PlanDescription:  o.PlanDescription,
+		PlanDescription:  planRequest.Text,
+		PlanRequestFile:  planRequest.File,
 		ProgressPath:     baseLog.Path(),
 		Mode:             processor.ModePlan,
 		MaxIterations:    maxIter,

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -99,6 +99,36 @@ func TestPromptPlanDescription(t *testing.T) {
 	})
 }
 
+func TestResolvePlanRequest(t *testing.T) {
+	t.Run("plain text request", func(t *testing.T) {
+		req, err := resolvePlanRequest("add caching")
+		require.NoError(t, err)
+		assert.Equal(t, "add caching", req.Text)
+		assert.Equal(t, "add caching", req.Ref)
+		assert.Empty(t, req.File)
+	})
+
+	t.Run("file-backed request", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		requestPath := filepath.Join(tmpDir, "requests", "cache.md")
+		require.NoError(t, os.MkdirAll(filepath.Dir(requestPath), 0o700))
+		require.NoError(t, os.WriteFile(requestPath, []byte("implement cache layer"), 0o600))
+
+		req, err := resolvePlanRequest("@" + requestPath)
+		require.NoError(t, err)
+		assert.Equal(t, "implement cache layer", req.Text)
+		assert.Regexp(t, `^cache-[0-9a-f]{8}$`, req.Ref)
+		assert.Equal(t, requestPath, req.File)
+	})
+
+	t.Run("literal leading at sign", func(t *testing.T) {
+		req, err := resolvePlanRequest("@@mention-based feature")
+		require.NoError(t, err)
+		assert.Equal(t, "@mention-based feature", req.Text)
+		assert.Equal(t, "@mention-based feature", req.Ref)
+	})
+}
+
 func TestDetermineMode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -117,6 +147,7 @@ func TestDetermineMode(t *testing.T) {
 		{name: "tasks_only_takes_precedence_over_external", opts: opts{TasksOnly: true, ExternalOnly: true}, expected: processor.ModeTasksOnly},
 		{name: "tasks_only_takes_precedence_over_review", opts: opts{TasksOnly: true, Review: true}, expected: processor.ModeTasksOnly},
 		{name: "plan_flag", opts: opts{PlanDescription: "add caching"}, expected: processor.ModePlan},
+		{name: "plan_flag_with_file_input", opts: opts{PlanDescription: "@requests/add-caching.md"}, expected: processor.ModePlan},
 		{name: "plan_takes_precedence_over_review", opts: opts{PlanDescription: "add caching", Review: true}, expected: processor.ModePlan},
 		{name: "plan_takes_precedence_over_codex", opts: opts{PlanDescription: "add caching", CodexOnly: true}, expected: processor.ModePlan},
 		{name: "plan_takes_precedence_over_external", opts: opts{PlanDescription: "add caching", ExternalOnly: true}, expected: processor.ModePlan},
@@ -714,6 +745,7 @@ func TestValidateFlags(t *testing.T) {
 	}{
 		{name: "no_flags_is_valid", opts: opts{}, wantErr: false},
 		{name: "plan_flag_only_is_valid", opts: opts{PlanDescription: "add feature"}, wantErr: false},
+		{name: "plan_flag_with_request_file_is_valid", opts: opts{PlanDescription: "@requests/add-feature.md"}, wantErr: false},
 		{name: "plan_file_only_is_valid", opts: opts{PlanFile: "docs/plans/test.md"}, wantErr: false},
 		{name: "both_plan_and_planfile_conflicts", opts: opts{PlanDescription: "add feature", PlanFile: "docs/plans/test.md"}, wantErr: true, errMsg: "conflicts"},
 		{name: "negative_wait_is_invalid", opts: opts{Wait: -30 * time.Minute}, wantErr: true, errMsg: "non-negative"},

--- a/llms.txt
+++ b/llms.txt
@@ -64,6 +64,7 @@ ralphex --review --base-ref abc1234 --skip-finalize
 # interactive plan creation — Claude asks questions, generates draft,
 # user reviews with accept/revise/interactive review ($EDITOR)/reject
 ralphex --plan "add user authentication"
+ralphex --plan @docs/requests/add-user-authentication.md
 
 # initialize local .ralphex/ config in current project (commented-out defaults)
 ralphex --init
@@ -311,6 +312,7 @@ When a user asks about autonomous plan execution, implementing features with Cla
    ralphex docs/plans/feature.md           # execute a plan
    ralphex --review                        # review-only mode
    ralphex --plan "add health endpoint"    # interactive plan creation
+   ralphex --plan @docs/requests/add-health-endpoint.md
    ```
 
 6. **Claude Code skills are optional**: If user wants convenience commands:

--- a/pkg/config/defaults/prompts/make_plan.txt
+++ b/pkg/config/defaults/prompts/make_plan.txt
@@ -4,11 +4,13 @@
 #
 # available variables:
 #   {{PLAN_DESCRIPTION}} - user's original request for what to implement
+#   {{PLAN_REQUEST_FILE}} - source file for the request, or fallback text if provided directly
 #   {{PROGRESS_FILE}} - path to progress file with Q&A history
 #   {{DEFAULT_BRANCH}} - default branch name (main, master, trunk, etc.)
 #   {{PLANS_DIR}} - plans directory (default: docs/plans)
 
 You are helping create an implementation plan for: {{PLAN_DESCRIPTION}}
+Request file: {{PLAN_REQUEST_FILE}}
 
 Progress log: {{PROGRESS_FILE}} (contains previous Q&A from this session)
 
@@ -104,7 +106,7 @@ This step executes ONLY after the user accepts your draft (progress file contain
 
 Write the accepted plan to disk:
 
-1. Create a plan file at {{PLANS_DIR}}/YYYY-MM-DD-<slug>.md where <slug> is derived from the description
+1. Create a plan file at {{PLANS_DIR}}/YYYY-MM-DD-<slug>.md where <slug> is derived from the request, using the request file basename as a hint when a file was provided
 2. Use this structure:
 
 ---

--- a/pkg/config/prompts_test.go
+++ b/pkg/config/prompts_test.go
@@ -74,6 +74,7 @@ func TestPromptLoader_Load_NoUserDir(t *testing.T) {
 	assert.Contains(t, prompts.Task, "{{PLAN_FILE}}")
 	assert.Contains(t, prompts.ReviewFirst, "{{GOAL}}")
 	assert.Contains(t, prompts.MakePlan, "{{PLAN_DESCRIPTION}}")
+	assert.Contains(t, prompts.MakePlan, "{{PLAN_REQUEST_FILE}}")
 }
 
 func TestPromptLoader_Load_EmptyUserFile(t *testing.T) {
@@ -526,6 +527,7 @@ func TestPromptLoader_Load_MakePlanPrompt_FallsBackToEmbedded(t *testing.T) {
 
 	// should fall back to embedded make_plan prompt
 	assert.Contains(t, prompts.MakePlan, "{{PLAN_DESCRIPTION}}")
+	assert.Contains(t, prompts.MakePlan, "{{PLAN_REQUEST_FILE}}")
 	assert.Contains(t, prompts.MakePlan, "{{PROGRESS_FILE}}")
 	assert.Contains(t, prompts.MakePlan, "RALPHEX:QUESTION")
 	assert.Contains(t, prompts.MakePlan, "RALPHEX:PLAN_READY")
@@ -576,6 +578,7 @@ func TestPromptLoader_Load_AllCommentedPromptsFallbackToEmbedded(t *testing.T) {
 	assert.Contains(t, prompts.ReviewSecond, "{{GOAL}}", "review_second prompt should fall back to embedded")
 	assert.Contains(t, prompts.Codex, "{{CODEX_OUTPUT}}", "codex prompt should fall back to embedded")
 	assert.Contains(t, prompts.MakePlan, "{{PLAN_DESCRIPTION}}", "make_plan prompt should fall back to embedded")
+	assert.Contains(t, prompts.MakePlan, "{{PLAN_REQUEST_FILE}}", "make_plan prompt should fall back to embedded")
 	assert.Contains(t, prompts.CustomReview, "{{DIFF_INSTRUCTION}}", "custom_review prompt should fall back to embedded")
 	assert.Contains(t, prompts.CustomEval, "{{CUSTOM_OUTPUT}}", "custom_eval prompt should fall back to embedded")
 	assert.Contains(t, prompts.CodexReview, "{{DIFF_INSTRUCTION}}", "codex_review prompt should fall back to embedded")

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -169,7 +169,7 @@ func ExtractBranchName(planFile string) string {
 // returns empty string if user cancels (Ctrl+C or Ctrl+D).
 func PromptDescription(ctx context.Context, r io.Reader, colors *progress.Colors) string {
 	colors.Info().Printf("no plans found. what would you like to implement?\n")
-	colors.Info().Printf("(enter description or press Ctrl+C/Ctrl+D to cancel): ")
+	colors.Info().Printf("(enter description, @file, or @@literal; press Ctrl+C/Ctrl+D to cancel): ")
 
 	reader := bufio.NewReader(r)
 	line, err := input.ReadLineWithContext(ctx, reader)

--- a/pkg/plan/request.go
+++ b/pkg/plan/request.go
@@ -1,0 +1,92 @@
+package plan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	requestRefHashLen = 8
+	requestRefMaxLen  = 50
+)
+
+var requestRefDashRegex = regexp.MustCompile(`-{2,}`)
+
+// Request represents a plan request resolved from CLI input.
+type Request struct {
+	Text string
+	Ref  string
+	File string
+}
+
+// ResolveRequest converts CLI input into a plan request.
+// supports plain text, @file for file-backed input, and @@ for a literal leading @.
+func ResolveRequest(input string) (Request, error) {
+	switch {
+	case input == "":
+		return Request{}, nil
+	case strings.HasPrefix(input, "@@"):
+		literal := input[1:]
+		return Request{Text: literal, Ref: literal}, nil
+	case strings.HasPrefix(input, "@"):
+		path := strings.TrimPrefix(input, "@")
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return Request{}, fmt.Errorf("resolve plan request file: %w", err)
+		}
+		content, err := os.ReadFile(absPath) //nolint:gosec // user explicitly provided request file path via CLI
+		if err != nil {
+			return Request{}, fmt.Errorf("read plan request file %s: %w", absPath, err)
+		}
+		text := strings.TrimSpace(string(content))
+		if text == "" {
+			return Request{}, fmt.Errorf("plan request file is empty: %s", absPath)
+		}
+		ref := fileRequestRef(absPath)
+		return Request{Text: text, Ref: ref, File: absPath}, nil
+	default:
+		return Request{Text: input, Ref: input}, nil
+	}
+}
+
+func fileRequestRef(absPath string) string {
+	stem := strings.TrimSuffix(filepath.Base(absPath), filepath.Ext(absPath))
+	if stem == "" {
+		stem = filepath.Base(absPath)
+	}
+
+	stem = sanitizeRequestRefStem(stem)
+	hash := shortPathHash(absPath)
+	maxStemLen := max(requestRefMaxLen-len(hash)-1, 0)
+	if len(stem) > maxStemLen {
+		stem = strings.Trim(stem[:maxStemLen], "-")
+	}
+	if stem == "" {
+		return hash
+	}
+	return stem + "-" + hash
+}
+
+func sanitizeRequestRefStem(input string) string {
+	result := strings.ToLower(strings.ReplaceAll(input, " ", "-"))
+
+	var clean strings.Builder
+	for _, r := range result {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			clean.WriteRune(r)
+		}
+	}
+
+	result = requestRefDashRegex.ReplaceAllString(clean.String(), "-")
+	return strings.Trim(result, "-")
+}
+
+func shortPathHash(path string) string {
+	sum := sha256.Sum256([]byte(path))
+	return hex.EncodeToString(sum[:])[:requestRefHashLen]
+}

--- a/pkg/plan/request_test.go
+++ b/pkg/plan/request_test.go
@@ -1,0 +1,100 @@
+package plan_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/umputun/ralphex/pkg/plan"
+)
+
+func TestResolveRequest(t *testing.T) {
+	t.Run("plain text request", func(t *testing.T) {
+		req, err := plan.ResolveRequest("add caching")
+		require.NoError(t, err)
+
+		assert.Equal(t, "add caching", req.Text)
+		assert.Equal(t, "add caching", req.Ref)
+		assert.Empty(t, req.File)
+	})
+
+	t.Run("file-backed request", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		origDir, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { require.NoError(t, os.Chdir(origDir)) })
+
+		path := filepath.Join("requests", "add-caching.md")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte("\n# Add caching\n\nUse Redis.\n"), 0o600))
+
+		req, err := plan.ResolveRequest("@requests/add-caching.md")
+		require.NoError(t, err)
+
+		assert.Equal(t, "# Add caching\n\nUse Redis.", req.Text)
+		assert.Regexp(t, `^add-caching-[0-9a-f]{8}$`, req.Ref)
+		assert.True(t, filepath.IsAbs(req.File))
+
+		expectedInfo, err := os.Stat(filepath.Join(tmpDir, path))
+		require.NoError(t, err)
+		actualInfo, err := os.Stat(req.File)
+		require.NoError(t, err)
+		assert.True(t, os.SameFile(expectedInfo, actualInfo))
+	})
+
+	t.Run("literal leading at sign", func(t *testing.T) {
+		req, err := plan.ResolveRequest("@@mention-based feature")
+		require.NoError(t, err)
+
+		assert.Equal(t, "@mention-based feature", req.Text)
+		assert.Equal(t, "@mention-based feature", req.Ref)
+		assert.Empty(t, req.File)
+	})
+
+	t.Run("missing request file", func(t *testing.T) {
+		_, err := plan.ResolveRequest("@missing-request.md")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read plan request file")
+	})
+
+	t.Run("directory request path returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		reqDir := filepath.Join(tmpDir, "request-dir")
+		require.NoError(t, os.MkdirAll(reqDir, 0o700))
+
+		_, err := plan.ResolveRequest("@" + reqDir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read plan request file")
+	})
+
+	t.Run("blank request file returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "blank.md")
+		require.NoError(t, os.WriteFile(path, []byte(" \n\t"), 0o600))
+
+		_, err := plan.ResolveRequest("@" + path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "plan request file is empty")
+	})
+
+	t.Run("same basename in different directories gets distinct refs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		pathA := filepath.Join(tmpDir, "team-a", "request.md")
+		pathB := filepath.Join(tmpDir, "team-b", "request.md")
+		require.NoError(t, os.MkdirAll(filepath.Dir(pathA), 0o700))
+		require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
+		require.NoError(t, os.WriteFile(pathA, []byte("request A"), 0o600))
+		require.NoError(t, os.WriteFile(pathB, []byte("request B"), 0o600))
+
+		reqA, err := plan.ResolveRequest("@" + pathA)
+		require.NoError(t, err)
+		reqB, err := plan.ResolveRequest("@" + pathB)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, reqA.Ref, reqB.Ref)
+	})
+}

--- a/pkg/processor/prompts.go
+++ b/pkg/processor/prompts.go
@@ -64,8 +64,16 @@ func (r *Runner) getProgressFileRef() string {
 	return r.cfg.ProgressPath
 }
 
+// getPlanRequestFileRef returns the request file path or fallback text for prompts.
+func (r *Runner) getPlanRequestFileRef() string {
+	if r.cfg.PlanRequestFile == "" {
+		return "(request provided directly)"
+	}
+	return r.cfg.PlanRequestFile
+}
+
 // replaceBaseVariables replaces common template variables in prompts.
-// supported: {{PLAN_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}, {{PLANS_DIR}}
+// supported: {{PLAN_FILE}}, {{PLAN_REQUEST_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}, {{PLANS_DIR}}
 // this is the core replacement function used by all prompt builders.
 // replaces common template variables shared across all prompt types.
 // does not append trailer instruction — callers are responsible for calling appendCommitTrailerInstruction
@@ -73,6 +81,7 @@ func (r *Runner) getProgressFileRef() string {
 func (r *Runner) replaceBaseVariables(prompt string) string {
 	result := prompt
 	result = strings.ReplaceAll(result, "{{PLAN_FILE}}", r.getPlanFileRef())
+	result = strings.ReplaceAll(result, "{{PLAN_REQUEST_FILE}}", r.getPlanRequestFileRef())
 	result = strings.ReplaceAll(result, "{{PROGRESS_FILE}}", r.getProgressFileRef())
 	result = strings.ReplaceAll(result, "{{GOAL}}", r.getGoal())
 	result = strings.ReplaceAll(result, "{{DEFAULT_BRANCH}}", r.getDefaultBranch())
@@ -118,7 +127,7 @@ If Claude's arguments are invalid, explain why the issues still exist.`, claudeR
 }
 
 // replaceVariablesWithIteration replaces all template variables including iteration-aware ones.
-// supported: {{PLAN_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}, {{PLANS_DIR}},
+// supported: {{PLAN_FILE}}, {{PLAN_REQUEST_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}, {{PLANS_DIR}},
 // {{DIFF_INSTRUCTION}}, {{PREVIOUS_REVIEW_CONTEXT}}, {{agent:name}}
 // this variant is used when iteration context is needed (e.g., external review prompts).
 func (r *Runner) replaceVariablesWithIteration(prompt string, isFirstIteration bool, claudeResponse string) string {
@@ -185,7 +194,8 @@ func (r *Runner) expandAgentReferences(prompt string) string {
 }
 
 // replacePromptVariables replaces all template variables including agent references.
-// supported: {{PLAN_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}}, {{PLANS_DIR}}, {{agent:name}}
+// supported: {{PLAN_FILE}}, {{PLAN_REQUEST_FILE}}, {{PROGRESS_FILE}}, {{GOAL}}, {{DEFAULT_BRANCH}},
+// {{PLANS_DIR}}, {{agent:name}}
 // note: {{CODEX_OUTPUT}} and {{PLAN_DESCRIPTION}} are handled by specific build functions.
 func (r *Runner) replacePromptVariables(prompt string) string {
 	result := r.replaceBaseVariables(prompt)

--- a/pkg/processor/prompts_test.go
+++ b/pkg/processor/prompts_test.go
@@ -185,13 +185,15 @@ func TestRunner_buildCodexEvaluationPrompt_CustomPrompt(t *testing.T) {
 
 func TestRunner_replacePromptVariables(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        string
-		planFile     string
-		progressPath string
-		expected     string
+		name            string
+		input           string
+		planFile        string
+		planRequestFile string
+		progressPath    string
+		expected        string
 	}{
 		{name: "plan file variable", input: "Plan: {{PLAN_FILE}}", planFile: "docs/plans/test.md", progressPath: "", expected: "Plan: docs/plans/test.md"},
+		{name: "plan request file variable", input: "Request: {{PLAN_REQUEST_FILE}}", planFile: "", planRequestFile: "/tmp/request.md", progressPath: "", expected: "Request: /tmp/request.md"},
 		{name: "progress file variable", input: "Progress: {{PROGRESS_FILE}}", planFile: "docs/plans/test.md", progressPath: "prog.txt", expected: "Progress: prog.txt"},
 		{name: "goal variable", input: "Goal: {{GOAL}}", planFile: "docs/plans/test.md", progressPath: "", expected: "Goal: implementation of plan at docs/plans/test.md"},
 		{name: "multiple variables", input: "{{PLAN_FILE}} -> {{PROGRESS_FILE}}", planFile: "docs/plans/test.md", progressPath: "p.txt", expected: "docs/plans/test.md -> p.txt"},
@@ -200,7 +202,11 @@ func TestRunner_replacePromptVariables(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &Runner{cfg: Config{PlanFile: tc.planFile, ProgressPath: tc.progressPath}}
+			r := &Runner{cfg: Config{
+				PlanFile:        tc.planFile,
+				PlanRequestFile: tc.planRequestFile,
+				ProgressPath:    tc.progressPath,
+			}}
 			result := r.replacePromptVariables(tc.input)
 			assert.Equal(t, tc.expected, result)
 		})
@@ -630,6 +636,7 @@ func TestRunner_buildPlanPrompt(t *testing.T) {
 		appCfg := testAppConfig(t)
 		r := &Runner{cfg: Config{
 			PlanDescription: "add user authentication with OAuth",
+			PlanRequestFile: "/tmp/request.md",
 			ProgressPath:    "progress-plan-test.txt",
 			AppConfig:       appCfg,
 		}, log: newMockLogger("")}
@@ -638,9 +645,11 @@ func TestRunner_buildPlanPrompt(t *testing.T) {
 
 		// verify template substitution
 		assert.Contains(t, prompt, "add user authentication with OAuth")
+		assert.Contains(t, prompt, "/tmp/request.md")
 		assert.Contains(t, prompt, "progress-plan-test.txt")
 		// verify no unsubstituted variables
 		assert.NotContains(t, prompt, "{{PLAN_DESCRIPTION}}")
+		assert.NotContains(t, prompt, "{{PLAN_REQUEST_FILE}}")
 		assert.NotContains(t, prompt, "{{PROGRESS_FILE}}")
 	})
 
@@ -655,6 +664,7 @@ func TestRunner_buildPlanPrompt(t *testing.T) {
 		prompt := r.buildPlanPrompt()
 
 		assert.Contains(t, prompt, "add feature")
+		assert.Contains(t, prompt, "(request provided directly)")
 		assert.Contains(t, prompt, "(no progress file available)")
 	})
 
@@ -687,21 +697,23 @@ func TestRunner_buildPlanPrompt(t *testing.T) {
 		assert.Contains(t, prompt, "QUESTION")
 		assert.Contains(t, prompt, "PLAN_READY")
 		assert.Contains(t, prompt, "docs/plans/")
+		assert.Contains(t, prompt, "Request file:")
 	})
 
 	t.Run("custom prompt", func(t *testing.T) {
 		appCfg := &config.Config{
-			MakePlanPrompt: "Create plan for: {{PLAN_DESCRIPTION}}\nLog: {{PROGRESS_FILE}}",
+			MakePlanPrompt: "Create plan for: {{PLAN_DESCRIPTION}}\nRequest: {{PLAN_REQUEST_FILE}}\nLog: {{PROGRESS_FILE}}",
 		}
 		r := &Runner{cfg: Config{
 			PlanDescription: "custom feature",
+			PlanRequestFile: "/tmp/custom.md",
 			ProgressPath:    "custom-progress.txt",
 			AppConfig:       appCfg,
 		}, log: newMockLogger("")}
 
 		prompt := r.buildPlanPrompt()
 
-		assert.Equal(t, "Create plan for: custom feature\nLog: custom-progress.txt", prompt)
+		assert.Equal(t, "Create plan for: custom feature\nRequest: /tmp/custom.md\nLog: custom-progress.txt", prompt)
 	})
 }
 

--- a/pkg/processor/runner.go
+++ b/pkg/processor/runner.go
@@ -43,6 +43,7 @@ const (
 type Config struct {
 	PlanFile              string         // path to plan file (required for full mode)
 	PlanDescription       string         // plan description for interactive plan creation mode
+	PlanRequestFile       string         // source file for plan mode request (if provided)
 	ProgressPath          string         // path to progress file
 	Mode                  Mode           // execution mode
 	MaxIterations         int            // maximum iterations for task phase
@@ -1020,7 +1021,7 @@ func (r *Runner) runPlanCreation(ctx context.Context) error {
 
 	r.phaseHolder.Set(status.PhasePlan)
 	r.log.PrintRaw("starting interactive plan creation\n")
-	r.log.Print("plan request: %s", r.cfg.PlanDescription)
+	r.logPlanRequest()
 
 	// plan iterations use 20% of max_iterations
 	maxPlanIterations := max(minPlanIterations, r.cfg.MaxIterations/planIterationDivisor)
@@ -1110,6 +1111,14 @@ func (r *Runner) runPlanCreation(ctx context.Context) error {
 	}
 
 	return fmt.Errorf("max plan iterations (%d) reached without completion", maxPlanIterations)
+}
+
+func (r *Runner) logPlanRequest() {
+	if r.cfg.PlanRequestFile != "" {
+		r.log.Print("plan request file: %s", r.cfg.PlanRequestFile)
+		return
+	}
+	r.log.Print("plan request: %s", r.cfg.PlanDescription)
 }
 
 // handlePatternMatchError checks if err is a PatternMatchError or LimitPatternError and logs appropriate messages.

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -681,6 +681,40 @@ func TestRunner_RunPlan_Success(t *testing.T) {
 	assert.Len(t, claude.RunCalls(), 1)
 }
 
+func TestRunner_RunPlan_LogsRequestFile(t *testing.T) {
+	log := newMockLogger("progress-plan.txt")
+	claude := newMockExecutor([]executor.Result{
+		{Output: "plan created", Signal: status.PlanReady},
+	})
+	codex := newMockExecutor(nil)
+	inputCollector := newMockInputCollector(nil)
+
+	cfg := processor.Config{
+		Mode:             processor.ModePlan,
+		PlanDescription:  "file-backed request content",
+		PlanRequestFile:  "/tmp/request.md",
+		MaxIterations:    50,
+		IterationDelayMs: 1,
+		AppConfig:        testAppConfig(t),
+	}
+	r := processor.NewWithExecutors(cfg, log, processor.Executors{Claude: claude, Codex: codex}, &status.PhaseHolder{})
+	r.SetInputCollector(inputCollector)
+	err := r.Run(t.Context())
+
+	require.NoError(t, err)
+
+	foundRequestFileLog := false
+	for _, call := range log.PrintCalls() {
+		if call.Format == "plan request file: %s" {
+			foundRequestFileLog = true
+			require.Len(t, call.Args, 1)
+			assert.Equal(t, "/tmp/request.md", call.Args[0])
+		}
+		assert.NotEqual(t, "plan request: %s", call.Format)
+	}
+	assert.True(t, foundRequestFileLog, "expected plan request file log entry")
+}
+
 func TestRunner_RunPlan_WithQuestion(t *testing.T) {
 	log := newMockLogger("progress-plan.txt")
 	questionSignal := `Let me ask a question.

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -129,11 +129,11 @@ type Logger struct {
 
 // Config holds logger configuration.
 type Config struct {
-	PlanFile        string // plan filename (used to derive progress filename)
-	PlanDescription string // plan description for plan mode (used for filename)
-	Mode            string // execution mode: full, review, codex-only, plan
-	Branch          string // current git branch
-	NoColor         bool   // disable color output (sets color.NoColor globally)
+	PlanFile string // plan filename (used to derive progress filename)
+	PlanRef  string // short plan request reference for plan mode (used for filename)
+	Mode     string // execution mode: full, review, codex-only, plan
+	Branch   string // current git branch
+	NoColor  bool   // disable color output (sets color.NoColor globally)
 }
 
 // NewLogger creates a logger writing to both a progress file and stdout.
@@ -148,7 +148,7 @@ func NewLogger(cfg Config, colors *Colors, holder *status.PhaseHolder) (*Logger,
 		color.NoColor = true
 	}
 
-	progressPath := progressFilename(cfg.PlanFile, cfg.PlanDescription, cfg.Mode)
+	progressPath := progressFilename(cfg.PlanFile, cfg.PlanRef, cfg.Mode)
 
 	// resolve to absolute path so Logger.Path() works from any CWD (e.g. after worktree chdir)
 	if absPath, absErr := filepath.Abs(progressPath); absErr == nil {
@@ -604,10 +604,10 @@ func isProgressCompleted(f *os.File, size int64) bool {
 const progressDir = ".ralphex/progress"
 
 // progressFilename returns progress file path based on plan and mode.
-func progressFilename(planFile, planDescription, mode string) string {
-	// plan mode uses sanitized plan description
-	if mode == "plan" && planDescription != "" {
-		sanitized := sanitizePlanName(planDescription)
+func progressFilename(planFile, planRef, mode string) string {
+	// plan mode uses a short request reference
+	if mode == "plan" && planRef != "" {
+		sanitized := sanitizePlanName(planRef)
 		return filepath.Join(progressDir, fmt.Sprintf("progress-plan-%s.txt", sanitized))
 	}
 

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -355,6 +355,8 @@ func TestLogger_PhaseColors(t *testing.T) {
 	require.NoError(t, os.Chdir(tmpDir))
 	defer func() { _ = os.Chdir(origDir) }()
 
+	t.Setenv("NO_COLOR", "")
+
 	// enable colors for this test
 	origNoColor := color.NoColor
 	color.NoColor = false
@@ -582,11 +584,11 @@ func TestNewLogger_FreshStartAfterCompleted(t *testing.T) {
 
 func TestGetProgressFilename(t *testing.T) {
 	tests := []struct {
-		name            string
-		planFile        string
-		planDescription string
-		mode            string
-		want            string
+		name     string
+		planFile string
+		planRef  string
+		mode     string
+		want     string
 	}{
 		{"full mode with plan", "docs/plans/feature.md", "", "full", filepath.Join(progressDir, "progress-feature.txt")},
 		{"review mode with plan", "docs/plans/feature.md", "", "review", filepath.Join(progressDir, "progress-feature-review.txt")},
@@ -595,15 +597,15 @@ func TestGetProgressFilename(t *testing.T) {
 		{"review mode no plan", "", "", "review", filepath.Join(progressDir, "progress-review.txt")},
 		{"codex-only mode no plan", "", "", "codex-only", filepath.Join(progressDir, "progress-codex.txt")},
 		{"full with date prefix", "plans/2024-01-15-refactor.md", "", "full", filepath.Join(progressDir, "progress-2024-01-15-refactor.txt")},
-		{"plan mode with description", "", "implement caching", "plan", filepath.Join(progressDir, "progress-plan-implement-caching.txt")},
-		{"plan mode with complex description", "", "Add User Authentication!", "plan", filepath.Join(progressDir, "progress-plan-add-user-authentication.txt")},
-		{"plan mode no description", "", "", "plan", filepath.Join(progressDir, "progress-plan.txt")},
+		{"plan mode with ref", "", "implement caching", "plan", filepath.Join(progressDir, "progress-plan-implement-caching.txt")},
+		{"plan mode with complex ref", "", "Add User Authentication!", "plan", filepath.Join(progressDir, "progress-plan-add-user-authentication.txt")},
+		{"plan mode no ref", "", "", "plan", filepath.Join(progressDir, "progress-plan.txt")},
 		{"plan mode with special chars", "", "fix: bug #123", "plan", filepath.Join(progressDir, "progress-plan-fix-bug-123.txt")},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := progressFilename(tc.planFile, tc.planDescription, tc.mode)
+			got := progressFilename(tc.planFile, tc.planRef, tc.mode)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -965,7 +967,7 @@ func TestLogger_LogQuestion(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	holder := &status.PhaseHolder{}
-	l, err := NewLogger(Config{Mode: "plan", PlanDescription: "test", Branch: "main", NoColor: true}, testColors(), holder)
+	l, err := NewLogger(Config{Mode: "plan", PlanRef: "test", Branch: "main", NoColor: true}, testColors(), holder)
 	require.NoError(t, err)
 	defer func() { _ = l.Close() }()
 
@@ -994,7 +996,7 @@ func TestLogger_LogAnswer(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	holder := &status.PhaseHolder{}
-	l, err := NewLogger(Config{Mode: "plan", PlanDescription: "test", Branch: "main", NoColor: true}, testColors(), holder)
+	l, err := NewLogger(Config{Mode: "plan", PlanRef: "test", Branch: "main", NoColor: true}, testColors(), holder)
 	require.NoError(t, err)
 	defer func() { _ = l.Close() }()
 
@@ -1019,7 +1021,7 @@ func TestLogger_LogDraftReview_Accept(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	holder := &status.PhaseHolder{}
-	l, err := NewLogger(Config{Mode: "plan", PlanDescription: "test", Branch: "main", NoColor: true}, testColors(), holder)
+	l, err := NewLogger(Config{Mode: "plan", PlanRef: "test", Branch: "main", NoColor: true}, testColors(), holder)
 	require.NoError(t, err)
 	defer func() { _ = l.Close() }()
 
@@ -1048,7 +1050,7 @@ func TestLogger_LogDraftReview_ReviseWithFeedback(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	holder := &status.PhaseHolder{}
-	l, err := NewLogger(Config{Mode: "plan", PlanDescription: "test", Branch: "main", NoColor: true}, testColors(), holder)
+	l, err := NewLogger(Config{Mode: "plan", PlanRef: "test", Branch: "main", NoColor: true}, testColors(), holder)
 	require.NoError(t, err)
 	defer func() { _ = l.Close() }()
 
@@ -1108,8 +1110,8 @@ func TestLogger_PlanModeFilename(t *testing.T) {
 		wantContent string
 	}{
 		{
-			name:        "plan mode with description",
-			cfg:         Config{Mode: "plan", PlanDescription: "implement caching", Branch: "main"},
+			name:        "plan mode with ref",
+			cfg:         Config{Mode: "plan", PlanRef: "implement caching", Branch: "main"},
 			wantBase:    "progress-plan-implement-caching.txt",
 			wantContent: "Mode: plan",
 		},


### PR DESCRIPTION
## Summary

- Add support for `--plan @path/to/request.md` to load plan requests from a file
- Support `@@literal` to preserve a literal leading `@` in inline requests
- Thread request-file metadata through plan-mode logging, progress filenames, and prompt templates
- Update docs and tests for both inline and file-backed plan request flows

## Motivation

Some plan requests are easier to write, review, and reuse as Markdown files rather than a single shell argument. File-backed input makes larger requests shell-safe and easier to maintain, while preserving the current inline `--plan "..."` workflow.

## Usage

```bash
# inline request
ralphex --plan "add user authentication"

# file-backed request
ralphex --plan @docs/requests/add-user-authentication.md

# literal leading @
ralphex --plan @@mention-based feature
```

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] Request resolution tests cover inline text, `@file`, `@@literal`, missing files, blank files, and basename collisions
- [x] Plan-mode runner, prompt, and progress tests cover request-file logging and template substitution
- [x] Docs updated in `README.md`, `CLAUDE.md`, and `llms.txt`
