### PR TITLE
fix: downgrade codex non-zero exit to warning when stdout has output

### DIFF
--- a/pkg/executor/codex.go
+++ b/pkg/executor/codex.go
@@ -164,6 +164,7 @@ func (e *CodexExecutor) Run(ctx context.Context, prompt string) Result {
 
 	// determine final error (prefer stderr/stdout errors over wait error)
 	var finalErr error
+	var isExitError bool // true when finalErr comes from non-zero exit code (not pipe errors)
 	switch {
 	case stderrRes.err != nil && !errors.Is(stderrRes.err, context.Canceled):
 		finalErr = stderrRes.err
@@ -173,6 +174,7 @@ func (e *CodexExecutor) Run(ctx context.Context, prompt string) Result {
 		if ctx.Err() != nil {
 			finalErr = fmt.Errorf("context error: %w", ctx.Err())
 		} else {
+			isExitError = true
 			// include stderr tail for error context when codex exits with non-zero status
 			if len(stderrRes.lastLines) > 0 {
 				finalErr = fmt.Errorf("codex exited with error: %w\nstderr: %s",
@@ -208,6 +210,19 @@ func (e *CodexExecutor) Run(ctx context.Context, prompt string) Result {
 				Error:  &PatternMatchError{Pattern: pattern, HelpCmd: "codex /status"},
 			}
 		}
+	}
+
+	// codex CLI sets exit code 1 on transient API errors (ServerNotification::Error,
+	// TurnCompleted with Failed/Interrupted status) even when the model already generated
+	// a complete response. When codex exits non-zero but produced substantive stdout output
+	// and no error/limit patterns matched, the output contains usable review findings.
+	// Downgrade the exit error to a warning so the caller processes the output normally
+	// instead of aborting the review loop. Only applies to exit code errors, not pipe failures.
+	if isExitError && finalErr != nil && strings.TrimSpace(stdoutContent) != "" {
+		if e.OutputHandler != nil {
+			e.OutputHandler(fmt.Sprintf("warning: codex exited with non-zero status but produced output, continuing\n"))
+		}
+		finalErr = nil
 	}
 
 	// return stdout content as the result (the actual answer from codex)

--- a/pkg/executor/codex_test.go
+++ b/pkg/executor/codex_test.go
@@ -149,10 +149,50 @@ func TestCodexExecutor_Run_StartError(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "command not found")
 }
 
-func TestCodexExecutor_Run_WaitError(t *testing.T) {
+func TestCodexExecutor_Run_WaitErrorWithOutput(t *testing.T) {
+	// codex exits non-zero but produced output — error should be cleared (output is usable).
+	// codex CLI sets exit code 1 on transient API errors even when the model generated
+	// a complete response; the findings in stdout are still valid.
+	var warnings []string
 	mock := &mockCodexRunner{
 		runFunc: func(_ context.Context, _ string, _ ...string) (CodexStreams, func() error, error) {
-			return mockStreams("", "partial output"), mockWaitError(errors.New("exit 1")), nil
+			return mockStreams("", "1. High: missing validation\n2. Medium: unused import"),
+				mockWaitError(errors.New("exit 1")), nil
+		},
+	}
+	e := &CodexExecutor{runner: mock, OutputHandler: func(text string) { warnings = append(warnings, text) }}
+
+	result := e.Run(context.Background(), "analyze code")
+
+	require.NoError(t, result.Error, "non-zero exit with output should not be treated as error")
+	assert.Contains(t, result.Output, "missing validation")
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "warning: codex exited with non-zero status but produced output")
+}
+
+func TestCodexExecutor_Run_WaitErrorWithOutputAndPattern(t *testing.T) {
+	// codex exits non-zero with output that matches an error pattern — pattern takes priority
+	mock := &mockCodexRunner{
+		runFunc: func(_ context.Context, _ string, _ ...string) (CodexStreams, func() error, error) {
+			return mockStreams("", "Error: Rate limit exceeded"),
+				mockWaitError(errors.New("exit 1")), nil
+		},
+	}
+	e := &CodexExecutor{runner: mock, ErrorPatterns: []string{"rate limit"}}
+
+	result := e.Run(context.Background(), "analyze code")
+
+	require.Error(t, result.Error, "pattern match should take priority over output-presence downgrade")
+	var patternErr *PatternMatchError
+	require.ErrorAs(t, result.Error, &patternErr)
+	assert.Equal(t, "rate limit", patternErr.Pattern)
+}
+
+func TestCodexExecutor_Run_WaitErrorNoOutput(t *testing.T) {
+	// codex exits non-zero with no output — genuine failure
+	mock := &mockCodexRunner{
+		runFunc: func(_ context.Context, _ string, _ ...string) (CodexStreams, func() error, error) {
+			return mockStreams("", ""), mockWaitError(errors.New("exit 1")), nil
 		},
 	}
 	e := &CodexExecutor{runner: mock}
@@ -161,7 +201,6 @@ func TestCodexExecutor_Run_WaitError(t *testing.T) {
 
 	require.Error(t, result.Error)
 	assert.Contains(t, result.Error.Error(), "codex exited with error")
-	assert.Equal(t, "partial output", result.Output)
 }
 
 func TestCodexExecutor_Run_WaitErrorWithStderr(t *testing.T) {
@@ -769,14 +808,14 @@ func TestCodexExecutor_Run_ErrorPattern(t *testing.T) {
 		wantOutput  string
 	}{
 		{
-			name: "no patterns configured, exit error only", stdout: "Rate limit exceeded",
+			name: "no patterns configured, exit error downgraded", stdout: "Rate limit exceeded",
 			patterns: nil, waitErr: exitErr, wantOutput: "Rate limit exceeded",
-			wantError: true,
+			wantError: false, // non-zero exit + output + no matching pattern → downgraded to warning
 		},
 		{
-			name: "pattern not matched, exit error only", stdout: "Analysis complete: no issues found",
+			name: "pattern not matched, exit error downgraded", stdout: "Analysis complete: no issues found",
 			patterns: []string{"rate limit", "quota exceeded"}, waitErr: exitErr,
-			wantOutput: "Analysis complete: no issues found", wantError: true,
+			wantOutput: "Analysis complete: no issues found", wantError: false, // downgraded
 		},
 		{
 			name: "pattern matched on non-zero exit", stdout: "Error: Rate limit exceeded, please try again later",
@@ -893,9 +932,9 @@ func TestCodexExecutor_Run_LimitPattern(t *testing.T) {
 			wantError: true, wantPattern: "quota exceeded",
 		},
 		{
-			name: "no pattern match, exit error only", stdout: "Analysis complete",
+			name: "no pattern match, exit error downgraded", stdout: "Analysis complete",
 			limitPat: []string{"rate limit"}, errorPat: []string{"quota exceeded"}, waitErr: exitErr,
-			wantError: true, // error from exit code, not pattern
+			wantError: false, // non-zero exit + output + no matching pattern → downgraded to warning
 		},
 		{
 			name: "patterns ignored on clean exit", stdout: "Rate limit handling code reviewed",


### PR DESCRIPTION
## Problem

Codex CLI (v0.105+) returns exit code 1 via an internal `error_seen` flag when it encounters transient API errors (`ServerNotification::Error`, `TurnCompleted` with `Failed`/`Interrupted` status), even when the model has already generated a complete response with review findings in stdout.

Currently, any non-zero exit from codex is treated as a fatal error in `CodexExecutor.Run()`, which propagates to `runExternalReviewLoop()` and aborts the entire pipeline:

```
error: runner: codex loop: codex execution: codex exited with error: command wait: exit status 1
stderr: 1. High: the new policy layer is still not the authoritative gate...
```

The findings are visible in stderr (as context), but the review loop never reaches Claude evaluation — the usable output is discarded.

## Root Cause

In `codex-rs/exec/src/lib.rs`, codex sets `error_seen = true` on:
- `ServerNotification::Error` with `will_retry: false`
- `TurnCompleted { status: Failed }`
- `TurnCompleted { status: Interrupted }`

Then exits with `process::exit(1)` if `error_seen` is true. This can happen after the model already wrote its full response to stdout (e.g., a transient API error on the final turn acknowledgment).

## Fix

Add a post-pattern-matching downgrade in `CodexExecutor.Run()`: when codex exits non-zero but produced substantive stdout output and no error/limit patterns matched, clear the error and log a warning.

**Priority order (preserved):**

| Priority | Condition | Result |
|----------|-----------|--------|
| 1 | Pipe errors (stderr/stdout read) | Fatal error |
| 2 | Context cancellation | Fatal error |
| 3 | Exit code + limit pattern match | `LimitPatternError` (retry) |
| 4 | Exit code + error pattern match | `PatternMatchError` (fatal) |
| 5 | **Exit code + non-empty output + no patterns** | **Warning (continue)** ← new |
| 6 | Exit code + empty output | Fatal error |

The downgrade only applies to exit code errors (`isExitError` flag), not to pipe read failures, so `TestCodexExecutor_Run_ErrorPriority` (stderr error > wait error) is unaffected.

## Tests

- `TestCodexExecutor_Run_WaitErrorWithOutput` — exit 1 + findings → no error, warning logged
- `TestCodexExecutor_Run_WaitErrorWithOutputAndPattern` — exit 1 + rate limit output → pattern error takes priority
- `TestCodexExecutor_Run_WaitErrorNoOutput` — exit 1 + empty output → fatal error (unchanged)
- Updated 3 existing tests where exit 1 + unmatched output is now downgraded

All `./pkg/...` tests pass.

## Reproduction

1. Run a ralphex plan with codex review enabled
2. Codex generates findings but encounters a transient OpenAI API error on the last turn
3. Codex exits with code 1
4. **Before fix:** pipeline aborts with `codex execution: codex exited with error`
5. **After fix:** warning logged, findings passed to Claude evaluation normally