### PR TITLE
feat: rename claude_model to task_model, address unmerged #272 review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ docs/plans/         # plan files location
 - Multiple execution modes: full, tasks-only, review-only, external-only/codex-only, plan creation
 - `--base-ref` flag overrides default branch for review diffs (branch name or commit hash)
 - `--skip-finalize` flag disables finalize step for a single run
-- `--task-model` flag sets model for task execution (e.g., `--task-model=opus`); `--review-model` sets model for review phases (falls back to `--task-model`). Only applies to default Claude CLI, ignored by custom wrappers (`claude_command`)
+- `--task-model` flag sets model for task execution (e.g., `--task-model=opus`); `--review-model` sets model for review phases (falls back to `--task-model`). The flag is appended as `--model <value>` to the configured `claude_command`; custom wrappers may ignore it (default behavior via `*) shift ;;`) or map it to their own model selection
 - `--wait` flag enables rate limit retry with specified duration (e.g., `--wait=1h`)
 - `--session-timeout` flag sets per-session timeout for claude (e.g., `--session-timeout=30m`), kills hanging sessions
 - `--idle-timeout` flag kills claude sessions when no output is received for a specified duration (e.g., `--idle-timeout=5m`), resets on each output line
@@ -278,8 +278,8 @@ GOOS=windows GOARCH=amd64 go build ./...
 - Precedence: CLI flags > local config > global config > embedded defaults
 - Custom prompts: `~/.config/ralphex/prompts/*.txt` or `.ralphex/prompts/*.txt`
 - Custom agents: `~/.config/ralphex/agents/*.txt` or `.ralphex/agents/*.txt`
