### PR TITLE
feat: add --effort support via model[:effort] syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ docs/plans/         # plan files location
 - Multiple execution modes: full, tasks-only, review-only, external-only/codex-only, plan creation
 - `--base-ref` flag overrides default branch for review diffs (branch name or commit hash)
 - `--skip-finalize` flag disables finalize step for a single run
-- `--task-model` flag sets model for task execution (e.g., `--task-model=opus`); `--review-model` sets model for review phases (falls back to `--task-model`). The flag is appended as `--model <value>` to the configured `claude_command`; custom wrappers may ignore it (default behavior via `*) shift ;;`) or map it to their own model selection
+- `--task-model` flag sets model for task execution with optional effort via `model[:effort]` syntax (e.g., `--task-model=opus`, `--task-model=opus:high`, `--task-model=:medium` for effort-only). Effort levels: `low`, `medium`, `high`, `xhigh`, `max`. `--review-model` sets model/effort for review phases (falls back to `--task-model`). Injected as `--model <value>` and/or `--effort <value>` into the configured `claude_command`; custom wrappers may ignore (default behavior via `*) shift ;;`) or map them to their own selection
 - `--wait` flag enables rate limit retry with specified duration (e.g., `--wait=1h`)
 - `--session-timeout` flag sets per-session timeout for claude (e.g., `--session-timeout=30m`), kills hanging sessions
 - `--idle-timeout` flag kills claude sessions when no output is received for a specified duration (e.g., `--idle-timeout=5m`), resets on each output line
@@ -278,8 +278,8 @@ GOOS=windows GOARCH=amd64 go build ./...
 - Precedence: CLI flags > local config > global config > embedded defaults
 - Custom prompts: `~/.config/ralphex/prompts/*.txt` or `.ralphex/prompts/*.txt`
 - Custom agents: `~/.config/ralphex/agents/*.txt` or `.ralphex/agents/*.txt`
-- `task_model` config option: model for task execution (e.g., "opus", "sonnet"). CLI flag `--task-model` takes precedence. Appended as `--model <value>` to the configured `claude_command`; custom wrappers may ignore or implement it. Disabled by default (empty = Claude CLI default)
-- `review_model` config option: model for review phases. Falls back to `task_model` if empty. CLI flag `--review-model` takes precedence. Same wrapper behavior as `task_model`. Disabled by default
+- `task_model` config option: model[:effort] for task execution (e.g., `opus`, `opus:high`, `:medium`). Effort values: `low`, `medium`, `high`, `xhigh`, `max`. CLI flag `--task-model` takes precedence. Parsed in `ParseModelEffort` (pkg/processor/runner.go), split on first colon. Appended to `claude_command` as `--model <m>` and/or `--effort <e>`; custom wrappers may ignore or implement the flags. Disabled by default (empty = Claude CLI defaults)
+- `review_model` config option: model[:effort] for review phases. Falls back to `task_model` if empty. CLI flag `--review-model` takes precedence. Same wrapper behavior and syntax as `task_model`. Disabled by default
 - `default_branch` config option: override auto-detected default branch for review diffs
 - `max_iterations` config option: override CLI default (50) for maximum task iterations per plan (CLI flag `--max-iterations` takes precedence)
 - `vcs_command` config option: override the VCS binary used by the git backend (default: `"git"`). Set to a translation script path (e.g., `scripts/hg2git/hg2git.sh`) to use ralphex with Mercurial repos. See `docs/hg-support.md`

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ ralphex --serve --port=3000 docs/plans/feature.md
 | `-t, --tasks-only` | Run only task phase, skip all reviews | false |
 | `-b, --base-ref` | Override default branch for review diffs (branch name or commit hash) | auto-detect |
 | `--skip-finalize` | Skip finalize step even if enabled in config | false |
