### PR TITLE
feat(ralphex-dk): add --image and --port CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ Then use `ralphex` as usual - it runs in a container with Claude Code and Codex 
 - Git config in `~/.gitconfig` (for commits)
 
 **Environment variables:**
-- `RALPHEX_IMAGE` - Docker image to use (default: `ghcr.io/umputun/ralphex-go:latest`)
-- `RALPHEX_PORT` - Port for web dashboard when using `--serve` (default: `8080`)
+- `RALPHEX_IMAGE` - Docker image to use (default: `ghcr.io/umputun/ralphex-go:latest`). CLI flag: `--image`
+- `RALPHEX_PORT` - Port for web dashboard when using `--serve` (default: `8080`). CLI flag: `--port`
 - `RALPHEX_CONFIG_DIR` - Custom config directory (default: `~/.config/ralphex`). Overrides global config location for prompts, agents, and settings
 - `CLAUDE_CONFIG_DIR` - Claude config directory (default: `~/.claude`). Use for alternate Claude installations (e.g., `~/.claude2`). Works both with Docker wrapper (volume mounts and keychain derivation) and non-Docker usage (passed through to Claude Code directly). Keychain service name is derived automatically from the path.
 - `RALPHEX_EXTRA_VOLUMES` - Extra volume mounts, comma-separated (e.g., `/data:/mnt/data:ro,/models:/mnt/models`). Entries without `:` are silently skipped

