### PR TITLE
fix: preserve progress file on failed run (#288)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ docs/plans/         # plan files location
 - Streaming output with timestamps
 - Progress logging to files
 - Progress file locking (flock) for active session detection
-- Progress file fresh start: completed files (with `Completed:` footer) are truncated on reuse instead of appending
+- Progress file fresh start: files ending in a `Completed:` footer are truncated on reuse; files ending in a `Failed:` footer (written when `Logger.SetFailed` was called before `Close`) or with no footer preserve existing content and write a `--- restarted at ... ---` separator, so retried failed/aborted runs keep history (issue #288). `SetFailed` is called in `cmd/ralphex/main.go` for `r.Run` errors (including `ErrUserAborted`), dashboard start errors, and any error return from `runWithWorktree`
 - Multiple execution modes: full, tasks-only, review-only, external-only/codex-only, plan creation
 - `--base-ref` flag overrides default branch for review diffs (branch name or commit hash)
 - `--skip-finalize` flag disables finalize step for a single run

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -521,8 +521,9 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 		var dashErr error
 		runnerLog, dashErr = dashboard.Start(ctx)
 		if dashErr != nil {
-			plr.baseLog.SetFailed(dashErr)
-			return fmt.Errorf("start dashboard: %w", dashErr)
+			wrapped := fmt.Errorf("start dashboard: %w", dashErr)
+			plr.baseLog.SetFailed(wrapped)
+			return wrapped
 		}
 	}
 
@@ -547,14 +548,17 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 	if runErr := r.Run(ctx); runErr != nil {
 		// mark logger as failed so Close writes "Failed:" footer, preserving history
 		// for restart. Applies to ErrUserAborted too — user aborts are not completions.
-		plr.baseLog.SetFailed(runErr)
+		// abort keeps the raw error in the footer (self-descriptive); real failures
+		// use the wrapped error so the footer matches what the caller sees.
 		if errors.Is(runErr, processor.ErrUserAborted) {
-			// user aborted during task phase — clean exit without success actions
+			plr.baseLog.SetFailed(runErr)
 			fmt.Fprintln(os.Stderr, "aborted by user, plan left in place")
 			return nil
 		}
+		wrapped := fmt.Errorf("runner: %w", runErr)
+		plr.baseLog.SetFailed(wrapped)
 		sendNotification(req, branch, plr.baseLog.Elapsed(), git.DiffStats{}, runErr)
-		return fmt.Errorf("runner: %w", runErr)
+		return wrapped
 	}
 
 	elapsed := plr.baseLog.Elapsed()
@@ -976,8 +980,9 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 
 	// run the plan creation loop
 	if runErr := r.Run(ctx); runErr != nil {
-		planCreationErr = runErr
-		return fmt.Errorf("plan creation: %w", runErr)
+		wrapped := fmt.Errorf("plan creation: %w", runErr)
+		planCreationErr = wrapped
+		return wrapped
 	}
 
 	// find the newly created plan file

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -521,6 +521,7 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 		var dashErr error
 		runnerLog, dashErr = dashboard.Start(ctx)
 		if dashErr != nil {
+			plr.baseLog.SetFailed(dashErr)
 			return fmt.Errorf("start dashboard: %w", dashErr)
 		}
 	}