-| `--task-model` | Model for task execution (e.g., `opus`, `sonnet`, `haiku`). Appended as `--model <value>` to `claude_command`; custom wrappers may ignore or implement it | empty |
-| `--review-model` | Model for review phases (falls back to `--task-model`). Same wrapper behavior as `--task-model` | empty |
+| `--task-model` | Model for task execution as `model[:effort]` (e.g., `opus`, `opus:high`, `:medium`). Effort values: `low`, `medium`, `high`, `xhigh`, `max`. Appended as `--model <m>` and/or `--effort <e>` to `claude_command`; custom wrappers may ignore or implement the flags | empty |
+| `--review-model` | Model for review phases as `model[:effort]` (falls back to `--task-model`). Same syntax and wrapper behavior as `--task-model` | empty |
 | `--wait` | Wait duration before retrying on rate limit (e.g., `1h`, `30m`) | disabled |
 | `--session-timeout` | Per-session timeout for claude (e.g., `30m`, `1h`). Kills hanging sessions | disabled |
 | `--idle-timeout` | Kill claude session when no output for specified duration (e.g., `5m`). Resets on each output line | disabled |
@@ -805,8 +805,8 @@ Use `--config-dir` or `RALPHEX_CONFIG_DIR` to override the global config locatio
 |--------|-------------|---------|
 | `claude_command` | Claude CLI command | `claude` |
 | `claude_args` | Claude CLI arguments | `--dangerously-skip-permissions --output-format stream-json --verbose` |
-| `task_model` | Model for task execution (e.g., `opus`, `sonnet`). Appended as `--model <value>` to `claude_command`; custom wrappers may ignore or implement it | empty |
-| `review_model` | Model for review phases. Falls back to `task_model` if empty. Same wrapper behavior as `task_model` | empty |
+| `task_model` | Model for task execution as `model[:effort]` (e.g., `opus`, `opus:high`, `:medium`). Effort: `low`, `medium`, `high`, `xhigh`, `max`. Appended as `--model <m>` and/or `--effort <e>` to `claude_command`; custom wrappers may ignore or implement the flags | empty |
+| `review_model` | Model for review phases as `model[:effort]`. Falls back to `task_model` if empty. Same syntax and wrapper behavior as `task_model` | empty |
 | `codex_enabled` | Enable codex review phase | `true` |
 | `codex_command` | Codex CLI command | `codex` |
 | `codex_model` | Codex model ID | `gpt-5.4` |

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -34,8 +34,8 @@ type opts struct {
 	MaxIterations         int           `short:"m" long:"max-iterations" description:"maximum task iterations (default: 50)"`
 	MaxExternalIterations int           `long:"max-external-iterations" default:"0" description:"override external review iteration limit (0 = auto)"`
 	ReviewPatience        int           `long:"review-patience" default:"0" description:"terminate external review after N unchanged rounds (0 = disabled)"`
-	TaskModel             string        `long:"task-model" description:"model for task execution (e.g., opus, sonnet, haiku)"`
-	ReviewModel           string        `long:"review-model" description:"model for review phases (falls back to --task-model)"`
+	TaskModel             string        `long:"task-model" description:"model for task execution as model[:effort] (e.g., opus, opus:high, :medium)"`
+	ReviewModel           string        `long:"review-model" description:"model for review phases as model[:effort] (falls back to --task-model)"`
 	Review                bool          `short:"r" long:"review" description:"skip task execution, run full review pipeline"`
 	ExternalOnly          bool          `short:"e" long:"external-only" description:"skip tasks and first review, run only external review loop"`
 	CodexOnly             bool          `short:"c" long:"codex-only" description:"alias for --external-only (deprecated)"`

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -24,8 +24,10 @@ ralphex prompts instruct the agent to emit signals like `<<<RALPHEX:COMPLETED>>>
 `ClaudeExecutor` builds the command as:
 
 ```
-<claude_command> <claude_args...> [--model <model>] --print
+<claude_command> <claude_args...> [--model <model>] [--effort <level>] --print
 ```
+
+`--model` and `--effort` are injected when `task_model`/`review_model` config provides them (via `model[:effort]` syntax). Either, both, or neither may be present. Any matching flag already in `claude_args` is stripped before injection to avoid duplicates. Wrappers that don't implement these flags will ignore them via the catch-all `*) shift ;;` pattern.
 
 The prompt is passed via stdin (not as a CLI argument). This avoids the cmd.exe 8191-character command-line limit on Windows, where large prompts (e.g., after variable expansion) can exceed the limit.
 

--- a/llms.txt
+++ b/llms.txt
@@ -114,12 +114,12 @@ Configuration directory: `~/.config/ralphex/` (override with `--config-dir` or `
 
 **Stalemate detection:** `review_patience` config option (or `--review-patience` CLI flag) terminates the external review loop early when Claude produces no commits for N consecutive rounds. Set to 0 (default) to disable. Useful when the external tool and Claude can't agree on findings.
 