--- a/llms.txt
+++ b/llms.txt
@@ -169,8 +169,8 @@ ralphex --dry-run docs/plans/feature.md
 ```
 
 **Environment variables:**
-- `RALPHEX_IMAGE` - Docker image (default: `ghcr.io/umputun/ralphex-go:latest`)
-- `RALPHEX_PORT` - Web dashboard port with `--serve` (default: `8080`)
+- `RALPHEX_IMAGE` - Docker image (default: `ghcr.io/umputun/ralphex-go:latest`). CLI flag: `--image`
+- `RALPHEX_PORT` - Web dashboard port with `--serve` (default: `8080`). CLI flag: `--port`
 - `RALPHEX_CONFIG_DIR` - Custom config directory (default: `~/.config/ralphex`). Overrides global config location for prompts, agents, and settings
 - `CLAUDE_CONFIG_DIR` - Claude config directory (default: `~/.claude`). Use for alternate Claude installations (e.g., `~/.claude2`). Works with both Docker wrapper and non-Docker usage.
 - `RALPHEX_EXTRA_VOLUMES` - Extra volume mounts, comma-separated (e.g., `/data:/mnt/data:ro,/models:/mnt/models`)

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -7,7 +7,10 @@ Usage: ralphex-dk.sh [wrapper-flags] [ralphex-args]
 Wrapper-specific flags (parsed by this script):
   -E, --env VAR[=val]        extra env var to pass to container (repeatable)
   -v, --volume src:dst[:opts] extra volume mount (repeatable)
+  --image IMAGE              Docker image (env: RALPHEX_IMAGE)
+  --port PORT                web dashboard port with --serve (env: RALPHEX_PORT)
   --docker                   mount host Docker socket into container
+  --network MODE             Docker network mode, e.g. 'host'
   --dry-run                  print docker command without executing
   --update                   pull latest Docker image and exit
   --update-script            update this wrapper script and exit
@@ -137,6 +140,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help="mount host Docker socket into container (env: RALPHEX_DOCKER_SOCKET)")
     parser.add_argument("--network", dest="network", metavar="MODE",
                         help="Docker network mode, e.g. 'host' (env: RALPHEX_DOCKER_NETWORK)")
+    parser.add_argument("--image", dest="image", metavar="IMAGE",
+                        help=f"Docker image (default: {DEFAULT_IMAGE}) (env: RALPHEX_IMAGE)")
+    parser.add_argument("--port", dest="port", metavar="PORT",
+                        help=f"web dashboard port with --serve (default: {DEFAULT_PORT}) (env: RALPHEX_PORT)")
     parser.add_argument("--dry-run", action="store_true", dest="dry_run",
                         help="print docker command that would be run, without executing")
     return parser
@@ -1001,8 +1008,8 @@ def main() -> int:
         run_tests()
         return 0
 
-    image = os.environ.get("RALPHEX_IMAGE", DEFAULT_IMAGE)
-    port = os.environ.get("RALPHEX_PORT", DEFAULT_PORT)
+    image = parsed.image or os.environ.get("RALPHEX_IMAGE", DEFAULT_IMAGE)
+    port = parsed.port or os.environ.get("RALPHEX_PORT", DEFAULT_PORT)
     network = parsed.network or os.environ.get("RALPHEX_DOCKER_NETWORK", "")
 
     # handle --update

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -930,6 +930,32 @@ class TestBuildParser(unittest.TestCase):
         self.assertFalse(args.update_script)
         self.assertEqual(unknown, ["--up"])
 
+    def test_image_flag(self) -> None:
+        """--image flag is parsed correctly."""
+        parser = build_parser()
+        args, unknown = parser.parse_known_args(["--image", "my/img:tag"])
+        self.assertEqual(args.image, "my/img:tag")
+        self.assertEqual(unknown, [])
+
+    def test_image_flag_default_none(self) -> None:
+        """--image default is None (so env/default fallback can apply)."""
+        parser = build_parser()
+        args, _ = parser.parse_known_args([])
+        self.assertIsNone(args.image)
+
+    def test_port_flag(self) -> None:
+        """--port flag is parsed correctly."""
+        parser = build_parser()
+        args, unknown = parser.parse_known_args(["--port", "9090"])
+        self.assertEqual(args.port, "9090")
+        self.assertEqual(unknown, [])
+
+    def test_port_flag_default_none(self) -> None:
+        """--port default is None (so env/default fallback can apply)."""
+        parser = build_parser()
+        args, _ = parser.parse_known_args([])
+        self.assertIsNone(args.port)
+
 class TestMainArgparse(EnvTestCase):
     """tests for main() argparse integration."""
     env_vars = ["RALPHEX_IMAGE", "RALPHEX_PORT", "RALPHEX_EXTRA_ENV",
@@ -1174,6 +1200,65 @@ class TestMainArgparse(EnvTestCase):
             self.assertIn("=invalid", warning)
         finally:
             shutil.rmtree(tmp)
+
+    def _run_main_capturing_image_port(self, argv: list[str]) -> tuple[str, str]:
+        """run main() with claude dir set up and capture resolved image/port."""
+        tmp = Path(tempfile.mkdtemp())
+        try:
+            claude_dir = tmp / ".claude"
+            claude_dir.mkdir()
+            (claude_dir / ".credentials.json").write_text("{}")
+            os.environ["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+
+            captured: dict[str, str] = {}
+
+            def fake_run_docker(image: str, port: str, volumes: list[str],
+                                env_vars: list[str], bind_port: bool, args: list[str],
+                                docker_gid: int | None = None, **kwargs: object) -> int:
+                captured["image"] = image
+                captured["port"] = port
+                return 0
+
+            with unittest.mock.patch("ralphex_dk.run_docker", side_effect=fake_run_docker):
+                with unittest.mock.patch("ralphex_dk.extract_macos_credentials", return_value=None):
+                    sys.argv = argv
+                    result = main()
+            self.assertEqual(result, 0)
+            return captured["image"], captured["port"]
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_image_port_defaults(self) -> None:
+        """without flag or env, image and port fall back to defaults."""
+        image, port = self._run_main_capturing_image_port(["ralphex-dk", "plan.md"])
+        self.assertEqual(image, DEFAULT_IMAGE)
+        self.assertEqual(port, DEFAULT_PORT)
+
+    def test_image_port_from_env(self) -> None:
+        """env vars provide image and port when CLI flags absent."""
+        os.environ["RALPHEX_IMAGE"] = "env-image:tag"
+        os.environ["RALPHEX_PORT"] = "7070"
+        image, port = self._run_main_capturing_image_port(["ralphex-dk", "plan.md"])
+        self.assertEqual(image, "env-image:tag")
+        self.assertEqual(port, "7070")
+
+    def test_image_port_cli_flags(self) -> None:
+        """CLI flags set image and port."""
+        image, port = self._run_main_capturing_image_port(
+            ["ralphex-dk", "--image", "cli-image:tag", "--port", "9090", "plan.md"],
+        )
+        self.assertEqual(image, "cli-image:tag")
+        self.assertEqual(port, "9090")
+
+    def test_image_port_cli_overrides_env(self) -> None:
+        """CLI flags take precedence over env vars."""
+        os.environ["RALPHEX_IMAGE"] = "env-image:tag"
+        os.environ["RALPHEX_PORT"] = "7070"
+        image, port = self._run_main_capturing_image_port(
+            ["ralphex-dk", "--image", "cli-image:tag", "--port", "9090", "plan.md"],
+        )
+        self.assertEqual(image, "cli-image:tag")
+        self.assertEqual(port, "9090")
 
 class TestHelpFlag(EnvTestCase):
     """tests for --help flag handling."""


### PR DESCRIPTION
Mirror the existing `RALPHEX_IMAGE` and `RALPHEX_PORT` env vars with CLI flags, consistent with how `--docker`, `--network`, and `--claude-provider` expose their env-backed settings. CLI flags take precedence over env vars when both are set.

Related to #298