### PR TITLE
fix: also pass TZ env var in docker wrapper for Go timezone

### DIFF
--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -878,9 +878,13 @@ def schedule_cleanup(creds_temp: Optional[Path]) -> None:
 
 def build_base_env_vars() -> list[str]:
     """build base docker environment variable flags shared by all docker commands."""
+    tz = detect_timezone()
+    # TIME_ZONE configures baseimage's /etc/localtime; TZ is what Go's time
+    # package reads for time.Local, so both must be set for consistent timestamps.
     return [
         "-e", f"APP_UID={os.getuid()}",
-        "-e", f"TIME_ZONE={detect_timezone()}",
+        "-e", f"TIME_ZONE={tz}",
+        "-e", f"TZ={tz}",
         "-e", "SKIP_HOME_CHOWN=1",
         "-e", "INIT_QUIET=1",
         "-e", "CLAUDE_CONFIG_DIR=/home/app/.claude",

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -298,16 +298,16 @@ class TestDetectTimezone(unittest.TestCase):
                 os.environ["TZ"] = old
 
     def test_timezone_in_docker_cmd(self) -> None:
-        """verify TIME_ZONE env var is included in base env vars."""
+        """verify both TIME_ZONE (baseimage) and TZ (Go runtime) env vars are set."""
         old = os.environ.get("TZ")
         try:
             os.environ["TZ"] = "Asia/Tokyo"
             env_vars = build_base_env_vars()
-            # find TIME_ZONE value in the flat list (format: ["-e", "KEY=val", ...])
-            tz_values = [env_vars[i] for i in range(len(env_vars))
-                         if env_vars[i].startswith("TIME_ZONE=")]
-            self.assertTrue(len(tz_values) > 0, "TIME_ZONE not found in base env vars")
-            self.assertEqual(tz_values[0], "TIME_ZONE=Asia/Tokyo")
+            # find matching values in the flat list (format: ["-e", "KEY=val", ...])
+            time_zone_values = [e for e in env_vars if e.startswith("TIME_ZONE=")]
+            tz_values = [e for e in env_vars if e.startswith("TZ=")]
+            self.assertEqual(time_zone_values, ["TIME_ZONE=Asia/Tokyo"])
+            self.assertEqual(tz_values, ["TZ=Asia/Tokyo"])
         finally:
             if old is None:
                 os.environ.pop("TZ", None)


### PR DESCRIPTION
Follow-up to #153. That fix detected the host timezone and forwarded it to the container as `TIME_ZONE`, but Go's `time.Now()` reads the standard `TZ` env var, not `TIME_ZONE`, so progress-log timestamps still rendered UTC inside the container.

`build_base_env_vars()` now sets both: `TIME_ZONE` (consumed by baseimage to configure `/etc/localtime`) and `TZ` (consumed by Go's `time.Local`). Both come from the same `detect_timezone()` result so they can't drift.

Closes #295
