### PR TITLE
fix(prompts): keep task section headers in English for localized plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ docs/plans/         # plan files location
 
 ## Key Patterns
 
-- Plan format: Checkboxes (`- [ ]` / `- [x]`) belong only in Task sections (`### Task N:` or `### Iteration N:`). Success criteria, Overview, and Context should not use checkboxes — they cause extra loop iterations. The task prompt handles them when present, but plan authors should avoid them.
+- Plan format: Checkboxes (`- [ ]` / `- [x]`) belong only in Task sections (`### Task N:` or `### Iteration N:`). The `Task` / `Iteration` keywords are structural tokens matched by `pkg/plan/parse.go` (`taskHeaderPattern`) and MUST stay in English even when plan content is written in another language — task titles and body text may be localized, but the section header keyword is fixed. Success criteria, Overview, and Context should not use checkboxes — they cause extra loop iterations. The task prompt handles them when present, but plan authors should avoid them.
 - Signal-based completion detection (COMPLETED, FAILED, REVIEW_DONE signals) — constants in `pkg/status/`
 - Plan creation signals: QUESTION (with JSON payload) and PLAN_READY
 - Streaming output with timestamps

--- a/pkg/config/defaults/prompts/make_plan.txt
+++ b/pkg/config/defaults/prompts/make_plan.txt
@@ -193,6 +193,7 @@ CRITICAL RULES:
 - DO NOT wait for user approval - ralphex handles confirmation externally
 - DO NOT use natural language questions - only use <<<RALPHEX:QUESTION>>> signal format
 - DO NOT iterate or refine the plan after validation passes
+- DO NOT translate the `### Task N:` and `### Iteration N:` section headers. These are structural tokens required by ralphex's parser and MUST use those exact English keywords even when the plan content is written in another language (Russian, Chinese, Spanish, etc.). Task titles and body text may be in the requested language; only the `Task` / `Iteration` keyword and the numbered format are fixed.
 - The PLAN_READY signal means "plan is complete, session is done"
 
 OUTPUT FORMAT: No markdown formatting in your response text (no **bold**, `code`, # headers). Plain text and - lists are fine. The plan FILE should use markdown.


### PR DESCRIPTION
When `ralphex --plan` generated a plan in a non-English language, the generator also translated the `### Task N:` / `### Iteration N:` section headers, and the parser (`pkg/plan/parse.go`, `taskHeaderPattern` matches on the literal English keywords) then rejected the plan.

Added a CRITICAL RULE in `make_plan.txt` requiring those headers to stay in English regardless of plan language. Task titles and body content may still be localized. Scoped to generation only — existing localized plans still need the manual rename workaround the reporter found.

Related to #300