-**Per-phase model configuration:** `task_model` config option (or `--task-model` CLI flag) sets the model for task execution (e.g., `opus`, `sonnet`, `haiku`). `review_model` (or `--review-model`) sets the model for review phases; falls back to `task_model` if empty. When set, `--model <value>` is appended to the configured `claude_command`. Custom wrappers may ignore the flag (default behavior via `*) shift ;;`) or map it to their own model selection. Empty by default (uses Claude CLI's default model).
+**Per-phase model configuration:** `task_model` config option (or `--task-model` CLI flag) sets the model for task execution using `model[:effort]` syntax. Examples: `opus` (model only), `opus:high` (both), `:medium` (effort only). Effort levels: `low`, `medium`, `high`, `xhigh`, `max`. `review_model` (or `--review-model`) sets the model/effort for review phases; falls back to `task_model` if empty. Parts are appended to the configured `claude_command` as `--model <m>` and/or `--effort <e>`. Custom wrappers may ignore the flags (default behavior via `*) shift ;;`) or map them to their own selection. Empty by default (uses Claude CLI's defaults).
 
 ```ini
 # in ~/.config/ralphex/config
-task_model = opus
-review_model = sonnet
+task_model = opus:high
+review_model = sonnet:medium
 ```
 
 **Manual break (Ctrl+\):** Press Ctrl+\ (SIGQUIT) to intervene during execution. In the task phase, it pauses execution and prompts "press Enter to continue, Ctrl+C to abort" — on Enter the same task re-runs with a fresh session that re-reads the plan file, so you can edit the plan mid-run. In the external review phase, it terminates the loop immediately. Not available on Windows.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,8 +44,8 @@ const (
 type Config struct {
 	ClaudeCommand string `json:"claude_command"`
 	ClaudeArgs    string `json:"claude_args"`
-	TaskModel     string `json:"task_model"`   // model for task execution (e.g., "opus", "sonnet")
-	ReviewModel   string `json:"review_model"` // model for review phases (falls back to TaskModel)
+	TaskModel     string `json:"task_model"`   // model[:effort] spec for task execution (e.g., "opus", "opus:high", ":medium")
+	ReviewModel   string `json:"review_model"` // model[:effort] spec for review phases (falls back to TaskModel)
 
 	CodexEnabled         bool   `json:"codex_enabled"`
 	CodexEnabledSet      bool   `json:"-"` // tracks if codex_enabled was explicitly set in config

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -23,13 +23,16 @@ claude_command = claude
 claude_args = --dangerously-skip-permissions --output-format stream-json --verbose
 
 # task_model: model to use for task execution
-# available: opus, sonnet, haiku (or full model IDs like claude-sonnet-4-5-20250929)
-# leave empty to use Claude Code's default model
+# syntax: model[:effort] where model is opus/sonnet/haiku (or a full model ID like
+# claude-sonnet-4-5-20250929) and effort is low/medium/high/xhigh/max.
+# either part is optional: "opus" sets model only, ":high" sets effort only,
+# "opus:high" sets both. leave empty to use Claude CLI's defaults.
 # task_model =
 
 # review_model: model to use for review phases (first review, fix loops, finalize)
-# falls back to task_model if not set, then to Claude Code's default
-# use a cheaper/faster model (e.g., sonnet) for reviews to reduce cost
+# same model[:effort] syntax as task_model.
+# falls back to task_model if not set, then to Claude CLI's defaults.
+# use a cheaper/faster model (e.g., sonnet) or lower effort for reviews to reduce cost.
 # review_model =
 
 # ------------------------------------------------------------------------------

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -215,6 +215,7 @@ type ClaudeExecutor struct {
 	Command       string            // command to execute, defaults to "claude"
 	Args          string            // additional arguments (space-separated), defaults to standard args
 	Model         string            // model override (e.g., "opus", "sonnet", "haiku"); empty = CLI default
+	Effort        string            // reasoning effort override (e.g., "low", "medium", "high", "xhigh", "max"); empty = CLI default
 	OutputHandler func(text string) // called for each text chunk, can be nil
 	Debug         bool              // enable debug output
 	ErrorPatterns []string          // patterns to detect in output (e.g., rate limit messages)
@@ -246,6 +247,12 @@ func (e *ClaudeExecutor) Run(ctx context.Context, prompt string) Result {
 	if e.Model != "" {
 		args = stripFlag(args, "--model")
 		args = append(args, "--model", e.Model)
+	}
+	// inject --effort flag if an effort override is configured;
+	// strip any existing --effort from args to avoid duplicate/conflicting flags
+	if e.Effort != "" {
+		args = stripFlag(args, "--effort")
+		args = append(args, "--effort", e.Effort)
 	}
 	// always append --print to enable non-interactive mode; mirrors old -p flag that was
 	// always appended. wrapper scripts ignore unknown flags via '*) shift ;;' catch-all.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -150,15 +150,17 @@ func splitArgs(s string) []string {
 }
 
 // stripFlag removes all occurrences of a flag and its value from args. Handles three forms:
-// "--flag value" (space-separated, skips next element), "--flag=value" (single token),
-// and a bare "--flag" with no following value. Returns a new slice.
+// "--flag value" (space-separated, skips next element only if it doesn't look like another flag),
+// "--flag=value" (single token), and a bare "--flag" with no following value. Returns a new slice.
+// The "looks like another flag" heuristic (starts with "-") preserves unrelated flags that happen
+// to follow a malformed bare "--flag" in the middle of args.
 func stripFlag(args []string, flag string) []string {
 	prefix := flag + "="
 	result := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		if args[i] == flag {
-			// space form: skip flag and its value (if present)
-			if i+1 < len(args) {
+			// space form: skip the next token only if it's an actual value, not another flag
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				i++
 			}
 			continue

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -472,6 +472,8 @@ func TestStripFlag(t *testing.T) {
 		{name: "removes bare flag at end", args: []string{"--verbose", "--model"}, flag: "--model", want: []string{"--verbose"}},
 		{name: "removes repeated occurrences", args: []string{"--model", "opus", "--verbose", "--model=sonnet"}, flag: "--model", want: []string{"--verbose"}},
 		{name: "does not match prefix-only", args: []string{"--model-foo", "bar", "--print"}, flag: "--model", want: []string{"--model-foo", "bar", "--print"}},
+		{name: "bare flag in middle preserves next flag", args: []string{"--verbose", "--model", "--print"}, flag: "--model", want: []string{"--verbose", "--print"}},
+		{name: "bare flag preserves next flag with dash value", args: []string{"--model", "-x", "--print"}, flag: "--model", want: []string{"-x", "--print"}},
 	}
 
 	for _, tc := range tests {

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -1269,3 +1269,76 @@ func TestClaudeExecutor_Run_ModelFlag(t *testing.T) {
 		assert.Equal(t, 1, count, "should have exactly one --model flag")
 	})
 }
+
+func TestClaudeExecutor_Run_EffortFlag(t *testing.T) {
+	jsonStream := `{"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}`
+
+	// newMock returns a fresh mock whose RunFunc writes captured args into
+	// the provided slot. using a per-subtest slot avoids cross-test leakage.
+	newMock := func(slot *[]string) *mocks.CommandRunnerMock {
+		return &mocks.CommandRunnerMock{
+			RunFunc: func(_ context.Context, _ string, args ...string) (io.Reader, func() error, error) {
+				*slot = args
+				return strings.NewReader(jsonStream), func() error { return nil }, nil
+			},
+		}
+	}
+
+	countFlag := func(args []string, flag string) int {
+		n := 0
+		for _, a := range args {
+			if a == flag {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("effort set injects --effort flag", func(t *testing.T) {
+		var capturedArgs []string
+		e := &ClaudeExecutor{Effort: "high", cmdRunner: newMock(&capturedArgs)}
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
+		assert.Contains(t, capturedArgs, "--effort")
+		assert.Contains(t, capturedArgs, "high")
+	})
+
+	t.Run("effort empty does not inject --effort flag", func(t *testing.T) {
+		var capturedArgs []string
+		e := &ClaudeExecutor{cmdRunner: newMock(&capturedArgs)}
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
+		assert.NotContains(t, capturedArgs, "--effort")
+	})
+
+	t.Run("model and effort together inject both flags", func(t *testing.T) {
+		var capturedArgs []string
+		e := &ClaudeExecutor{Model: "opus", Effort: "medium", cmdRunner: newMock(&capturedArgs)}
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
+		assert.Contains(t, capturedArgs, "--model")
+		assert.Contains(t, capturedArgs, "opus")
+		assert.Contains(t, capturedArgs, "--effort")
+		assert.Contains(t, capturedArgs, "medium")
+	})
+
+	t.Run("effort overrides existing --effort in args", func(t *testing.T) {
+		var capturedArgs []string
+		e := &ClaudeExecutor{Args: "--verbose --effort low --output-format json", Effort: "high", cmdRunner: newMock(&capturedArgs)}
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
+		assert.Contains(t, capturedArgs, "high")
+		assert.NotContains(t, capturedArgs, "low", "old --effort value should be stripped")
+		assert.Equal(t, 1, countFlag(capturedArgs, "--effort"), "should have exactly one --effort flag")
+	})
+
+	t.Run("effort overrides equals form in args", func(t *testing.T) {
+		var capturedArgs []string
+		e := &ClaudeExecutor{Args: "--verbose --effort=low --output-format json", Effort: "high", cmdRunner: newMock(&capturedArgs)}
+		result := e.Run(context.Background(), "test")
+		require.NoError(t, result.Error)
+		assert.Contains(t, capturedArgs, "high")
+		assert.NotContains(t, capturedArgs, "--effort=low", "equals form should be stripped")
+		assert.Equal(t, 1, countFlag(capturedArgs, "--effort"), "should have exactly one --effort flag")
+	})
+}

--- a/pkg/processor/export_test.go
+++ b/pkg/processor/export_test.go
@@ -60,3 +60,14 @@ func (r *Runner) TestSetTaskPhaseOverride(fn func(ctx context.Context) error) {
 func (r *Runner) TestDrainBreakCh() {
 	r.drainBreakCh()
 }
+
+// TestClaudeExecutor returns the task-phase Claude executor for inspection.
+func (r *Runner) TestClaudeExecutor() Executor {
+	return r.claude
+}
+
+// TestReviewClaudeExecutor returns the review-phase Claude executor for inspection.
+// Returns the same value as TestClaudeExecutor when no separate review executor was built.
+func (r *Runner) TestReviewClaudeExecutor() Executor {
+	return r.reviewClaude
+}

--- a/pkg/processor/runner.go
+++ b/pkg/processor/runner.go
@@ -52,8 +52,8 @@ type Config struct {
 	NoColor               bool           // disable color output
 	IterationDelayMs      int            // delay between iterations in milliseconds
 	TaskRetryCount        int            // number of times to retry failed tasks
-	TaskModel             string         // model for task execution (empty = CLI default)
-	ReviewModel           string         // model for review phases (empty = falls back to TaskModel)
+	TaskModel             string         // model[:effort] spec for task execution; parsed via ParseModelEffort (empty = CLI defaults)
+	ReviewModel           string         // model[:effort] spec for review phases; empty falls back to TaskModel
 	CodexEnabled          bool           // whether codex review is enabled
 	FinalizeEnabled       bool           // whether finalize step is enabled
 	DefaultBranch         string         // default branch name (detected from repo)
@@ -139,19 +139,24 @@ func New(cfg Config, log Logger, holder *status.PhaseHolder) *Runner {
 		claudeExec.LimitPatterns = cfg.AppConfig.ClaudeLimitPatterns
 		claudeExec.IdleTimeout = cfg.AppConfig.IdleTimeout
 	}
-	claudeExec.Model = cfg.TaskModel
+	taskModel, taskEffort := ParseModelEffort(cfg.TaskModel)
+	claudeExec.Model, claudeExec.Effort = taskModel, taskEffort
 
-	// build review executor (shares base config, may use a different model)
-	reviewModel := cfg.ReviewModel
-	if reviewModel == "" {
-		reviewModel = cfg.TaskModel // fall back to task model
+	// build review executor (shares base config, may use a different model or effort).
+	// compare parsed tuples rather than raw strings so equivalent specs like "opus" and
+	// "opus:" don't produce a redundant second executor.
+	reviewSpec := cfg.ReviewModel
+	if reviewSpec == "" {
+		reviewSpec = cfg.TaskModel // fall back to task model spec
 	}
+	reviewModel, reviewEffort := ParseModelEffort(reviewSpec)
 	var reviewExec Executor
-	if reviewModel != cfg.TaskModel {
+	if reviewModel != taskModel || reviewEffort != taskEffort {
 		re := &executor.ClaudeExecutor{
 			OutputHandler: claudeExec.OutputHandler,
 			Debug:         cfg.Debug,
 			Model:         reviewModel,
+			Effort:        reviewEffort,
 		}
 		if cfg.AppConfig != nil {
 			re.Command = cfg.AppConfig.ClaudeCommand
@@ -1327,4 +1332,15 @@ func needsCodexBinary(appConfig *config.Config) bool {
 	default:
 		return true // "codex" or empty (default) requires codex binary
 	}
+}
+
+// ParseModelEffort splits a "model[:effort]" spec into separate parts.
+// Used by New to parse task_model/review_model config values into the
+// ClaudeExecutor.Model and ClaudeExecutor.Effort fields.
+// Empty input returns ("", ""). Missing colon returns (s, "").
+// A leading colon (":high") returns ("", "high"); a trailing colon ("opus:") returns ("opus", "").
+// Only the first colon is treated as the separator; anything after is passed through as effort.
+func ParseModelEffort(s string) (model, effort string) {
+	model, effort, _ = strings.Cut(s, ":")
+	return model, effort
 }

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -1672,13 +1672,13 @@ func TestRunner_CodexAndPostReview_PipelineOrder(t *testing.T) {
 			}
 
 			cfg := processor.Config{
-				Mode:            tc.mode,
-				PlanFile:        planFile,
-				MaxIterations:   50,
+				Mode:             tc.mode,
+				PlanFile:         planFile,
+				MaxIterations:    50,
 				IterationDelayMs: 1,
-				CodexEnabled:    true,
-				FinalizeEnabled: true,
-				AppConfig:       testAppConfig(t),
+				CodexEnabled:     true,
+				FinalizeEnabled:  true,
+				AppConfig:        testAppConfig(t),
 			}
 			r := processor.NewWithExecutors(cfg, log, processor.Executors{Claude: claude, Codex: codex}, holder)
 			err := r.Run(t.Context())
@@ -2884,9 +2884,9 @@ func TestRunner_PostCodexReview_SkippedWhenNoFindings(t *testing.T) {
 		log := newMockLogger("progress.txt")
 		// codex finds issue, claude fixes it, then next codex iteration is clean
 		claude := newMockExecutor([]executor.Result{
-			{Output: "fixed the issue"},                        // codex eval iter 1 — fixed
-			{Output: "clean", Signal: status.CodexDone},        // codex eval iter 2 — done
-			{Output: "done", Signal: status.ReviewDone},        // post-codex review loop
+			{Output: "fixed the issue"},                 // codex eval iter 1 — fixed
+			{Output: "clean", Signal: status.CodexDone}, // codex eval iter 2 — done
+			{Output: "done", Signal: status.ReviewDone}, // post-codex review loop
 		})
 		codex := newMockExecutor([]executor.Result{
 			{Output: "found issue in foo.go:10"},
@@ -3867,4 +3867,81 @@ func TestRunner_ReviewClaude_NilFallsBackToTaskExecutor(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Len(t, claude.RunCalls(), 5, "task executor should handle all review phases when ReviewClaude is nil")
+}
+
+func TestParseModelEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		model  string
+		effort string
+	}{
+		{name: "empty", input: "", model: "", effort: ""},
+		{name: "model only", input: "opus", model: "opus", effort: ""},
+		{name: "model and effort", input: "opus:high", model: "opus", effort: "high"},
+		{name: "effort only", input: ":high", model: "", effort: "high"},
+		{name: "trailing colon", input: "opus:", model: "opus", effort: ""},
+		{name: "full model id with effort", input: "claude-sonnet-4-6:medium", model: "claude-sonnet-4-6", effort: "medium"},
+		{name: "multiple colons — split on first", input: "opus:high:extra", model: "opus", effort: "high:extra"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model, effort := processor.ParseModelEffort(tc.input)
+			assert.Equal(t, tc.model, model)
+			assert.Equal(t, tc.effort, effort)
+		})
+	}
+}
+
+func TestRunner_New_ModelEffortWiring(t *testing.T) {
+	log := newMockLogger("progress.txt")
+	holder := &status.PhaseHolder{}
+
+	tests := []struct {
+		name         string
+		taskModel    string
+		reviewModel  string
+		wantTask     [2]string // {model, effort}
+		wantReview   [2]string
+		sameExecutor bool      // true when review falls back to task executor
+	}{
+		{name: "empty specs", taskModel: "", reviewModel: "", wantTask: [2]string{"", ""}, wantReview: [2]string{"", ""}, sameExecutor: true},
+		{name: "task model only, review empty", taskModel: "opus", reviewModel: "", wantTask: [2]string{"opus", ""}, wantReview: [2]string{"opus", ""}, sameExecutor: true},
+		{name: "task model with effort, review empty", taskModel: "opus:high", reviewModel: "", wantTask: [2]string{"opus", "high"}, wantReview: [2]string{"opus", "high"}, sameExecutor: true},
+		{name: "effort only, review empty", taskModel: ":medium", reviewModel: "", wantTask: [2]string{"", "medium"}, wantReview: [2]string{"", "medium"}, sameExecutor: true},
+		{name: "trailing colon equivalent to plain model", taskModel: "opus", reviewModel: "opus:", wantTask: [2]string{"opus", ""}, wantReview: [2]string{"opus", ""}, sameExecutor: true},
+		{name: "same model different effort — separate executor", taskModel: "opus", reviewModel: "opus:high", wantTask: [2]string{"opus", ""}, wantReview: [2]string{"opus", "high"}, sameExecutor: false},
+		{name: "different model and effort — separate executor", taskModel: "opus:high", reviewModel: "sonnet:medium", wantTask: [2]string{"opus", "high"}, wantReview: [2]string{"sonnet", "medium"}, sameExecutor: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := processor.Config{
+				Mode:          processor.ModeReview,
+				MaxIterations: 50,
+				CodexEnabled:  false,
+				TaskModel:     tc.taskModel,
+				ReviewModel:   tc.reviewModel,
+				AppConfig:     testAppConfig(t),
+			}
+			r := processor.New(cfg, log, holder)
+
+			taskExec, ok := r.TestClaudeExecutor().(*executor.ClaudeExecutor)
+			require.True(t, ok, "task executor should be *executor.ClaudeExecutor")
+			assert.Equal(t, tc.wantTask[0], taskExec.Model, "task model")
+			assert.Equal(t, tc.wantTask[1], taskExec.Effort, "task effort")
+
+			reviewExec, ok := r.TestReviewClaudeExecutor().(*executor.ClaudeExecutor)
+			require.True(t, ok, "review executor should be *executor.ClaudeExecutor")
+			assert.Equal(t, tc.wantReview[0], reviewExec.Model, "review model")
+			assert.Equal(t, tc.wantReview[1], reviewExec.Effort, "review effort")
+
+			if tc.sameExecutor {
+				assert.Same(t, taskExec, reviewExec, "review executor should be the same instance as task executor when specs equivalent")
+			} else {
+				assert.NotSame(t, taskExec, reviewExec, "review executor should be a distinct instance when specs differ")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Extends `task_model` / `review_model` (and their CLI flags) to carry Claude's `--effort` level alongside the model, using `model[:effort]` syntax. Single flag, both knobs.

**Examples:**

```ini
task_model = opus:high
review_model = sonnet:medium
```

```bash
ralphex --task-model=opus:high docs/plans/foo.md
ralphex --review-model=:medium  # effort only
```

Effort levels: `low`, `medium`, `high`, `xhigh`, `max`. Either part is optional: `opus`, `opus:high`, `:medium`, `opus:`, all work.

**Changes:**

- `ClaudeExecutor.Effort` field; injects `--effort <val>` alongside existing `--model`, with the same dedupe treatment (handles `--effort=val` and bare `--effort`)
- `ParseModelEffort` helper in pkg/processor (exported for external test package)
- `Runner.New` compares parsed `(model, effort)` tuples when deciding whether to build a separate review executor — so `opus` and `opus:` don't produce redundant executors
- `TestRunner_New_ModelEffortWiring` covers 7 spec combinations, including the same-model-different-effort case (the main feature motivation)
- Docs updated: `docs/custom-providers.md` command template now shows `--effort`; README, CLAUDE.md, llms.txt, config defaults, field godoc all mention the new syntax

Not in a release yet, so no compat shim.