-- `task_model` config option: model for task execution (e.g., "opus", "sonnet"). CLI flag `--task-model` takes precedence. Only applies to default Claude CLI, ignored by custom wrappers (`claude_command`). Disabled by default (empty = Claude CLI default)
-- `review_model` config option: model for review phases. Falls back to `task_model` if empty. CLI flag `--review-model` takes precedence. Only applies to default Claude CLI. Disabled by default
+- `task_model` config option: model for task execution (e.g., "opus", "sonnet"). CLI flag `--task-model` takes precedence. Appended as `--model <value>` to the configured `claude_command`; custom wrappers may ignore or implement it. Disabled by default (empty = Claude CLI default)
+- `review_model` config option: model for review phases. Falls back to `task_model` if empty. CLI flag `--review-model` takes precedence. Same wrapper behavior as `task_model`. Disabled by default
 - `default_branch` config option: override auto-detected default branch for review diffs
 - `max_iterations` config option: override CLI default (50) for maximum task iterations per plan (CLI flag `--max-iterations` takes precedence)
 - `vcs_command` config option: override the VCS binary used by the git backend (default: `"git"`). Set to a translation script path (e.g., `scripts/hg2git/hg2git.sh`) to use ralphex with Mercurial repos. See `docs/hg-support.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ docs/plans/         # plan files location
 - All comments lowercase except godoc
 - Table-driven tests with testify
 - 80%+ test coverage target
+- Documentation: use `--flag=value` form for long CLI flags with values (not `--flag value`)
 
 ## Key Patterns
 
@@ -70,9 +71,10 @@ docs/plans/         # plan files location
 - Multiple execution modes: full, tasks-only, review-only, external-only/codex-only, plan creation
 - `--base-ref` flag overrides default branch for review diffs (branch name or commit hash)
 - `--skip-finalize` flag disables finalize step for a single run
-- `--wait` flag enables rate limit retry with specified duration (e.g., `--wait 1h`)
-- `--session-timeout` flag sets per-session timeout for claude (e.g., `--session-timeout 30m`), kills hanging sessions
-- `--idle-timeout` flag kills claude sessions when no output is received for a specified duration (e.g., `--idle-timeout 5m`), resets on each output line
+- `--task-model` flag sets model for task execution (e.g., `--task-model=opus`); `--review-model` sets model for review phases (falls back to `--task-model`). Only applies to default Claude CLI, ignored by custom wrappers (`claude_command`)
+- `--wait` flag enables rate limit retry with specified duration (e.g., `--wait=1h`)
+- `--session-timeout` flag sets per-session timeout for claude (e.g., `--session-timeout=30m`), kills hanging sessions
+- `--idle-timeout` flag kills claude sessions when no output is received for a specified duration (e.g., `--idle-timeout=5m`), resets on each output line
 - `--review-patience` flag terminates external review after N unchanged rounds (stalemate detection)
 - Manual break via SIGQUIT (Ctrl+\) works in both task and external review loops. In task phase, break pauses execution and prompts "press Enter to continue, Ctrl+C to abort"; on resume the same task re-runs with a fresh session that re-reads the plan file (allowing mid-run plan edits). In external review, break terminates the loop immediately. Not available on Windows
 - Custom external review support via scripts (wraps any AI tool)
@@ -276,6 +278,8 @@ GOOS=windows GOARCH=amd64 go build ./...
 - Precedence: CLI flags > local config > global config > embedded defaults
 - Custom prompts: `~/.config/ralphex/prompts/*.txt` or `.ralphex/prompts/*.txt`
 - Custom agents: `~/.config/ralphex/agents/*.txt` or `.ralphex/agents/*.txt`
+- `task_model` config option: model for task execution (e.g., "opus", "sonnet"). CLI flag `--task-model` takes precedence. Only applies to default Claude CLI, ignored by custom wrappers (`claude_command`). Disabled by default (empty = Claude CLI default)
+- `review_model` config option: model for review phases. Falls back to `task_model` if empty. CLI flag `--review-model` takes precedence. Only applies to default Claude CLI. Disabled by default
 - `default_branch` config option: override auto-detected default branch for review diffs
 - `max_iterations` config option: override CLI default (50) for maximum task iterations per plan (CLI flag `--max-iterations` takes precedence)
 - `vcs_command` config option: override the VCS binary used by the git backend (default: `"git"`). Set to a translation script path (e.g., `scripts/hg2git/hg2git.sh`) to use ralphex with Mercurial repos. See `docs/hg-support.md`

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ ralphex --docker --dry-run   # verify socket mount in command
 
 **AWS Bedrock support:**
 
-When `--claude-provider bedrock` or `RALPHEX_CLAUDE_PROVIDER=bedrock` is set:
+When `--claude-provider=bedrock` or `RALPHEX_CLAUDE_PROVIDER=bedrock` is set:
 - Keychain credential extraction is skipped (not needed for Bedrock auth)
 - AWS credentials are automatically exported from `AWS_PROFILE` via `aws configure export-credentials`
 - Required Bedrock env vars are passed to container: `CLAUDE_CODE_USE_BEDROCK`, `AWS_REGION`, credentials
@@ -357,13 +357,13 @@ Required environment for Bedrock:
 - `AWS_REGION` - AWS region where Bedrock is enabled
 - `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` - authentication
 
-Note: `CLAUDE_CODE_USE_BEDROCK=1` is automatically set when using `--claude-provider bedrock`.
+Note: `CLAUDE_CODE_USE_BEDROCK=1` is automatically set when using `--claude-provider=bedrock`.
 
 ```bash
 # with AWS profile (credentials exported automatically)
 export AWS_PROFILE=my-bedrock-profile
 export AWS_REGION=us-east-1
-ralphex --claude-provider bedrock docs/plans/feature.md
+ralphex --claude-provider=bedrock docs/plans/feature.md
 
 # or use env var for session-wide setting
 export RALPHEX_CLAUDE_PROVIDER=bedrock
@@ -496,7 +496,7 @@ RALPHEX_IMAGE=my-ralphex ralphex docs/plans/feature.md
 
 Example with custom port:
 ```bash
-RALPHEX_PORT=3000 ralphex --serve --port 3000 docs/plans/feature.md
+RALPHEX_PORT=3000 ralphex --serve --port=3000 docs/plans/feature.md
 ```
 
 ## Usage
@@ -542,19 +542,22 @@ ralphex --max-external-iterations=5 docs/plans/feature.md
 ralphex --review-patience=3 docs/plans/feature.md
 
 # wait and retry on rate limit (instead of exiting)
-ralphex --wait 1h docs/plans/feature.md
+ralphex --wait=1h docs/plans/feature.md
+
+# use different models for tasks vs reviews (e.g., opus for tasks, sonnet for reviews)
+ralphex --task-model=opus --review-model=sonnet docs/plans/feature.md
 
 # set per-session timeout to kill hanging claude sessions
-ralphex --session-timeout 30m docs/plans/feature.md
+ralphex --session-timeout=30m docs/plans/feature.md
 
 # kill claude session when no output for 5 minutes (idle detection)
-ralphex --idle-timeout 5m docs/plans/feature.md
+ralphex --idle-timeout=5m docs/plans/feature.md
 
 # with web dashboard
 ralphex --serve docs/plans/feature.md
 
 # web dashboard on custom port
-ralphex --serve --port 3000 docs/plans/feature.md
+ralphex --serve --port=3000 docs/plans/feature.md
 ```
 
 ### Options
@@ -570,6 +573,8 @@ ralphex --serve --port 3000 docs/plans/feature.md
 | `-t, --tasks-only` | Run only task phase, skip all reviews | false |
 | `-b, --base-ref` | Override default branch for review diffs (branch name or commit hash) | auto-detect |
 | `--skip-finalize` | Skip finalize step even if enabled in config | false |
+| `--task-model` | Model for task execution (e.g., `opus`, `sonnet`, `haiku`). Only applies to default Claude CLI | empty |
+| `--review-model` | Model for review phases (falls back to `--task-model`). Only applies to default Claude CLI | empty |
 | `--wait` | Wait duration before retrying on rate limit (e.g., `1h`, `30m`) | disabled |
 | `--session-timeout` | Per-session timeout for claude (e.g., `30m`, `1h`). Kills hanging sessions | disabled |
 | `--idle-timeout` | Kill claude session when no output for specified duration (e.g., `5m`). Resets on each output line | disabled |
@@ -800,6 +805,8 @@ Use `--config-dir` or `RALPHEX_CONFIG_DIR` to override the global config locatio
 |--------|-------------|---------|
 | `claude_command` | Claude CLI command | `claude` |
 | `claude_args` | Claude CLI arguments | `--dangerously-skip-permissions --output-format stream-json --verbose` |
+| `task_model` | Model for task execution (e.g., `opus`, `sonnet`). Only applies to default Claude CLI, ignored by custom wrappers | empty |
+| `review_model` | Model for review phases. Falls back to `task_model` if empty. Only applies to default Claude CLI | empty |
 | `codex_enabled` | Enable codex review phase | `true` |
 | `codex_command` | Codex CLI command | `codex` |
 | `codex_model` | Codex model ID | `gpt-5.4` |
@@ -1084,7 +1091,7 @@ This works because ralphex only checks for the `ALL_TASKS_DONE` signal — it do
 Yes. Pro plans hit rate limits more frequently. Use `--wait` to pause and retry automatically instead of exiting:
 
 ```bash
-ralphex --wait 1h docs/plans/feature.md
+ralphex --wait=1h docs/plans/feature.md
 ```
 
 When a rate limit is detected, ralphex waits the specified duration and retries. Execution takes longer but completes unattended. You can also set `wait_on_limit = 1h` in config to make it the default.

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ ralphex --serve --port=3000 docs/plans/feature.md
 | `-t, --tasks-only` | Run only task phase, skip all reviews | false |
 | `-b, --base-ref` | Override default branch for review diffs (branch name or commit hash) | auto-detect |
 | `--skip-finalize` | Skip finalize step even if enabled in config | false |
-| `--task-model` | Model for task execution (e.g., `opus`, `sonnet`, `haiku`). Only applies to default Claude CLI | empty |
-| `--review-model` | Model for review phases (falls back to `--task-model`). Only applies to default Claude CLI | empty |
+| `--task-model` | Model for task execution (e.g., `opus`, `sonnet`, `haiku`). Appended as `--model <value>` to `claude_command`; custom wrappers may ignore or implement it | empty |
+| `--review-model` | Model for review phases (falls back to `--task-model`). Same wrapper behavior as `--task-model` | empty |
 | `--wait` | Wait duration before retrying on rate limit (e.g., `1h`, `30m`) | disabled |
 | `--session-timeout` | Per-session timeout for claude (e.g., `30m`, `1h`). Kills hanging sessions | disabled |
 | `--idle-timeout` | Kill claude session when no output for specified duration (e.g., `5m`). Resets on each output line | disabled |
@@ -805,8 +805,8 @@ Use `--config-dir` or `RALPHEX_CONFIG_DIR` to override the global config locatio
 |--------|-------------|---------|
 | `claude_command` | Claude CLI command | `claude` |
 | `claude_args` | Claude CLI arguments | `--dangerously-skip-permissions --output-format stream-json --verbose` |
-| `task_model` | Model for task execution (e.g., `opus`, `sonnet`). Only applies to default Claude CLI, ignored by custom wrappers | empty |
-| `review_model` | Model for review phases. Falls back to `task_model` if empty. Only applies to default Claude CLI | empty |
+| `task_model` | Model for task execution (e.g., `opus`, `sonnet`). Appended as `--model <value>` to `claude_command`; custom wrappers may ignore or implement it | empty |
+| `review_model` | Model for review phases. Falls back to `task_model` if empty. Same wrapper behavior as `task_model` | empty |
 | `codex_enabled` | Enable codex review phase | `true` |
 | `codex_command` | Codex CLI command | `codex` |
 | `codex_model` | Codex model ID | `gpt-5.4` |

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -34,8 +34,8 @@ type opts struct {
 	MaxIterations         int           `short:"m" long:"max-iterations" description:"maximum task iterations (default: 50)"`
 	MaxExternalIterations int           `long:"max-external-iterations" default:"0" description:"override external review iteration limit (0 = auto)"`
 	ReviewPatience        int           `long:"review-patience" default:"0" description:"terminate external review after N unchanged rounds (0 = disabled)"`
-	ClaudeModel           string        `long:"claude-model" description:"model for task execution (e.g., opus, sonnet, haiku)"`
-	ReviewModel           string        `long:"review-model" description:"model for review phases (falls back to --claude-model)"`
+	TaskModel             string        `long:"task-model" description:"model for task execution (e.g., opus, sonnet, haiku)"`
+	ReviewModel           string        `long:"review-model" description:"model for review phases (falls back to --task-model)"`
 	Review                bool          `short:"r" long:"review" description:"skip task execution, run full review pipeline"`
 	ExternalOnly          bool          `short:"e" long:"external-only" description:"skip tasks and first review, run only external review loop"`
 	CodexOnly             bool          `short:"c" long:"codex-only" description:"alias for --external-only (deprecated)"`
@@ -836,13 +836,13 @@ func createRunner(req executePlanRequest, o opts, log processor.Logger, holder *
 		reviewPatience = o.ReviewPatience
 	}
 
-	// resolve claude model: CLI flag > config file > empty (use CLI default)
-	claudeModel := req.Config.ClaudeModel
-	if o.ClaudeModel != "" {
-		claudeModel = o.ClaudeModel
+	// resolve task model: CLI flag > config file > empty (use CLI default)
+	taskModel := req.Config.TaskModel
+	if o.TaskModel != "" {
+		taskModel = o.TaskModel
 	}
 
-	// resolve review model: CLI flag > config file > claude_model > empty
+	// resolve review model: CLI flag > config file > empty (falls back to task_model in processor)
 	reviewModel := req.Config.ReviewModel
 	if o.ReviewModel != "" {
 		reviewModel = o.ReviewModel
@@ -862,7 +862,7 @@ func createRunner(req executePlanRequest, o opts, log processor.Logger, holder *
 		CodexEnabled:          codexEnabled,
 		FinalizeEnabled:       req.Config.FinalizeEnabled,
 		DefaultBranch:         req.BaseRef,
-		ClaudeModel:           claudeModel,
+		TaskModel:             taskModel,
 		ReviewModel:           reviewModel,
 		AppConfig:             req.Config,
 	}, log, holder)
@@ -937,6 +937,12 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 	startTime := time.Now()
 
 	// create and configure runner
+	// resolve task model for plan creation (same precedence as task execution)
+	planTaskModel := req.Config.TaskModel
+	if o.TaskModel != "" {
+		planTaskModel = o.TaskModel
+	}
+
 	r := processor.New(processor.Config{
 		PlanDescription:  o.PlanDescription,
 		ProgressPath:     baseLog.Path(),
@@ -946,6 +952,7 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 		NoColor:          o.NoColor,
 		IterationDelayMs: req.Config.IterationDelayMs,
 		DefaultBranch:    req.BaseRef,
+		TaskModel:        planTaskModel,
 		AppConfig:        req.Config,
 	}, baseLog, holder)
 	r.SetInputCollector(collector)

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -24,7 +24,7 @@ ralphex prompts instruct the agent to emit signals like `<<<RALPHEX:COMPLETED>>>
 `ClaudeExecutor` builds the command as:
 
 ```
-<claude_command> <claude_args...> --print
+<claude_command> <claude_args...> [--model <model>] --print
 ```
 
 The prompt is passed via stdin (not as a CLI argument). This avoids the cmd.exe 8191-character command-line limit on Windows, where large prompts (e.g., after variable expansion) can exceed the limit.

--- a/llms.txt
+++ b/llms.txt
@@ -114,7 +114,7 @@ Configuration directory: `~/.config/ralphex/` (override with `--config-dir` or `
 
 **Stalemate detection:** `review_patience` config option (or `--review-patience` CLI flag) terminates the external review loop early when Claude produces no commits for N consecutive rounds. Set to 0 (default) to disable. Useful when the external tool and Claude can't agree on findings.
 
-**Per-phase model configuration:** `task_model` config option (or `--task-model` CLI flag) sets the model for task execution (e.g., `opus`, `sonnet`, `haiku`). `review_model` (or `--review-model`) sets the model for review phases; falls back to `task_model` if empty. When set, `--model <value>` is injected into the Claude CLI args. Only applies to the default Claude CLI — custom wrappers (`claude_command`) ignore the `--model` flag. Empty by default (uses Claude CLI's default model).
+**Per-phase model configuration:** `task_model` config option (or `--task-model` CLI flag) sets the model for task execution (e.g., `opus`, `sonnet`, `haiku`). `review_model` (or `--review-model`) sets the model for review phases; falls back to `task_model` if empty. When set, `--model <value>` is appended to the configured `claude_command`. Custom wrappers may ignore the flag (default behavior via `*) shift ;;`) or map it to their own model selection. Empty by default (uses Claude CLI's default model).
 
 ```ini
 # in ~/.config/ralphex/config

--- a/llms.txt
+++ b/llms.txt
@@ -40,13 +40,16 @@ ralphex --max-external-iterations=5 docs/plans/feature.md
 ralphex --review-patience=3 docs/plans/feature.md
 
 # wait and retry on rate limit (instead of exiting)
-ralphex --wait 1h docs/plans/feature.md
+ralphex --wait=1h docs/plans/feature.md
+
+# use different models for tasks vs reviews (e.g., opus for tasks, sonnet for reviews)
+ralphex --task-model=opus --review-model=sonnet docs/plans/feature.md
 
 # set per-session timeout to kill hanging claude sessions
-ralphex --session-timeout 30m docs/plans/feature.md
+ralphex --session-timeout=30m docs/plans/feature.md
 
 # kill claude session when no output for 5 minutes (idle detection)
-ralphex --idle-timeout 5m docs/plans/feature.md
+ralphex --idle-timeout=5m docs/plans/feature.md
 
 # codex-only mode (alias for --external-only, deprecated)
 ralphex --codex-only
@@ -72,14 +75,14 @@ ralphex --init
 ralphex --reset
 
 # extract raw embedded defaults for comparison
-ralphex --dump-defaults /tmp/ralphex-defaults
+ralphex --dump-defaults=/tmp/ralphex-defaults
 
 # use custom config directory
-ralphex --config-dir ~/my-config docs/plans/feature.md
+ralphex --config-dir=~/my-config docs/plans/feature.md
 RALPHEX_CONFIG_DIR=~/my-config ralphex docs/plans/feature.md
 
 # use AWS Bedrock for Claude (Docker wrapper only)
-ralphex --claude-provider bedrock docs/plans/feature.md
+ralphex --claude-provider=bedrock docs/plans/feature.md
 RALPHEX_CLAUDE_PROVIDER=bedrock ralphex docs/plans/feature.md
 ```
 
@@ -110,6 +113,14 @@ Configuration directory: `~/.config/ralphex/` (override with `--config-dir` or `
 **External review iterations:** By default, external review runs up to `max(3, max_iterations/5)` iterations. Override with `max_external_iterations` config option or `--max-external-iterations` CLI flag (0 = auto).
 
 **Stalemate detection:** `review_patience` config option (or `--review-patience` CLI flag) terminates the external review loop early when Claude produces no commits for N consecutive rounds. Set to 0 (default) to disable. Useful when the external tool and Claude can't agree on findings.
+
+**Per-phase model configuration:** `task_model` config option (or `--task-model` CLI flag) sets the model for task execution (e.g., `opus`, `sonnet`, `haiku`). `review_model` (or `--review-model`) sets the model for review phases; falls back to `task_model` if empty. When set, `--model <value>` is injected into the Claude CLI args. Only applies to the default Claude CLI — custom wrappers (`claude_command`) ignore the `--model` flag. Empty by default (uses Claude CLI's default model).
+
+```ini
+# in ~/.config/ralphex/config
+task_model = opus
+review_model = sonnet
+```
 
 **Manual break (Ctrl+\):** Press Ctrl+\ (SIGQUIT) to intervene during execution. In the task phase, it pauses execution and prompts "press Enter to continue, Ctrl+C to abort" — on Enter the same task re-runs with a fresh session that re-reads the plan file, so you can edit the plan mid-run. In the external review phase, it terminates the loop immediately. Not available on Windows.
 
@@ -184,7 +195,7 @@ ralphex --docker --dry-run   # verify socket mount in command
 
 **AWS Bedrock support** (Docker wrapper only):
 
-When `--claude-provider bedrock` or `RALPHEX_CLAUDE_PROVIDER=bedrock` is set:
+When `--claude-provider=bedrock` or `RALPHEX_CLAUDE_PROVIDER=bedrock` is set:
 - Keychain credential extraction is skipped (not needed for Bedrock auth)
 - AWS credentials are automatically exported from `AWS_PROFILE` via `aws configure export-credentials`
 - Required Bedrock env vars are passed to container: `CLAUDE_CODE_USE_BEDROCK`, `AWS_REGION`, credentials
@@ -193,7 +204,7 @@ Required environment for Bedrock:
 - `AWS_REGION` - AWS region where Bedrock is enabled
 - `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` - authentication
 
-Note: `CLAUDE_CODE_USE_BEDROCK=1` is automatically set when using `--claude-provider bedrock`.
+Note: `CLAUDE_CODE_USE_BEDROCK=1` is automatically set when using `--claude-provider=bedrock`.
 
 See `docs/bedrock-setup.md` for detailed setup instructions and IAM policies.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,8 +44,8 @@ const (
 type Config struct {
 	ClaudeCommand string `json:"claude_command"`
 	ClaudeArgs    string `json:"claude_args"`
-	ClaudeModel   string `json:"claude_model"`  // model for task execution (e.g., "opus", "sonnet")
-	ReviewModel   string `json:"review_model"`  // model for review phases (falls back to ClaudeModel)
+	TaskModel     string `json:"task_model"`   // model for task execution (e.g., "opus", "sonnet")
+	ReviewModel   string `json:"review_model"` // model for review phases (falls back to TaskModel)
 
 	CodexEnabled         bool   `json:"codex_enabled"`
 	CodexEnabledSet      bool   `json:"-"` // tracks if codex_enabled was explicitly set in config
@@ -277,7 +277,7 @@ func loadConfigFromDirs(globalDir, localDir string) (*Config, error) {
 	c := &Config{
 		ClaudeCommand:         values.ClaudeCommand,
 		ClaudeArgs:            values.ClaudeArgs,
-		ClaudeModel:           values.ClaudeModel,
+		TaskModel:             values.TaskModel,
 		ReviewModel:           values.ReviewModel,
 		CodexEnabled:          values.CodexEnabled,
 		CodexEnabledSet:       values.CodexEnabledSet,

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -22,15 +22,15 @@ claude_command = claude
 # --verbose: enable detailed logging
 claude_args = --dangerously-skip-permissions --output-format stream-json --verbose
 
-# claude_model: model to use for task execution
+# task_model: model to use for task execution
 # available: opus, sonnet, haiku (or full model IDs like claude-sonnet-4-5-20250929)
 # leave empty to use Claude Code's default model
-# claude_model =
+# task_model =
 
 # review_model: model to use for review phases (first review, fix loops, finalize)
-# falls back to claude_model if not set, then to Claude Code's default
+# falls back to task_model if not set, then to Claude Code's default
 # use a cheaper/faster model (e.g., sonnet) for reviews to reduce cost
-# claude_model =
+# review_model =
 
 # ------------------------------------------------------------------------------
 # codex executor

--- a/pkg/config/values.go
+++ b/pkg/config/values.go
@@ -17,8 +17,8 @@ import (
 type Values struct {
 	ClaudeCommand         string
 	ClaudeArgs            string
-	ClaudeModel           string // model for task execution (e.g., "opus", "sonnet", "haiku")
-	ReviewModel           string // model for review phases (falls back to ClaudeModel if empty)
+	TaskModel             string   // model for task execution (e.g., "opus", "sonnet", "haiku")
+	ReviewModel           string   // model for review phases (falls back to TaskModel if empty)
 	ClaudeErrorPatterns   []string // patterns to detect in claude output (e.g., rate limit messages)
 	CodexEnabled          bool
 	CodexEnabledSet       bool // tracks if codex_enabled was explicitly set
@@ -181,8 +181,8 @@ func (vl *valuesLoader) parseValuesFromBytes(data []byte) (Values, error) {
 	if key, err := section.GetKey("claude_args"); err == nil {
 		values.ClaudeArgs = key.String()
 	}
-	if key, err := section.GetKey("claude_model"); err == nil {
-		values.ClaudeModel = key.String()
+	if key, err := section.GetKey("task_model"); err == nil {
+		values.TaskModel = key.String()
 	}
 	if key, err := section.GetKey("review_model"); err == nil {
 		values.ReviewModel = key.String()
@@ -423,8 +423,8 @@ func (dst *Values) mergeFrom(src *Values) {
 	if src.ClaudeArgs != "" {
 		dst.ClaudeArgs = src.ClaudeArgs
 	}
-	if src.ClaudeModel != "" {
-		dst.ClaudeModel = src.ClaudeModel
+	if src.TaskModel != "" {
+		dst.TaskModel = src.TaskModel
 	}
 	if src.ReviewModel != "" {
 		dst.ReviewModel = src.ReviewModel

--- a/pkg/config/values_test.go
+++ b/pkg/config/values_test.go
@@ -2172,34 +2172,34 @@ func TestValuesLoader_Load_LimitPatternsOverride(t *testing.T) {
 	assert.Equal(t, []string{"local pattern"}, values.ClaudeLimitPatterns)
 }
 
-func TestValuesLoader_Load_ClaudeModel(t *testing.T) {
+func TestValuesLoader_Load_TaskModel(t *testing.T) {
 	t.Run("parse valid value", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		cfgPath := filepath.Join(tmpDir, "config")
-		require.NoError(t, os.WriteFile(cfgPath, []byte(`claude_model = sonnet`), 0o600))
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`task_model = sonnet`), 0o600))
 
 		loader := newValuesLoader(defaultsFS)
 		values, err := loader.Load("", cfgPath)
 		require.NoError(t, err)
-		assert.Equal(t, "sonnet", values.ClaudeModel)
+		assert.Equal(t, "sonnet", values.TaskModel)
 	})
 
 	t.Run("not set defaults to empty", func(t *testing.T) {
 		loader := newValuesLoader(defaultsFS)
 		values, err := loader.Load("", "")
 		require.NoError(t, err)
-		assert.Empty(t, values.ClaudeModel)
+		assert.Empty(t, values.TaskModel)
 	})
 
 	t.Run("full model ID accepted", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		cfgPath := filepath.Join(tmpDir, "config")
-		require.NoError(t, os.WriteFile(cfgPath, []byte(`claude_model = claude-sonnet-4-5-20250929`), 0o600))
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`task_model = claude-sonnet-4-5-20250929`), 0o600))
 
 		loader := newValuesLoader(defaultsFS)
 		values, err := loader.Load("", cfgPath)
 		require.NoError(t, err)
-		assert.Equal(t, "claude-sonnet-4-5-20250929", values.ClaudeModel)
+		assert.Equal(t, "claude-sonnet-4-5-20250929", values.TaskModel)
 	})
 }
 
@@ -2223,32 +2223,32 @@ func TestValuesLoader_Load_ReviewModel(t *testing.T) {
 	})
 }
 
-func TestValues_mergeFrom_ClaudeModel(t *testing.T) {
+func TestValues_mergeFrom_TaskModel(t *testing.T) {
 	t.Run("non-empty overrides", func(t *testing.T) {
-		dst := Values{ClaudeModel: ""}
-		src := Values{ClaudeModel: "opus"}
+		dst := Values{TaskModel: ""}
+		src := Values{TaskModel: "opus"}
 		dst.mergeFrom(&src)
-		assert.Equal(t, "opus", dst.ClaudeModel)
+		assert.Equal(t, "opus", dst.TaskModel)
 	})
 
 	t.Run("empty preserves existing", func(t *testing.T) {
-		dst := Values{ClaudeModel: "opus"}
-		src := Values{ClaudeModel: ""}
+		dst := Values{TaskModel: "opus"}
+		src := Values{TaskModel: ""}
 		dst.mergeFrom(&src)
-		assert.Equal(t, "opus", dst.ClaudeModel)
+		assert.Equal(t, "opus", dst.TaskModel)
 	})
 
 	t.Run("local overrides global", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		globalCfg := filepath.Join(tmpDir, "global")
 		localCfg := filepath.Join(tmpDir, "local")
-		require.NoError(t, os.WriteFile(globalCfg, []byte(`claude_model = opus`), 0o600))
-		require.NoError(t, os.WriteFile(localCfg, []byte(`claude_model = haiku`), 0o600))
+		require.NoError(t, os.WriteFile(globalCfg, []byte(`task_model = opus`), 0o600))
+		require.NoError(t, os.WriteFile(localCfg, []byte(`task_model = haiku`), 0o600))
 
 		loader := newValuesLoader(defaultsFS)
 		values, err := loader.Load(localCfg, globalCfg)
 		require.NoError(t, err)
-		assert.Equal(t, "haiku", values.ClaudeModel)
+		assert.Equal(t, "haiku", values.TaskModel)
 	})
 }
 
@@ -2265,5 +2265,18 @@ func TestValues_mergeFrom_ReviewModel(t *testing.T) {
 		src := Values{ReviewModel: ""}
 		dst.mergeFrom(&src)
 		assert.Equal(t, "sonnet", dst.ReviewModel)
+	})
+
+	t.Run("local overrides global", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		globalCfg := filepath.Join(tmpDir, "global")
+		localCfg := filepath.Join(tmpDir, "local")
+		require.NoError(t, os.WriteFile(globalCfg, []byte(`review_model = sonnet`), 0o600))
+		require.NoError(t, os.WriteFile(localCfg, []byte(`review_model = haiku`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load(localCfg, globalCfg)
+		require.NoError(t, err)
+		assert.Equal(t, "haiku", values.ReviewModel)
 	})
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -149,6 +149,20 @@ func splitArgs(s string) []string {
 	return args
 }
 
+// stripFlag removes a flag and its value from args (e.g., stripFlag(args, "--model")
+// removes both "--model" and the following element). Returns a new slice.
+func stripFlag(args []string, flag string) []string {
+	result := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		if args[i] == flag && i+1 < len(args) {
+			i++ // skip flag and its value
+			continue
+		}
+		result = append(result, args[i])
+	}
+	return result
+}
+
 // filterEnv returns a copy of env with specified keys removed.
 func filterEnv(env []string, keysToRemove ...string) []string {
 	result := make([]string, 0, len(env))
@@ -218,8 +232,10 @@ func (e *ClaudeExecutor) Run(ctx context.Context, prompt string) Result {
 			"--verbose",
 		}
 	}
-	// inject --model flag if a model override is configured
+	// inject --model flag if a model override is configured;
+	// strip any existing --model from args to avoid duplicate/conflicting flags
 	if e.Model != "" {
+		args = stripFlag(args, "--model")
 		args = append(args, "--model", e.Model)
 	}
 	// always append --print to enable non-interactive mode; mirrors old -p flag that was

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -149,13 +149,22 @@ func splitArgs(s string) []string {
 	return args
 }
 
-// stripFlag removes a flag and its value from args (e.g., stripFlag(args, "--model")
-// removes both "--model" and the following element). Returns a new slice.
+// stripFlag removes all occurrences of a flag and its value from args. Handles three forms:
+// "--flag value" (space-separated, skips next element), "--flag=value" (single token),
+// and a bare "--flag" with no following value. Returns a new slice.
 func stripFlag(args []string, flag string) []string {
+	prefix := flag + "="
 	result := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
-		if args[i] == flag && i+1 < len(args) {
-			i++ // skip flag and its value
+		if args[i] == flag {
+			// space form: skip flag and its value (if present)
+			if i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(args[i], prefix) {
+			// equals form: drop the single token "--flag=value"
 			continue
 		}
 		result = append(result, args[i])

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -467,6 +467,11 @@ func TestStripFlag(t *testing.T) {
 		{name: "flag not present", args: []string{"--verbose", "--print"}, flag: "--model", want: []string{"--verbose", "--print"}},
 		{name: "flag at end with value", args: []string{"--verbose", "--model", "opus"}, flag: "--model", want: []string{"--verbose"}},
 		{name: "empty args", args: []string{}, flag: "--model", want: []string{}},
+		{name: "removes equals form", args: []string{"--verbose", "--model=opus", "--print"}, flag: "--model", want: []string{"--verbose", "--print"}},
+		{name: "removes equals form at end", args: []string{"--verbose", "--model=opus"}, flag: "--model", want: []string{"--verbose"}},
+		{name: "removes bare flag at end", args: []string{"--verbose", "--model"}, flag: "--model", want: []string{"--verbose"}},
+		{name: "removes repeated occurrences", args: []string{"--model", "opus", "--verbose", "--model=sonnet"}, flag: "--model", want: []string{"--verbose"}},
+		{name: "does not match prefix-only", args: []string{"--model-foo", "bar", "--print"}, flag: "--model", want: []string{"--model-foo", "bar", "--print"}},
 	}
 
 	for _, tc := range tests {

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -456,6 +456,27 @@ func TestSplitArgs(t *testing.T) {
 	}
 }
 
+func TestStripFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		flag string
+		want []string
+	}{
+		{name: "removes flag and value", args: []string{"--verbose", "--model", "opus", "--print"}, flag: "--model", want: []string{"--verbose", "--print"}},
+		{name: "flag not present", args: []string{"--verbose", "--print"}, flag: "--model", want: []string{"--verbose", "--print"}},
+		{name: "flag at end with value", args: []string{"--verbose", "--model", "opus"}, flag: "--model", want: []string{"--verbose"}},
+		{name: "empty args", args: []string{}, flag: "--model", want: []string{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripFlag(tc.args, tc.flag)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestFilterEnv(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1214,14 +1235,32 @@ func TestClaudeExecutor_Run_ModelFlag(t *testing.T) {
 
 	t.Run("model set injects --model flag", func(t *testing.T) {
 		e := &ClaudeExecutor{Model: "sonnet", cmdRunner: mock}
-		e.Run(context.Background(), "test")
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
 		assert.Contains(t, capturedArgs, "--model")
 		assert.Contains(t, capturedArgs, "sonnet")
 	})
 
 	t.Run("model empty does not inject --model flag", func(t *testing.T) {
 		e := &ClaudeExecutor{cmdRunner: mock}
-		e.Run(context.Background(), "test")
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
 		assert.NotContains(t, capturedArgs, "--model")
+	})
+
+	t.Run("model overrides existing --model in args", func(t *testing.T) {
+		e := &ClaudeExecutor{Args: "--verbose --model opus --output-format json", Model: "sonnet", cmdRunner: mock}
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
+		assert.Contains(t, capturedArgs, "sonnet")
+		assert.NotContains(t, capturedArgs, "opus", "old --model value should be stripped")
+		// count --model occurrences — should be exactly one
+		count := 0
+		for _, a := range capturedArgs {
+			if a == "--model" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "should have exactly one --model flag")
 	})
 }

--- a/pkg/processor/runner.go
+++ b/pkg/processor/runner.go
@@ -52,8 +52,8 @@ type Config struct {
 	NoColor               bool           // disable color output
 	IterationDelayMs      int            // delay between iterations in milliseconds
 	TaskRetryCount        int            // number of times to retry failed tasks
-	ClaudeModel           string         // model for task execution (empty = CLI default)
-	ReviewModel           string         // model for review phases (empty = falls back to ClaudeModel)
+	TaskModel             string         // model for task execution (empty = CLI default)
+	ReviewModel           string         // model for review phases (empty = falls back to TaskModel)
 	CodexEnabled          bool           // whether codex review is enabled
 	FinalizeEnabled       bool           // whether finalize step is enabled
 	DefaultBranch         string         // default branch name (detected from repo)
@@ -97,7 +97,7 @@ type GitChecker interface {
 // Executors groups the executor dependencies for the Runner.
 type Executors struct {
 	Claude       Executor
-	ReviewClaude Executor                // optional: separate executor for review phases (nil = use Claude)
+	ReviewClaude Executor // optional: separate executor for review phases (nil = use Claude)
 	Codex        Executor
 	Custom       *executor.CustomExecutor
 }
@@ -139,15 +139,15 @@ func New(cfg Config, log Logger, holder *status.PhaseHolder) *Runner {
 		claudeExec.LimitPatterns = cfg.AppConfig.ClaudeLimitPatterns
 		claudeExec.IdleTimeout = cfg.AppConfig.IdleTimeout
 	}
-	claudeExec.Model = cfg.ClaudeModel
+	claudeExec.Model = cfg.TaskModel
 
 	// build review executor (shares base config, may use a different model)
 	reviewModel := cfg.ReviewModel
 	if reviewModel == "" {
-		reviewModel = cfg.ClaudeModel // fall back to task model
+		reviewModel = cfg.TaskModel // fall back to task model
 	}
 	var reviewExec Executor
-	if reviewModel != cfg.ClaudeModel {
+	if reviewModel != cfg.TaskModel {
 		re := &executor.ClaudeExecutor{
 			OutputHandler: claudeExec.OutputHandler,
 			Debug:         cfg.Debug,

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -3812,3 +3812,59 @@ func TestRunner_IdleTimeout_ReviewLoopExitsWhenSignalPresent(t *testing.T) {
 	}
 	assert.False(t, foundIdleMsg, "should NOT log idle timeout when signal is present")
 }
+
+func TestRunner_ReviewClaude_UsedForReviewPhases(t *testing.T) {
+	log := newMockLogger("progress.txt")
+
+	// task executor should NOT be called in review-only mode
+	taskClaude := newMockExecutor(nil)
+
+	// review executor handles all review phases
+	reviewClaude := newMockExecutor([]executor.Result{
+		{Output: "review done", Signal: status.ReviewDone}, // first review
+		{Output: "review done", Signal: status.ReviewDone}, // pre-codex review loop
+		{Output: "fixed issues"},                           // codex eval iter 1 — findings fixed
+		{Output: "done", Signal: status.CodexDone},         // codex eval iter 2 — no more findings
+		{Output: "review done", Signal: status.ReviewDone}, // post-codex review loop
+	})
+	codex := newMockExecutor([]executor.Result{
+		{Output: "found issue"},     // codex iteration 1 — findings trigger eval + post-codex review
+		{Output: "no issues found"}, // codex iteration 2 — clean
+	})
+
+	cfg := processor.Config{Mode: processor.ModeReview, MaxIterations: 50, IterationDelayMs: 1, CodexEnabled: true, AppConfig: testAppConfig(t)}
+	r := processor.NewWithExecutors(cfg, log, processor.Executors{
+		Claude: taskClaude, ReviewClaude: reviewClaude, Codex: codex,
+	}, &status.PhaseHolder{})
+	err := r.Run(t.Context())
+
+	require.NoError(t, err)
+	assert.Empty(t, taskClaude.RunCalls(), "task executor should not be called in review-only mode")
+	assert.Len(t, reviewClaude.RunCalls(), 5, "review executor should handle all review phases including codex eval")
+}
+
+func TestRunner_ReviewClaude_NilFallsBackToTaskExecutor(t *testing.T) {
+	log := newMockLogger("progress.txt")
+
+	// when ReviewClaude is nil, all review calls should go to Claude (task executor)
+	claude := newMockExecutor([]executor.Result{
+		{Output: "review done", Signal: status.ReviewDone}, // first review
+		{Output: "review done", Signal: status.ReviewDone}, // pre-codex review loop
+		{Output: "fixed issues"},                           // codex eval iter 1 — findings fixed
+		{Output: "done", Signal: status.CodexDone},         // codex eval iter 2 — no more findings
+		{Output: "review done", Signal: status.ReviewDone}, // post-codex review loop
+	})
+	codex := newMockExecutor([]executor.Result{
+		{Output: "found issue"},     // codex iteration 1 — findings trigger eval + post-codex review
+		{Output: "no issues found"}, // codex iteration 2 — clean
+	})
+
+	cfg := processor.Config{Mode: processor.ModeReview, MaxIterations: 50, IterationDelayMs: 1, CodexEnabled: true, AppConfig: testAppConfig(t)}
+	r := processor.NewWithExecutors(cfg, log, processor.Executors{
+		Claude: claude, ReviewClaude: nil, Codex: codex,
+	}, &status.PhaseHolder{})
+	err := r.Run(t.Context())
+
+	require.NoError(t, err)
+	assert.Len(t, claude.RunCalls(), 5, "task executor should handle all review phases when ReviewClaude is nil")
+}


### PR DESCRIPTION
Picks up unmerged follow-up commits from `feat/claude-model-config` (those 3 commits ended up on the branch but didn't make it into the squash-merge of #272).

**Changes:**

- rename `claude_model` -> `task_model` and `--claude-model` -> `--task-model` for symmetry with `review_model` / `--review-model`
- pass task model to plan mode (was missing in original PR)
- strip duplicate `--model` flags from `claude_args` to avoid CLI errors when users put `--model` in args
- fix typo in `pkg/config/defaults/config`: review_model section had `# claude_model =` example
- add processor test for `ReviewClaude` executor separation (nil fallback + distinct review executor)
- add `ReviewModel` merge test, normalize `--flag=value` form in docs
- update README, CLAUDE.md, llms.txt, custom-providers.md
- update review-claude tests for the post-codex-skip behavior added in #282

The `claude_model` name was introduced by the partial merge of #272, so the rename is correcting an in-flight feature rather than a stable API.