@@ -544,6 +545,9 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 	}
 
 	if runErr := r.Run(ctx); runErr != nil {
+		// mark logger as failed so Close writes "Failed:" footer, preserving history
+		// for restart. Applies to ErrUserAborted too — user aborts are not completions.
+		plr.baseLog.SetFailed(runErr)
 		if errors.Is(runErr, processor.ErrUserAborted) {
 			// user aborted during task phase — clean exit without success actions
 			fmt.Fprintln(os.Stderr, "aborted by user, plan left in place")
@@ -589,7 +593,7 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 // runWithWorktree creates a worktree, creates the progress logger (before chdir so it lands
 // in the main repo), chdirs into the worktree, and runs executePlan. On return the worktree
 // is cleaned up and CWD is restored. req.WtCleanup is populated for interrupt handler use.
-func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) error {
+func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err error) {
 	wtPath, planNeedsCommit, err := req.GitSvc.CreateWorktreeForPlan(req.PlanFile, req.DefaultBranch)
 	if err != nil {
 		return fmt.Errorf("create worktree: %w", err)
@@ -638,6 +642,11 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) error 
 		return fmt.Errorf("create progress logger: %w", err)
 	}
 	defer func() {
+		// mark failure on any error return so Close writes "Failed:" instead of "Completed:",
+		// preserving progress history across restart (issue #288)
+		if err != nil {
+			baseLog.SetFailed(err)
+		}
 		if closeErr := baseLog.Close(); closeErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to close progress log: %v\n", closeErr)
 		}
@@ -913,7 +922,15 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 	if err != nil {
 		return fmt.Errorf("create progress logger: %w", err)
 	}
+	// planCreationErr is scoped to the plan-creation phase only. If r.Run fails, the
+	// deferred Close writes "Failed:" so restart preserves Q&A history (issue #288).
+	// Follow-on execution errors (executePlan/runWithWorktree below) do not affect
+	// this log since plan creation already succeeded by that point.
+	var planCreationErr error
 	defer func() {
+		if planCreationErr != nil {
+			baseLog.SetFailed(planCreationErr)
+		}
 		if closeErr := baseLog.Close(); closeErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to close progress log: %v\n", closeErr)
 		}
@@ -959,6 +976,7 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 
 	// run the plan creation loop
 	if runErr := r.Run(ctx); runErr != nil {
+		planCreationErr = runErr
 		return fmt.Errorf("plan creation: %w", runErr)
 	}
 

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -3904,7 +3904,7 @@ func TestRunner_New_ModelEffortWiring(t *testing.T) {
 		reviewModel  string
 		wantTask     [2]string // {model, effort}
 		wantReview   [2]string
-		sameExecutor bool      // true when review falls back to task executor
+		sameExecutor bool // true when review falls back to task executor
 	}{
 		{name: "empty specs", taskModel: "", reviewModel: "", wantTask: [2]string{"", ""}, wantReview: [2]string{"", ""}, sameExecutor: true},
 		{name: "task model only, review empty", taskModel: "opus", reviewModel: "", wantTask: [2]string{"opus", ""}, wantReview: [2]string{"opus", ""}, sameExecutor: true},

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -125,6 +125,7 @@ type Logger struct {
 	startTime time.Time
 	holder    *status.PhaseHolder
 	colors    *Colors
+	runErr    error // set via SetFailed to record non-success outcome for the footer
 }
 
 // Config holds logger configuration.
@@ -546,14 +547,30 @@ func (l *Logger) Elapsed() string {
 	return d.Truncate(time.Second).String()
 }
 
+// SetFailed marks the logger as failed with the given reason. On Close, a "Failed:"
+// footer is written instead of "Completed:", so the restart path appends to the file
+// (preserving history) rather than truncating. Safe to call multiple times; the most
+// recent non-nil reason wins. Passing nil clears any previous failure state.
+func (l *Logger) SetFailed(reason error) {
+	l.runErr = reason
+}
+
 // Close writes footer, releases the file lock, and closes the progress file.
+// Writes "Completed:" footer on success, or "Failed: ... - <reason>" if SetFailed
+// was called with a non-nil error.
 func (l *Logger) Close() error {
 	if l.file == nil {
 		return nil
 	}
 
 	l.writeFile("\n%s\n", separatorLine)
-	l.writeFile("Completed: %s (%s)\n", time.Now().Format("2006-01-02 15:04:05"), l.Elapsed())
+	ts := time.Now().Format("2006-01-02 15:04:05")
+	if l.runErr == nil {
+		l.writeFile("Completed: %s (%s)\n", ts, l.Elapsed())
+	} else {
+		reason := sanitizeFailureReason(l.runErr.Error())
+		l.writeFile("Failed: %s (%s) - %s\n", ts, l.Elapsed(), reason)
+	}
 
 	// release file lock before closing
 	_ = unlockFile(l.file)
@@ -563,6 +580,43 @@ func (l *Logger) Close() error {
 		return fmt.Errorf("close progress file: %w", err)
 	}
 	return nil
+}
+
+// maxFailureReasonRunes caps the failure reason written into the footer.
+// Rune-based cap avoids splitting multibyte sequences at the boundary.
+const maxFailureReasonRunes = 200
+
+// sanitizeFailureReason prepares an error string for single-line footer output.
+// Replaces any control character (including CR/LF/tab) with a single space,
+// collapses consecutive whitespace, and rune-aware truncates to maxFailureReasonRunes.
+// Critical for isProgressCompleted integrity: the reason must not contain
+// "\n<separatorLine>\nCompleted:" which would false-positive the tail scan.
+func sanitizeFailureReason(s string) string {
+	if s == "" {
+		return "unknown error"
+	}
+	// replace control chars with spaces
+	b := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			b = append(b, ' ')
+			continue
+		}
+		b = append(b, r)
+	}
+	// collapse whitespace runs and truncate by rune count
+	out := strings.Join(strings.Fields(string(b)), " ")
+	runes := []rune(out)
+	if len(runes) > maxFailureReasonRunes {
+		runes = runes[:maxFailureReasonRunes]
+		out = string(runes) + "..."
+	} else {
+		out = string(runes)
+	}
+	if out == "" {
+		return "unknown error"
+	}
+	return out
 }
 
 func (l *Logger) writeFile(format string, args ...any) {

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -138,9 +138,10 @@ type Config struct {
 }
 
 // NewLogger creates a logger writing to both a progress file and stdout.
-// if the progress file already exists with a completion footer, it is truncated
-// and a fresh header is written. if the file exists without a completion footer
-// (interrupted run), existing log is preserved and a restart separator is written.
+// if the progress file already ends with a "Completed:" footer (successful run),
+// it is truncated and a fresh header is written. if the file ended with a "Failed:"
+// footer or has no footer (interrupted/failed run), the existing log is preserved
+// and a restart separator is written so history carries across retries (issue #288).
 // colors must be provided (created via NewColors from config).
 // holder is the shared PhaseHolder for reading the current execution phase.
 func NewLogger(cfg Config, colors *Colors, holder *status.PhaseHolder) (*Logger, error) {
@@ -550,7 +551,7 @@ func (l *Logger) Elapsed() string {
 // SetFailed marks the logger as failed with the given reason. On Close, a "Failed:"
 // footer is written instead of "Completed:", so the restart path appends to the file
 // (preserving history) rather than truncating. Safe to call multiple times; the most
-// recent non-nil reason wins. Passing nil clears any previous failure state.
+// recent call wins (passing nil clears any previous failure state).
 func (l *Logger) SetFailed(reason error) {
 	l.runErr = reason
 }
@@ -592,26 +593,15 @@ const maxFailureReasonRunes = 200
 // Critical for isProgressCompleted integrity: the reason must not contain
 // "\n<separatorLine>\nCompleted:" which would false-positive the tail scan.
 func sanitizeFailureReason(s string) string {
-	if s == "" {
-		return "unknown error"
-	}
-	// replace control chars with spaces
-	b := make([]rune, 0, len(s))
-	for _, r := range s {
+	mapped := strings.Map(func(r rune) rune {
 		if r < 0x20 || r == 0x7f {
-			b = append(b, ' ')
-			continue
+			return ' '
 		}
-		b = append(b, r)
-	}
-	// collapse whitespace runs and truncate by rune count
-	out := strings.Join(strings.Fields(string(b)), " ")
-	runes := []rune(out)
-	if len(runes) > maxFailureReasonRunes {
-		runes = runes[:maxFailureReasonRunes]
-		out = string(runes) + "..."
-	} else {
-		out = string(runes)
+		return r
+	}, s)
+	out := strings.Join(strings.Fields(mapped), " ")
+	if runes := []rune(out); len(runes) > maxFailureReasonRunes {
+		out = string(runes[:maxFailureReasonRunes]) + "..."
 	}
 	if out == "" {
 		return "unknown error"
@@ -629,9 +619,11 @@ func (l *Logger) writeStdout(format string, args ...any) {
 	fmt.Fprintf(l.stdout, format, args...)
 }
 
-// isProgressCompleted checks if a progress file has a completion footer written by Close().
+// isProgressCompleted reports whether the progress file ends with a successful "Completed:"
+// footer written by Close(). "Failed:" footers are intentionally excluded so failed/aborted
+// runs preserve history on restart (issue #288).
 // reads the last ~256 bytes from the provided file descriptor and checks for the dash separator
-// followed by "Completed:" — the exact pattern Close() writes.
+// followed by "Completed:" — the exact pattern Close() writes on success.
 // uses the already-locked fd to avoid TOCTOU path-vs-inode mismatch.
 // returns false for zero-size files or read errors.
 func isProgressCompleted(f *os.File, size int64) bool {

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/fatih/color"
 	"golang.org/x/term"
@@ -588,13 +589,15 @@ func (l *Logger) Close() error {
 const maxFailureReasonRunes = 200
 
 // sanitizeFailureReason prepares an error string for single-line footer output.
-// Replaces any control character (including CR/LF/tab) with a single space,
-// collapses consecutive whitespace, and rune-aware truncates to maxFailureReasonRunes.
-// Critical for isProgressCompleted integrity: the reason must not contain
-// "\n<separatorLine>\nCompleted:" which would false-positive the tail scan.
+// Replaces Unicode control chars (unicode.IsControl, covers ASCII C0 + C1 ranges)
+// and line/paragraph separators (U+2028, U+2029) with a single space, collapses
+// consecutive whitespace via strings.Fields, and rune-aware truncates to
+// maxFailureReasonRunes. Critical for isProgressCompleted integrity: the reason
+// must not contain "\n<separatorLine>\nCompleted:" which would false-positive
+// the tail scan.
 func sanitizeFailureReason(s string) string {
 	mapped := strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
+		if unicode.IsControl(r) || r == '\u2028' || r == '\u2029' {
 			return ' '
 		}
 		return r

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -546,8 +546,8 @@ func TestLogger_SetFailed_TruncatesLongReason(t *testing.T) {
 	l, err := NewLogger(Config{Mode: "full", Branch: "test"}, testColors(), &status.PhaseHolder{})
 	require.NoError(t, err)
 
-	// 1000-char reason with multibyte runes at the truncation boundary
-	longReason := strings.Repeat("x", 500) + strings.Repeat("й", 500) // cyrillic, 2 bytes each
+	// pure multibyte payload so truncation at maxFailureReasonRunes lands inside a cyrillic run
+	longReason := strings.Repeat("й", maxFailureReasonRunes*2) // cyrillic, 2 bytes each
 	l.SetFailed(errors.New(longReason))
 	require.NoError(t, l.Close())
 
@@ -555,7 +555,6 @@ func TestLogger_SetFailed_TruncatesLongReason(t *testing.T) {
 	require.NoError(t, err)
 	s := string(content)
 
-	// footer line with reason must not exceed reasonable length
 	lines := strings.Split(s, "\n")
 	var footerLine string
 	for _, line := range lines {
@@ -565,9 +564,18 @@ func TestLogger_SetFailed_TruncatesLongReason(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, footerLine)
-	assert.LessOrEqual(t, len(footerLine), 400, "failed footer should truncate long reasons")
 	// truncated output must still be valid utf-8
 	assert.True(t, utf8.ValidString(footerLine), "truncated reason must not split a multibyte rune")
+	// reason is rune-capped at maxFailureReasonRunes + "..." suffix
+	reason := footerLine[strings.LastIndex(footerLine, " - ")+3:]
+	assert.True(t, strings.HasSuffix(reason, "..."), "long reason must be truncated with ellipsis")
+	assert.Equal(t, maxFailureReasonRunes, utf8.RuneCountInString(strings.TrimSuffix(reason, "...")))
+}
+
+func TestSanitizeFailureReason_OnlyControlChars(t *testing.T) {
+	// input composed purely of control characters collapses to empty, must fall back to "unknown error"
+	assert.Equal(t, "unknown error", sanitizeFailureReason("\x01\x02\x03\t\r\n"))
+	assert.Equal(t, "unknown error", sanitizeFailureReason(""))
 }
 
 func TestLogger_LogDiffStats(t *testing.T) {

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -2,11 +2,13 @@ package progress
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
@@ -462,6 +464,112 @@ func TestLogger_Close(t *testing.T) {
 	assert.Contains(t, string(content), strings.Repeat("-", 60))
 }
 
+func TestLogger_Close_AfterSetFailed_WritesFailedFooter(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	l, err := NewLogger(Config{Mode: "full", Branch: "test"}, testColors(), &status.PhaseHolder{})
+	require.NoError(t, err)
+
+	l.Print("some output")
+	l.SetFailed(errors.New("Not logged in · Please run /login"))
+	require.NoError(t, l.Close())
+
+	content, err := os.ReadFile(l.Path())
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "Failed:")
+	assert.Contains(t, s, "Not logged in")
+	assert.NotContains(t, s, "Completed:")
+	assert.Contains(t, s, strings.Repeat("-", 60))
+}
+
+func TestLogger_Close_WithoutSetFailed_WritesCompleted(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	l, err := NewLogger(Config{Mode: "full", Branch: "test"}, testColors(), &status.PhaseHolder{})
+	require.NoError(t, err)
+	l.Print("ok")
+	require.NoError(t, l.Close())
+
+	content, err := os.ReadFile(l.Path())
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "Completed:")
+	assert.NotContains(t, s, "Failed:")
+}
+
+func TestLogger_SetFailed_SanitizesReason(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	l, err := NewLogger(Config{Mode: "full", Branch: "test"}, testColors(), &status.PhaseHolder{})
+	require.NoError(t, err)
+
+	// craft a reason that embeds the exact completion pattern — attack vector for isProgressCompleted
+	sep := strings.Repeat("-", 60)
+	payload := "git output:\n" + sep + "\nCompleted: fake completion from external tool stderr"
+	l.SetFailed(errors.New(payload))
+	require.NoError(t, l.Close())
+
+	path := l.Path()
+	content, err := os.ReadFile(path) //nolint:gosec // test path from t.TempDir
+	require.NoError(t, err)
+	s := string(content)
+
+	// sanitized reason should not contain CR/LF, so the embedded pattern is neutralized
+	assert.NotContains(t, s, sep+"\nCompleted:", "sanitization must strip newlines from failure reason")
+	assert.Contains(t, s, "Failed:")
+
+	// verify detection still returns false — the whole point of sanitization
+	f, err := os.Open(path) //nolint:gosec // test path from t.TempDir
+	require.NoError(t, err)
+	defer f.Close()
+	fi, err := f.Stat()
+	require.NoError(t, err)
+	assert.False(t, isProgressCompleted(f, fi.Size()))
+}
+
+func TestLogger_SetFailed_TruncatesLongReason(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	l, err := NewLogger(Config{Mode: "full", Branch: "test"}, testColors(), &status.PhaseHolder{})
+	require.NoError(t, err)
+
+	// 1000-char reason with multibyte runes at the truncation boundary
+	longReason := strings.Repeat("x", 500) + strings.Repeat("й", 500) // cyrillic, 2 bytes each
+	l.SetFailed(errors.New(longReason))
+	require.NoError(t, l.Close())
+
+	content, err := os.ReadFile(l.Path())
+	require.NoError(t, err)
+	s := string(content)
+
+	// footer line with reason must not exceed reasonable length
+	lines := strings.Split(s, "\n")
+	var footerLine string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Failed:") {
+			footerLine = line
+			break
+		}
+	}
+	require.NotEmpty(t, footerLine)
+	assert.LessOrEqual(t, len(footerLine), 400, "failed footer should truncate long reasons")
+	// truncated output must still be valid utf-8
+	assert.True(t, utf8.ValidString(footerLine), "truncated reason must not split a multibyte rune")
+}
+
 func TestLogger_LogDiffStats(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
@@ -512,6 +620,7 @@ func TestIsProgressCompleted(t *testing.T) {
 		{"completed without dash separator", "log line\nCompleted: now\n", false},
 		{"completed in log output", "[ts] task said: Completed: the migration\nmore work\n", false},
 		{"no completed substring", "some text without the keyword", false},
+		{"file with Failed footer", "some content\n" + sep + "\nFailed: 2026-01-15 10:30:00 (5m30s) - Not logged in\n", false},
 	}
 
 	for _, tc := range tests {
@@ -578,6 +687,50 @@ func TestNewLogger_FreshStartAfterCompleted(t *testing.T) {
 
 	// new content present
 	assert.Contains(t, contentStr, "second session output")
+}
+
+func TestNewLogger_RestartAfterFailure_PreservesContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	colors := testColors()
+	// plan mode — deterministic filename from plan description, the scenario from issue #288
+	cfg := Config{PlanDescription: "add user auth", Mode: "plan", Branch: "main"}
+	holder := &status.PhaseHolder{}
+
+	// first run fails mid-way
+	l1, err := NewLogger(cfg, colors, holder)
+	require.NoError(t, err)
+	l1.Print("iteration 1 output")
+	l1.Print("iteration 2 Q&A")
+	l1.SetFailed(errors.New("auth error"))
+	progressPath := l1.Path()
+	require.NoError(t, l1.Close())
+
+	// second run with same config — should NOT truncate, should append restart separator
+	l2, err := NewLogger(cfg, colors, holder)
+	require.NoError(t, err)
+	assert.Equal(t, progressPath, l2.Path())
+	l2.Print("iteration 3 after restart")
+	require.NoError(t, l2.Close())
+
+	content, err := os.ReadFile(l2.Path())
+	require.NoError(t, err)
+	s := string(content)
+
+	// previous iterations preserved
+	assert.Contains(t, s, "iteration 1 output")
+	assert.Contains(t, s, "iteration 2 Q&A")
+	// failed footer from first run preserved
+	assert.Contains(t, s, "Failed:")
+	// restart separator present
+	assert.Contains(t, s, "--- restarted at")
+	// new content appended
+	assert.Contains(t, s, "iteration 3 after restart")
+	// exactly one header (not rewritten)
+	assert.Equal(t, 1, strings.Count(s, "# Ralphex Progress Log"))
 }
 
 func TestGetProgressFilename(t *testing.T) {

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -537,6 +537,44 @@ func TestLogger_SetFailed_SanitizesReason(t *testing.T) {
 	assert.False(t, isProgressCompleted(f, fi.Size()))
 }
 
+func TestLogger_SetFailed_SanitizesUnicodeControlChars(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	l, err := NewLogger(Config{Mode: "full", Branch: "test"}, testColors(), &status.PhaseHolder{})
+	require.NoError(t, err)
+
+	// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are Unicode control chars
+	// classified by unicode.IsControl; they must be neutralized in the footer just like
+	// ASCII CR/LF, so the footer stays a single printable line.
+	payload := "before\u2028middle\u2029after\u0085bell"
+	l.SetFailed(errors.New(payload))
+	require.NoError(t, l.Close())
+
+	content, err := os.ReadFile(l.Path())
+	require.NoError(t, err)
+	s := string(content)
+
+	for _, r := range []rune{'\u2028', '\u2029', '\u0085'} {
+		assert.NotContains(t, s, string(r), "unicode control char %U must be sanitized", r)
+	}
+	// find the footer line and verify everything got joined into one line
+	var footer string
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.HasPrefix(line, "Failed:") {
+			footer = line
+			break
+		}
+	}
+	require.NotEmpty(t, footer)
+	assert.Contains(t, footer, "before")
+	assert.Contains(t, footer, "middle")
+	assert.Contains(t, footer, "after")
+	assert.Contains(t, footer, "bell")
+}
+
 func TestLogger_SetFailed_TruncatesLongReason(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()


### PR DESCRIPTION
Fixes #288.

**Problem**

`Close()` on the progress logger wrote a `Completed:` footer on every exit, regardless of whether the run actually succeeded. On restart with the same plan description, `isProgressCompleted` matched the footer and truncated the file, wiping Q&A history that plan mode relies on to resume.

**Fix**

Adds `Logger.SetFailed(err)`. When set, `Close()` writes `Failed: ts (elapsed) - <reason>` instead of `Completed:`. Detection logic stays unchanged (matches only `Completed:`), so failed files take the existing append-on-restart path and history is preserved.

Wired up at all executor sites:
- `executePlan` — calls `SetFailed(runErr)` before the `ErrUserAborted` check, so user aborts are treated as non-completions too
- `executePlan` dashboard-start failure path
- `runWithWorktree` — named-return defer catches any error path
- `runPlanMode` — scoped `planCreationErr` so that failures in the follow-on execution phase don't retroactively mark the plan-creation log failed

`sanitizeFailureReason` strips control chars and rune-aware truncates to 200 runes. Defends against an attack vector where an embedded `\n<separator>\nCompleted:` in external tool stderr (e.g. `git` CombinedOutput) could false-positive the 256-byte tail scan.

**TDD**

Wrote failing tests first (`TestNewLogger_RestartAfterFailure_PreservesContent` reproduces the exact bug #288 scenario — content wiped after simulated failed run). After implementation, the same test asserts content preserved, Failed footer present, restart separator written. Sanitization test uses a crafted error string containing the full `\n---\nCompleted:` pattern to verify `isProgressCompleted` still returns false.
