### PR TITLE
fix: pre-initialize config dir

### DIFF
--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -403,7 +403,10 @@ def build_volumes(creds_temp: Optional[Path], claude_home: Optional[Path] = None
     # permission errors when SKIP_HOME_CHOWN=1 leaves /home/app unwritable
     # to the remapped APP_UID
     ralphex_config = home / ".config" / "ralphex"
-    ralphex_config.mkdir(parents=True, exist_ok=True)
+    try:
+        ralphex_config.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as exc:
+        raise SystemExit(f"error: failed to create config directory {ralphex_config}: {exc}")
     add(resolve_path(ralphex_config), "/home/app/.config/ralphex")
     add_symlink_targets(ralphex_config)
 

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -398,10 +398,14 @@ def build_volumes(creds_temp: Optional[Path], claude_home: Optional[Path] = None
         add_symlink_targets(codex_dir)
 
     # 7. ~/.config/ralphex -> /home/app/.config/ralphex + symlink targets
+    # always mount, creating the host dir if missing — this ensures docker
+    # creates /home/app/.config in the container (as root), avoiding mkdir
+    # permission errors when SKIP_HOME_CHOWN=1 leaves /home/app unwritable
+    # to the remapped APP_UID
     ralphex_config = home / ".config" / "ralphex"
-    if ralphex_config.is_dir():
-        add(resolve_path(ralphex_config), "/home/app/.config/ralphex")
-        add_symlink_targets(ralphex_config)
+    ralphex_config.mkdir(parents=True, exist_ok=True)
+    add(resolve_path(ralphex_config), "/home/app/.config/ralphex")
+    add_symlink_targets(ralphex_config)
 
     # 8. .ralphex/ symlink targets only (workspace mount already includes it)
     local_ralphex = cwd / ".ralphex"

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -406,7 +406,7 @@ def build_volumes(creds_temp: Optional[Path], claude_home: Optional[Path] = None
     try:
         ralphex_config.mkdir(mode=0o700, parents=True, exist_ok=True)
     except OSError as exc:
-        raise SystemExit(f"error: failed to create config directory {ralphex_config}: {exc}")
+        raise OSError(f"failed to create config directory {ralphex_config}") from exc
     add(resolve_path(ralphex_config), "/home/app/.config/ralphex")
     add_symlink_targets(ralphex_config)
 
@@ -1061,6 +1061,9 @@ def main() -> int:
             cmd.extend(["-w", "/workspace"])
             cmd.extend([image, "/srv/ralphex", "--help"])
             return subprocess.run(cmd, check=False).returncode
+        except OSError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
         finally:
             if creds_temp:
                 try:
@@ -1222,6 +1225,9 @@ def main() -> int:
         schedule_cleanup(creds_temp)
 
         return run_docker(image, port, volumes, extra_env, bind_port, ralphex_args, docker_gid=docker_gid, network=network)
+    except OSError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
     finally:
         # only skip cleanup if dry-run completed successfully (user got the file path warning)
         if not dry_run_completed:

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -222,6 +222,43 @@ class TestBuildVolumes(unittest.TestCase):
             found = any("/mnt/claude:ro,z" in v for v in vols)
             self.assertTrue(found, "should mount ~/.claude to /mnt/claude:ro,z")
 
+    def test_creates_ralphex_config_dir_when_missing(self) -> None:
+        """build_volumes creates ~/.config/ralphex with mode 0o700 when it does not exist."""
+        tmp = Path(tempfile.mkdtemp()).resolve()
+        try:
+            fake_home = tmp / "home"
+            fake_home.mkdir()
+            (fake_home / ".claude").mkdir()
+            ralphex_config = fake_home / ".config" / "ralphex"
+            self.assertFalse(ralphex_config.exists())
+            with (
+                unittest.mock.patch("ralphex_dk.Path.home", return_value=fake_home),
+                unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False),
+            ):
+                build_volumes(None)
+            self.assertTrue(ralphex_config.is_dir(), "~/.config/ralphex should be created")
+            mode = ralphex_config.stat().st_mode & 0o777
+            self.assertEqual(mode, 0o700, f"expected mode 0700, got {oct(mode)}")
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_always_mounts_ralphex_config(self) -> None:
+        """build_volumes always includes the ~/.config/ralphex mount even when dir was missing."""
+        tmp = Path(tempfile.mkdtemp()).resolve()
+        try:
+            fake_home = tmp / "home"
+            fake_home.mkdir()
+            (fake_home / ".claude").mkdir()
+            with (
+                unittest.mock.patch("ralphex_dk.Path.home", return_value=fake_home),
+                unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False),
+            ):
+                vols = build_volumes(None)
+            found = any("/home/app/.config/ralphex" in v for v in vols)
+            self.assertTrue(found, "~/.config/ralphex should always be mounted to /home/app/.config/ralphex")
+        finally:
+            shutil.rmtree(tmp)
+
 class TestBuildVolumesGitignore(unittest.TestCase):
     def test_global_gitignore_remapped_to_home_app(self) -> None:
         """global gitignore under $HOME should be mounted at /home/app/<relative>."""

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -188,6 +188,18 @@ class TestShouldBindPort(unittest.TestCase):
         self.assertFalse(should_bind_port([]))
 
 class TestBuildVolumes(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp()).resolve()
+        self.fake_home = self.tmp / "home"
+        self.fake_home.mkdir()
+        (self.fake_home / ".claude").mkdir()
+        self._home_patcher = unittest.mock.patch("ralphex_dk.Path.home", return_value=self.fake_home)
+        self._home_patcher.start()
+
+    def tearDown(self) -> None:
+        self._home_patcher.stop()
+        shutil.rmtree(self.tmp)
+
     def test_volume_pairs(self) -> None:
         with unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False):
             vols = build_volumes(None)
@@ -224,40 +236,20 @@ class TestBuildVolumes(unittest.TestCase):
 
     def test_creates_ralphex_config_dir_when_missing(self) -> None:
         """build_volumes creates ~/.config/ralphex with mode 0o700 when it does not exist."""
-        tmp = Path(tempfile.mkdtemp()).resolve()
-        try:
-            fake_home = tmp / "home"
-            fake_home.mkdir()
-            (fake_home / ".claude").mkdir()
-            ralphex_config = fake_home / ".config" / "ralphex"
-            self.assertFalse(ralphex_config.exists())
-            with (
-                unittest.mock.patch("ralphex_dk.Path.home", return_value=fake_home),
-                unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False),
-            ):
-                build_volumes(None)
-            self.assertTrue(ralphex_config.is_dir(), "~/.config/ralphex should be created")
-            mode = ralphex_config.stat().st_mode & 0o777
-            self.assertEqual(mode, 0o700, f"expected mode 0700, got {oct(mode)}")
-        finally:
-            shutil.rmtree(tmp)
+        ralphex_config = self.fake_home / ".config" / "ralphex"
+        self.assertFalse(ralphex_config.exists())
+        with unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False):
+            build_volumes(None)
+        self.assertTrue(ralphex_config.is_dir(), "~/.config/ralphex should be created")
+        mode = ralphex_config.stat().st_mode & 0o777
+        self.assertEqual(mode, 0o700, f"expected mode 0700, got {oct(mode)}")
 
     def test_always_mounts_ralphex_config(self) -> None:
         """build_volumes always includes the ~/.config/ralphex mount even when dir was missing."""
-        tmp = Path(tempfile.mkdtemp()).resolve()
-        try:
-            fake_home = tmp / "home"
-            fake_home.mkdir()
-            (fake_home / ".claude").mkdir()
-            with (
-                unittest.mock.patch("ralphex_dk.Path.home", return_value=fake_home),
-                unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False),
-            ):
-                vols = build_volumes(None)
-            found = any("/home/app/.config/ralphex" in v for v in vols)
-            self.assertTrue(found, "~/.config/ralphex should always be mounted to /home/app/.config/ralphex")
-        finally:
-            shutil.rmtree(tmp)
+        with unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False):
+            vols = build_volumes(None)
+        found = any("/home/app/.config/ralphex" in v for v in vols)
+        self.assertTrue(found, "~/.config/ralphex should always be mounted to /home/app/.config/ralphex")
 
 class TestBuildVolumesGitignore(unittest.TestCase):
     def test_global_gitignore_remapped_to_home_app(self) -> None:

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -187,7 +187,15 @@ class TestShouldBindPort(unittest.TestCase):
     def test_empty(self) -> None:
         self.assertFalse(should_bind_port([]))
 
-class TestBuildVolumes(unittest.TestCase):
+class _FakeHomeTestCase(unittest.TestCase):
+    """base test case providing a fake $HOME for tests that exercise build_volumes()
+    or any helper that reads/writes paths under the user's home directory. patches
+    Path.home() and the HOME env var so build_volumes' new mkdir for
+    ~/.config/ralphex lands in a tempdir, keeping the suite hermetic on real CI
+    runners and dev boxes. HOME is patched in addition to Path.home so
+    Path.expanduser('~/...') stays consistent with Path.home(); without it,
+    expanduser still reads the real HOME and the two diverge."""
+
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp()).resolve()
         self.fake_home = self.tmp / "home"
@@ -195,11 +203,16 @@ class TestBuildVolumes(unittest.TestCase):
         (self.fake_home / ".claude").mkdir()
         self._home_patcher = unittest.mock.patch("ralphex_dk.Path.home", return_value=self.fake_home)
         self._home_patcher.start()
+        self._env_patcher = unittest.mock.patch.dict(os.environ, {"HOME": str(self.fake_home)})
+        self._env_patcher.start()
 
     def tearDown(self) -> None:
+        self._env_patcher.stop()
         self._home_patcher.stop()
         shutil.rmtree(self.tmp)
 
+
+class TestBuildVolumes(_FakeHomeTestCase):
     def test_volume_pairs(self) -> None:
         with unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False):
             vols = build_volumes(None)
@@ -251,10 +264,10 @@ class TestBuildVolumes(unittest.TestCase):
         found = any("/home/app/.config/ralphex" in v for v in vols)
         self.assertTrue(found, "~/.config/ralphex should always be mounted to /home/app/.config/ralphex")
 
-class TestBuildVolumesGitignore(unittest.TestCase):
+class TestBuildVolumesGitignore(_FakeHomeTestCase):
     def test_global_gitignore_remapped_to_home_app(self) -> None:
         """global gitignore under $HOME should be mounted at /home/app/<relative>."""
-        home = Path.home()
+        home = self.fake_home
         fake_ignore = home / ".gitignore"
         with (
             unittest.mock.patch("ralphex_dk.get_global_gitignore", return_value=fake_ignore),
@@ -267,7 +280,7 @@ class TestBuildVolumesGitignore(unittest.TestCase):
 
     def test_global_gitignore_also_mounted_at_original_absolute_path(self) -> None:
         """gitignore under $HOME should also be mounted at original absolute path for .gitconfig refs."""
-        home = Path.home()
+        home = self.fake_home
         fake_ignore = home / ".gitignore_global"
         with (
             unittest.mock.patch("ralphex_dk.get_global_gitignore", return_value=fake_ignore),
@@ -414,7 +427,7 @@ class TestScheduleCleanup(unittest.TestCase):
 
         self.assertEqual(captured_delay, [60.0])
 
-class TestBuildDockerCmd(unittest.TestCase):
+class TestBuildDockerCmd(_FakeHomeTestCase):
     def test_creds_volume_mount_without_selinux(self) -> None:
         """build_volumes should include creds temp mount when provided."""
         fd, tmp_path = tempfile.mkstemp()
@@ -470,7 +483,7 @@ class TestKeychainServiceName(unittest.TestCase):
         """tilde path ~/.claude is expanded and recognized as default."""
         self.assertEqual(keychain_service_name(Path("~/.claude")), "Claude Code-credentials")
 
-class TestBuildVolumesClaudeHome(unittest.TestCase):
+class TestBuildVolumesClaudeHome(_FakeHomeTestCase):
     def test_custom_claude_home_mount_without_selinux(self) -> None:
         """build_volumes with custom claude_home mounts that dir to /mnt/claude:ro."""
         tmp = Path(tempfile.mkdtemp()).resolve()
@@ -549,7 +562,7 @@ class TestSelinuxEnabled(unittest.TestCase):
             mock_path.return_value.exists.return_value = True
             self.assertTrue(selinux_enabled())
 
-class TestSelinuxVolumeSuffix(unittest.TestCase):
+class TestSelinuxVolumeSuffix(_FakeHomeTestCase):
     def test_z_label_in_volumes_when_selinux(self) -> None:
         """volume mounts include :z label when SELinux is enabled."""
         with unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=True):
@@ -567,7 +580,7 @@ class TestSelinuxVolumeSuffix(unittest.TestCase):
             self.assertFalse(vols[i].endswith(":z"),
                              f"volume {vols[i]} should not have :z without SELinux")
 
-class TestClaudeConfigDirEnv(unittest.TestCase):
+class TestClaudeConfigDirEnv(_FakeHomeTestCase):
     def test_env_sets_claude_home(self) -> None:
         """CLAUDE_CONFIG_DIR env var selects alternate claude directory."""
         tmp = Path(tempfile.mkdtemp()).resolve()
@@ -598,7 +611,7 @@ class TestClaudeConfigDirEnv(unittest.TestCase):
             with unittest.mock.patch("ralphex_dk.selinux_enabled", return_value=False):
                 vols = build_volumes(None, claude_home=None)
             # the first volume mount should map ~/.claude -> /mnt/claude
-            default_claude = str((Path.home() / ".claude").resolve())
+            default_claude = str((self.fake_home / ".claude").resolve())
             vol_sources = [v.split(":")[0] for v in vols if v.startswith("/")]
             self.assertIn(default_claude, vol_sources,
                           f"default ~/.claude path not found in volume mounts: {vols}")


### PR DESCRIPTION
closes #303 

If a user runs the Ralphex Docker image via a shell wrapper, the .config/ralphex directory may not be initialized. This results in an error when the container attempts to create the directory.