### PR TITLE
fix: resume watch-mode tailing after flock race marks session completed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ docs/plans/         # plan files location
 - Streaming output with timestamps
 - Progress logging to files
 - Progress file locking (flock) for active session detection
+- Watch-mode dashboard reactivates completed sessions on fsnotify Write events, resuming tailing from the recorded `Session.lastOffset` — recovery path for the flock race in `RefreshStates` that can prematurely mark a still-running session as completed (issue #283). `Session.Reactivate()` is idempotent and scoped to the exact path that received the write; `loadProgressFileIntoSession` records `lastOffset` after the initial load so reactivation does not re-emit already-replayed events
 - Progress file fresh start: files ending in a `Completed:` footer are truncated on reuse; files ending in a `Failed:` footer (written when `Logger.SetFailed` was called before `Close`) or with no footer preserve existing content and write a `--- restarted at ... ---` separator, so retried failed/aborted runs keep history (issue #288). `SetFailed` is called in `cmd/ralphex/main.go` for `r.Run` errors (including `ErrUserAborted`), dashboard start errors, and any error return from `runWithWorktree`
 - Multiple execution modes: full, tasks-only, review-only, external-only/codex-only, plan creation
 - `--base-ref` flag overrides default branch for review diffs (branch name or commit hash)

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -266,12 +266,12 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 
 ### Task 6: Verify acceptance criteria
 
-- [ ] re-read issue #283 and confirm Option B semantics match this implementation
-- [ ] run full test suite: `make test`
-- [ ] verify race-free: `go test -race ./pkg/web/...`
-- [ ] run linter: `make lint` (fix all issues — no "pre-existing" dismissals)
-- [ ] run formatter: `make fmt`
-- [ ] check coverage: `go test -cover ./pkg/web/...` — must be >=80% for touched files, ideally no regression
+- [x] re-read issue #283 and confirm Option B semantics match this implementation
+- [x] run full test suite: `make test`
+- [x] verify race-free: `go test -race ./pkg/web/...`
+- [x] run linter: `make lint` (fix all issues — no "pre-existing" dismissals)
+- [x] run formatter: `make fmt`
+- [x] check coverage: `go test -cover ./pkg/web/...` — must be >=80% for touched files, ideally no regression
 
 ### Task 7: End-to-end toy-project verification
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -149,19 +149,19 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 - Modify: `pkg/web/tail.go`
 - Modify: `pkg/web/tail_test.go`
 
-- [ ] add `(t *Tailer) Offset() int64` method returning `t.offset` under `t.mu`
-- [ ] add `(t *Tailer) StartFromOffset(offset int64) error`:
-  - [ ] if offset <= 0, treat as "seek to end" (same as `Start(false)` path) — documented in godoc, makes callers robust for fresh sessions
-  - [ ] open file, `Stat` to get size, clamp offset to `min(offset, fileSize)` to avoid seeking past EOF
-  - [ ] seek to clamped offset, set `t.offset = clampedOffset`, `t.inHeader = false` (offset>0 means we're past the header — if caller violates this contract, worst case is header detection breaks on rare edge cases; godoc warns)
-  - [ ] set `t.deferSections = false`, clear pending section state
-  - [ ] set `t.running = true`, init `stopCh`/`doneCh`, launch `tailLoop`
-- [ ] keep existing `Start(fromStart bool) error` unchanged to avoid breaking other callers
-- [ ] add test: `TestTailer_Offset` — writes lines, reads partial, verifies `Offset()` reflects bytes consumed (including LF and CRLF line endings)
-- [ ] add test: `TestTailer_StartFromOffset` — pre-writes content, starts tailer from middle, verifies only post-offset lines emit
-- [ ] add test: `TestTailer_StartFromOffset_BeyondFileSize` — offset > file size, verifies offset is clamped, no panic, no spurious events
-- [ ] add test: `TestTailer_StartFromOffset_ZeroFallsBack` — offset <= 0 behaves like `Start(false)`, seeks to end
-- [ ] run tests: `go test ./pkg/web/... -run Tailer` must pass before next task
+- [x] add `(t *Tailer) Offset() int64` method returning `t.offset` under `t.mu`
+- [x] add `(t *Tailer) StartFromOffset(offset int64) error`:
+  - [x] if offset <= 0, treat as "seek to end" (same as `Start(false)` path) — documented in godoc, makes callers robust for fresh sessions
+  - [x] open file, `Stat` to get size, clamp offset to `min(offset, fileSize)` to avoid seeking past EOF
+  - [x] seek to clamped offset, set `t.offset = clampedOffset`, `t.inHeader = false` (offset>0 means we're past the header — if caller violates this contract, worst case is header detection breaks on rare edge cases; godoc warns)
+  - [x] set `t.deferSections = false`, clear pending section state
+  - [x] set `t.running = true`, init `stopCh`/`doneCh`, launch `tailLoop`
+- [x] keep existing `Start(fromStart bool) error` unchanged to avoid breaking other callers
+- [x] add test: `TestTailer_Offset` — writes lines, reads partial, verifies `Offset()` reflects bytes consumed (including LF and CRLF line endings)
+- [x] add test: `TestTailer_StartFromOffset` — pre-writes content, starts tailer from middle, verifies only post-offset lines emit
+- [x] add test: `TestTailer_StartFromOffset_BeyondFileSize` — offset > file size, verifies offset is clamped, no panic, no spurious events
+- [x] add test: `TestTailer_StartFromOffset_ZeroFallsBack` — offset <= 0 behaves like `Start(false)`, seeks to end
+- [x] run tests: `go test ./pkg/web/... -run Tailer` must pass before next task
 
 ### Task 2: Track last-read offset on Session
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -275,14 +275,14 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 
 ### Task 7: End-to-end toy-project verification
 
-- [ ] build fresh binary: `make build`
-- [ ] prepare toy project: `./scripts/internal/prep-toy-test.sh`
-- [ ] terminal A: start watch-mode dashboard — `.bin/ralphex -s -w /tmp/ralphex-test`
-- [ ] terminal B: from `/tmp/ralphex-test`, run `.../ralphex docs/plans/fix-issues.md` (without `-s`)
-- [ ] open dashboard in browser, confirm live log streaming
-- [ ] leave running past the 5-second `RefreshStates` tick; confirm streaming does NOT freeze mid-run
-- [ ] confirm session flips back to active after any transient "completed" (check browser devtools or sidebar)
-- [ ] kill executor mid-run; confirm tailing stops cleanly (no zombie tailers) and session shows completed
+- [x] build fresh binary: `make build`
+- [x] prepare toy project: `./scripts/internal/prep-toy-test.sh`
+- [x] terminal A: start watch-mode dashboard — `.bin/ralphex -s -w /tmp/ralphex-test`
+- [x] terminal B: from `/tmp/ralphex-test`, run `.../ralphex docs/plans/fix-issues.md` (without `-s`)
+- [x] open dashboard in browser, confirm live log streaming
+- [x] leave running past the 5-second `RefreshStates` tick; confirm streaming does NOT freeze mid-run
+- [x] confirm session flips back to active after any transient "completed" (check browser devtools or sidebar)
+- [x] kill executor mid-run; confirm tailing stops cleanly (no zombie tailers) and session shows completed
 
 ### Task 8: [Final] Update documentation
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -244,25 +244,25 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 - Modify: `pkg/web/watcher.go`
 - Modify: `pkg/web/watcher_test.go`
 
-- [ ] in `handleProgressFileChange(path)`, after the `Discover` call and the `startTailingIfNeeded` loop:
-  - [ ] look up the session for this path: `id := sessionIDFromPath(path); session := w.sm.Get(id)`
-  - [ ] if session != nil and `session.GetState() == SessionStateCompleted` and `session.IsLoaded()`:
-    - [ ] call `session.Reactivate()`, log any error at WARN level
-  - [ ] the `IsLoaded()` check ensures `loadProgressFileIntoSession` has finished (lastOffset is set) before we reactivate — avoids the race where a mid-load write triggers reactivation with lastOffset=0
-- [ ] keep existing `startTailingIfNeeded(id)` loop unchanged — it handles fresh-active-from-Discover; Reactivate handles the completed case
-- [ ] this design means the post-Discover sequence handles:
+- [x] in `handleProgressFileChange(path)`, after the `Discover` call and the `startTailingIfNeeded` loop:
+  - [x] look up the session for this path: `id := sessionIDFromPath(path); session := w.sm.Get(id)`
+  - [x] if session != nil and `session.GetState() == SessionStateCompleted` and `session.IsLoaded()`:
+    - [x] call `session.Reactivate()`, log any error at WARN level
+  - [x] the `IsLoaded()` check ensures `loadProgressFileIntoSession` has finished (lastOffset is set) before we reactivate — avoids the race where a mid-load write triggers reactivation with lastOffset=0
+- [x] keep existing `startTailingIfNeeded(id)` loop unchanged — it handles fresh-active-from-Discover; Reactivate handles the completed case
+- [x] this design means the post-Discover sequence handles:
   - already-active session: no-op (startTailingIfNeeded sees tailing, skips; Reactivate sees not-completed, skips)
   - Discover flipped completed→active: startTailingIfNeeded starts tailing (from start)
   - Discover kept completed, write event occurred: Reactivate resumes from lastOffset
-- [ ] add test: `TestWatcher_ReactivatesCompletedSessionOnWrite`:
-  - [ ] create progress file, pre-populate with initial content
-  - [ ] start watcher, wait for initial discovery to load content (state=completed, lastOffset > 0)
-  - [ ] append new lines to file (triggers fsnotify Write)
-  - [ ] assert state transitions to `active` and NEW lines arrive via SSE (subscribe and consume events) — verify that the pre-existing content is NOT re-emitted after reactivation
-- [ ] add test: `TestWatcher_DoesNotReactivateActiveSession` — session already active + tailing, write event should not spawn duplicate tailer. Assertion: subscribe to SSE, write a line, verify exactly one event arrives (no duplication). Do NOT rely on tailer pointer identity or goroutine counts — those helpers don't exist and would add test-only APIs
-- [ ] add test: `TestWatcher_OnlyReactivatesWrittenPath` — create two progress files in same dir, both completed; write to one only; verify only that session is reactivated, the other stays completed
-- [ ] run tests: `go test ./pkg/web/... -run Watcher` must pass before next task
-- [ ] **re-run the Task 0 reproduction test** `TestWatcher_ResumesStreamingAfterFlockRace` — it must now pass (this is the green half of red-green-refactor for the bug fix)
+- [x] add test: `TestWatcher_ReactivatesCompletedSessionOnWrite`:
+  - [x] create progress file, pre-populate with initial content
+  - [x] start watcher, wait for initial discovery to load content (state=completed, lastOffset > 0)
+  - [x] append new lines to file (triggers fsnotify Write)
+  - [x] assert state transitions to `active` and NEW lines arrive via SSE (subscribe and consume events) — verify that the pre-existing content is NOT re-emitted after reactivation
+- [x] add test: `TestWatcher_DoesNotReactivateActiveSession` — session already active + tailing, write event should not spawn duplicate tailer. Assertion: subscribe to SSE, write a line, verify exactly one event arrives (no duplication). Do NOT rely on tailer pointer identity or goroutine counts — those helpers don't exist and would add test-only APIs
+- [x] add test: `TestWatcher_OnlyReactivatesWrittenPath` — create two progress files in same dir, both completed; write to one only; verify only that session is reactivated, the other stays completed
+- [x] run tests: `go test ./pkg/web/... -run Watcher` must pass before next task
+- [x] **re-run the Task 0 reproduction test** `TestWatcher_ResumesStreamingAfterFlockRace` — it must now pass (this is the green half of red-green-refactor for the bug fix)
 
 ### Task 6: Verify acceptance criteria
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -1,0 +1,307 @@
+# Watch-mode reactivate tailing on write events
+
+## Overview
+
+Fix issue #283: the watch-mode dashboard (`ralphex -s -w /path` running as a separate process) stops streaming logs mid-run. Once `RefreshStates()` briefly sees the progress file unlocked — which happens whenever `TryLockFile` wins a race against the executor's flock, or after the executor finishes — it marks the session `completed` and stops tailing. Subsequent writes from the still-running (or restarted) executor are ignored because `startTailingIfNeeded()` refuses to re-start tailing for non-active sessions.
+
+**Fix:** implement Option B from umputun's comment on the issue — on a `Write` event for a progress file that belongs to a `completed` session, reactivate the session and resume tailing. To avoid re-emitting events into the SSE replay buffer, track the last-read file offset on the `Session` and resume tailing from there instead of from the beginning.
+
+**Benefits:**
+- watch-mode + separate executor (the pm2 deployment pattern) actually works
+- no duplicate events in SSE replay after reactivation
+- `RefreshStates` / flock detection stays unchanged — reactivation is the recovery path, not a replacement
+
+## Context (from discovery)
+
+- **files involved:**
+  - `pkg/web/tail.go` — expose Tailer offset and accept starting offset
+  - `pkg/web/session.go` — track `lastOffset`, add `Reactivate()` method
+  - `pkg/web/session_progress.go` — update `loadProgressFileIntoSession` to record offset after initial load (loader function lives here, not in session_manager.go)
+  - `pkg/web/watcher.go` — in `handleProgressFileChange`, reactivate a completed session that just received a write
+  - tests: `session_test.go`, `watcher_test.go`, `session_progress_test.go`, `tail_test.go`
+- **related patterns found:**
+  - flock-based activity detection in `IsActive()` (session_manager.go:359)
+  - 5-second tick in `refreshLoop` calling `RefreshStates` (watcher.go:214)
+  - Tailer already tracks `offset` internally (`tail.go:40`) — needs accessor + seek-to-offset variant
+  - tests already use `t.TempDir()` and real fsnotify watches
+- **dependencies identified:**
+  - `fsnotify` Write events must be delivered (already working — plan panel updates prove this)
+  - executor's `progress.NewLogger` does hold flock for the whole run (`progress.go:178`) — confirmed via code read, contradicts the reporter's guess
+
+## Development Approach
+
+- **testing approach:** TDD for Task 0 (failing reproduction test to prove the bug exists), then Regular for Tasks 1-5 (implement + tests per task). This satisfies the user's CLAUDE.md rule "For bug fixes: Use TDD approach - write failing test first"
+- complete each task fully before moving to the next
+- make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  - tests are not optional — they are a required part of the checklist
+  - cover both success and error scenarios
+- **CRITICAL: all tests must pass before starting next task**
+- **CRITICAL: update this plan file when scope changes during implementation**
+- run `make test` after each change
+- run `make lint` at the end; fix all linter issues (BANNED: "pre-existing")
+- maintain backward compatibility — don't break non-watch-mode users
+
+## Testing Strategy
+
+- **unit tests**: required for every task
+  - extend `tail_test.go` for offset accessor and seek-to-offset start
+  - extend `session_test.go` for `lastOffset` tracking, `Reactivate`
+  - extend `watcher_test.go` for the reactivation-on-write flow end-to-end (use real `fsnotify` and real files via `t.TempDir()` as existing tests do)
+  - extend `session_manager_test.go` / `session_progress_test.go` if loader-offset recording lives there
+- **e2e tests**: the project has playwright e2e tests under `e2e/`; this fix is a non-UI backend change, but the dashboard behavior is visible. After all unit tests pass, run the toy-project end-to-end test (`scripts/internal/prep-toy-test.sh` + `ralphex -s -w` + separate executor) to verify live streaming survives the 5-second tick
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+- update plan if implementation deviates from original scope
+- keep plan in sync with actual work done
+
+## Solution Overview
+
+**The bug in one picture:**
+
+```
+executor process                 dashboard process (-w)
+----------------                 ----------------------
+write line                   -->
+flock held                       refresh tick: TryLockFile fails → still active
+...                              tail keeps streaming
+flock momentarily free / run ends
+                                 refresh tick: TryLockFile succeeds → marks completed, stops tailer
+flock re-held (or same executor keeps writing)
+write line                   --> fsnotify Write event
+                                 handleProgressFileChange → Discover → updateSession
+                                 IsActive may STILL say "not active" (flock race) → state stays completed
+                                 startTailingIfNeeded: state != active → NO-OP ❌
+```
+
+**Fix:** after `Discover` in `handleProgressFileChange`, if the session for the written path is `completed`, call `session.Reactivate()` which flips state to `active` and restarts tailing from the stored `lastOffset` (captured when the previous tailer stopped, or set to file size after `loadProgressFileIntoSession`).
+
+**Why we keep RefreshStates unchanged:** flock-based completion detection is still correct when the run genuinely ends. Reactivation handles the case where writes resume after a false "completed" marking — no cost to correct cases.
+
+**Key design decisions:**
+
+- **offset tracking on the Session (not the Tailer):** tailers are one-shot (`Stop()` makes them non-reusable per tail.go:84). The Session outlives tailer instances, so it owns the offset.
+- **`Reactivate()` bypasses the flock check:** a write event is strong evidence of activity. False positives (a human editing the progress file) are harmless — at worst, tailer starts and finds nothing to emit.
+- **loader records offset too:** when a completed session is discovered for the first time, `loadProgressFileIntoSession` reads the whole file into SSE. We record the bytes consumed as `lastOffset` so a later reactivation (if writes resume) picks up after the loaded content, not from scratch.
+- **Windows:** on Windows, flock is a no-op (`IsActive` always returns false). That means every session is marked completed immediately after discovery, and reactivation-on-write becomes the *primary* streaming mechanism on Windows — not just a recovery path for the race. The fix works the same way on both platforms; no platform-specific branches needed.
+- **Interaction with `updateSession` StopTailing path:** `handleProgressFileChange` calls `Discover` → `updateSession` which, if it observes an `active→completed` transition under the flock race, will call `StopTailing()` and capture the current offset. Our reactivation step runs immediately after. Flow: Discover(race→completed) → StopTailing(offset captured) → Reactivate(starts from captured offset). No events are lost: the tailer's in-flight read loop writes `t.offset` incrementally, `StopTailing` snapshots it, and the new tailer resumes from that byte position. This interaction is intentional — reactivation is the undo button for the flock race, not an attempt to prevent the race in the first place.
+
+## Technical Details
+
+**New / changed APIs:**
+
+- `Tailer.Offset() int64` — read current offset under tailer mutex
+- `Tailer.StartFromOffset(offset int64) error` — new method; opens file, seeks to offset (if offset <= 0, behaves as `Start(false)` / seek-to-end; if offset > file size, clamps to file size); sets `t.offset=offset`, `t.inHeader=false`, `t.deferSections=false`, launches tailLoop. `Start(fromStart bool)` stays unchanged.
+- `Session.lastOffset int64` — private, guarded by `s.mu`
+- `Session.getLastOffset()` / `Session.setLastOffset(int64)` — **unexported** package-internal accessors (no external callers; tests are in-package)
+- `Session.StopTailing()` — before stopping, capture `tailer.Offset()` into `s.lastOffset` (under the write lock, same critical section as nilling `stopTailCh`)
+- `Session.Reactivate() error` — starts tailing from `lastOffset`, then sets state to `active` on success. If already tailing, returns nil (idempotent). On tailer-start failure, leaves state unchanged.
+- `SessionManager.loadProgressFileIntoSession()` — accumulate `bytesRead += int64(len(line))` on each `ReadString('\n')` return BEFORE `trimLineEnding` is applied (so CRLF, LF, and bare CR all count correctly). After the read loop, call `session.setLastOffset(bytesRead)`.
+- `Watcher.handleProgressFileChange()` — after `Discover`, look up the specific session by `sessionIDFromPath(path)` and call `Reactivate()` only if its state is `completed`. This is scoped to the exact path that received the write — other completed sessions in the same directory are not reactivated.
+
+**Why `Reactivate()` and not `SetState(active) + StartTailing`:** atomicity — we want "check state, start tailing from offset, flip state on success" under a single lock boundary without re-entering the public `StartTailing(fromStart bool)` path (whose `fromStart=true` semantics would reset offset to 0).
+
+**Shared helper:** `startTailerLocked(mode tailerStartMode, offset int64) error` — called with `s.mu` held (write lock). Creates a new `Tailer`, starts it according to `mode` (resumeFromOffset / fromStart / fromEnd), allocates `stopTailCh`, launches `feedEvents` goroutine. Modes are distinct to avoid ambiguity: `modeResume` with `offset<=0` would re-emit everything if misrouted through `fromStart`, so `Reactivate` with `lastOffset==0` uses `fromEnd`, not `fromStart`. Dispatch:
+- `modeFromStart` → `tailer.Start(true)` (existing behavior, used by `StartTailing(true)`)
+- `modeFromEnd` → `tailer.Start(false)` (seek to end; used by `StartTailing(false)` and `Reactivate` when `lastOffset==0`)
+- `modeResume(offset)` → `tailer.StartFromOffset(offset)` (used by `Reactivate` when `lastOffset>0`)
+
+The feedEvents goroutine acquires its own `RLock` once running — no deadlock because the outer caller unlocks immediately after returning from the helper. Contract documented in godoc.
+
+**Potential races considered:**
+
+- `RefreshStates` + `Reactivate` racing: both take `s.mu` for state transitions; worst case RefreshStates flips back to completed, next write event re-flips to active. Self-healing.
+- Multiple write events arriving in burst: `Reactivate()` early-returns if `tailer.IsRunning()`. Idempotent.
+- Session closed while reactivating: `StartFromOffset` would fail opening the file; `Reactivate` returns the error without flipping state. Watcher logs and moves on. No state desync.
+- `updateSession` stops tailing due to flock race, then `Reactivate` restarts: offset is captured inside `StopTailing`, so no events are re-emitted — the new tailer resumes from the exact byte where the old one stopped. Worth an explicit test (see Task 5).
+- Concurrent `loadProgressFileIntoSession` + write-triggered reactivation: protected by `MarkLoadedIfNot` — only one loader runs ever. If loader is still running when a reactivation fires, the reactivation sees `lastOffset=0` (not yet set) and starts from 0 → would re-emit everything the loader already published. Mitigation: set `lastOffset` at the END of the loader (after the read loop completes), and ensure reactivation only fires AFTER `MarkLoadedIfNot` finishes by checking `session.IsLoaded()` before reactivating, OR accept the rare duplication (loader is fast, this race is tiny). Plan chooses the check: `Watcher.handleProgressFileChange` only calls `Reactivate()` when session is `completed` AND loaded.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): code, tests, doc updates inside this repo
+- **Post-Completion** (no checkboxes): manual verification against the toy project, responding on issue #283 after PR lands
+
+## Implementation Steps
+
+### Task 0: TDD reproduction — failing test for issue #283
+
+**Files:**
+- Modify: `pkg/web/watcher_test.go`
+
+- [ ] add test `TestWatcher_ResumesStreamingAfterFlockRace`:
+  - [ ] create a temp dir + progress file, write the standard header and some initial lines
+  - [ ] create SessionManager + Watcher (real fsnotify), start with context
+  - [ ] wait for initial discovery (poll session state until non-nil, sanity check)
+  - [ ] simulate the flock race: force the session state to `SessionStateCompleted` via `session.SetState(SessionStateCompleted)` and stop tailing via `session.StopTailing()` (this models what `RefreshStates` does when TryLockFile transiently succeeds)
+  - [ ] append new lines to the progress file
+  - [ ] assert within a generous timeout (~500ms) that the session state returns to `SessionStateActive` and the new lines arrive via SSE — tests poll for state and consume from `session.SSE` subscription or use the tail/event interface existing tests use
+  - [ ] run the test: `go test ./pkg/web/... -run TestWatcher_ResumesStreamingAfterFlockRace` — **MUST FAIL on master** (this confirms the bug is reproducible)
+- [ ] document the expected failure in the test with a comment referencing issue #283
+- [ ] **Do NOT commit the failing test as a separate commit** — it would land a red commit on the branch and break bisect. Keep the test uncommitted (or bundle with Task 5 commit) until it passes. If TDD hygiene is desired, `t.Skip` the test in its own commit then un-skip in Task 5
+
+### Task 1: Expose offset and seek-to-offset on Tailer
+
+**Files:**
+- Modify: `pkg/web/tail.go`
+- Modify: `pkg/web/tail_test.go`
+
+- [ ] add `(t *Tailer) Offset() int64` method returning `t.offset` under `t.mu`
+- [ ] add `(t *Tailer) StartFromOffset(offset int64) error`:
+  - [ ] if offset <= 0, treat as "seek to end" (same as `Start(false)` path) — documented in godoc, makes callers robust for fresh sessions
+  - [ ] open file, `Stat` to get size, clamp offset to `min(offset, fileSize)` to avoid seeking past EOF
+  - [ ] seek to clamped offset, set `t.offset = clampedOffset`, `t.inHeader = false` (offset>0 means we're past the header — if caller violates this contract, worst case is header detection breaks on rare edge cases; godoc warns)
+  - [ ] set `t.deferSections = false`, clear pending section state
+  - [ ] set `t.running = true`, init `stopCh`/`doneCh`, launch `tailLoop`
+- [ ] keep existing `Start(fromStart bool) error` unchanged to avoid breaking other callers
+- [ ] add test: `TestTailer_Offset` — writes lines, reads partial, verifies `Offset()` reflects bytes consumed (including LF and CRLF line endings)
+- [ ] add test: `TestTailer_StartFromOffset` — pre-writes content, starts tailer from middle, verifies only post-offset lines emit
+- [ ] add test: `TestTailer_StartFromOffset_BeyondFileSize` — offset > file size, verifies offset is clamped, no panic, no spurious events
+- [ ] add test: `TestTailer_StartFromOffset_ZeroFallsBack` — offset <= 0 behaves like `Start(false)`, seeks to end
+- [ ] run tests: `go test ./pkg/web/... -run Tailer` must pass before next task
+
+### Task 2: Track last-read offset on Session
+
+**Files:**
+- Modify: `pkg/web/session.go`
+- Modify: `pkg/web/session_test.go`
+
+- [ ] add private `lastOffset int64` field on `Session` (guarded by `s.mu`)
+- [ ] add **unexported** `getLastOffset() int64` and `setLastOffset(offset int64)` accessors (thread-safe). Keep them unexported — tests are in-package, loader and StopTailing are in the same package. Per the user's convention: do not export without an out-of-package caller
+- [ ] modify `StopTailing()` — before nilling `stopTailCh`, capture `tailer.Offset()` and store in `s.lastOffset` (under the same write lock). Pseudocode:
+  ```go
+  s.mu.Lock()
+  if s.tailer != nil {
+      s.lastOffset = s.tailer.Offset()
+  }
+  if s.stopTailCh != nil { close(s.stopTailCh); s.stopTailCh = nil }
+  tailer := s.tailer
+  s.mu.Unlock()
+  if tailer != nil { tailer.Stop() }
+  ```
+- [ ] add test: `TestSession_LastOffset` — verifies get/set thread-safety via concurrent goroutines (use the in-package unexported names)
+- [ ] add test: `TestSession_StopTailingCapturesOffset` — start tailing, write lines, wait for ingest (poll until events received), stop, verify `getLastOffset()` > 0 and roughly matches bytes written
+- [ ] run tests: `go test ./pkg/web/... -run Session` must pass before next task
+
+### Task 3: Add Session.Reactivate() method
+
+**Files:**
+- Modify: `pkg/web/session.go`
+- Modify: `pkg/web/session_test.go`
+
+- [ ] define private enum `tailerStartMode` with values `modeFromStart`, `modeFromEnd`, `modeResume` (type int, const block)
+- [ ] extract a private helper `startTailerLocked(mode tailerStartMode, offset int64) error` with **lock-held contract** (caller must hold `s.mu` write lock). Behavior:
+  - create new `Tailer` at `s.Path`
+  - dispatch on mode: `modeFromStart` → `tailer.Start(true)`, `modeFromEnd` → `tailer.Start(false)`, `modeResume` → `tailer.StartFromOffset(offset)`
+  - on error, return error; do not store tailer or allocate stopTailCh
+  - on success, set `s.tailer`, create `s.stopTailCh = make(chan struct{})`, launch `go s.feedEvents()` (goroutine acquires its own RLock; safe because caller unlocks after return)
+- [ ] refactor existing `StartTailing(fromStart bool) error` to use `startTailerLocked(modeFromStart or modeFromEnd, 0)` — keep public signature and behavior identical, existing tests still pass
+- [ ] add `Reactivate() error` on `Session`:
+  - [ ] `s.mu.Lock(); defer s.mu.Unlock()`
+  - [ ] if `s.tailer != nil && s.tailer.IsRunning()`, return nil (idempotent)
+  - [ ] capture `offset := s.lastOffset`
+  - [ ] choose mode: if `offset > 0` use `modeResume`, else use `modeFromEnd` (NOT `modeFromStart` — that would re-emit the whole file if lastOffset was never set; `modeFromEnd` is safe because the loader already loaded historical content into SSE replay)
+  - [ ] call `startTailerLocked(mode, offset)` — if it returns error, return it without touching state
+  - [ ] on success: `s.state = SessionStateActive` (only after tailer confirmed started — avoids lying about state if tailer-start fails)
+- [ ] add godoc on `Reactivate` explaining: called when a completed session receives a write event; resumes from `lastOffset` to avoid duplicating events already in SSE replay buffer
+- [ ] add test: `TestSession_Reactivate_ResumesFromOffset` — start tailing, stop (records offset), write more lines, Reactivate, verify SSE receives only new lines (no duplicates from before stop)
+- [ ] add test: `TestSession_Reactivate_Idempotent` — call Reactivate twice in quick succession, verify only one tailer exists and no duplicate events
+- [ ] add test: `TestSession_Reactivate_OnClosedSession` — call after Close, verify graceful error (no panic) and state not flipped to active
+- [ ] add test: `TestSession_Reactivate_FailedStartLeavesStateUnchanged` — use a session with non-existent path, verify Reactivate returns error and state stays completed
+- [ ] run tests: `go test ./pkg/web/... -run Session` must pass before next task
+
+### Task 4: Record offset after loadProgressFileIntoSession
+
+**Files:**
+- Modify: `pkg/web/session_progress.go`
+- Modify: `pkg/web/session_progress_test.go`
+
+- [ ] in `loadProgressFileIntoSession`, accumulate bytes read during the loop:
+  ```go
+  var bytesRead int64
+  for {
+      line, readErr := reader.ReadString('\n')
+      bytesRead += int64(len(line))  // BEFORE trimLineEnding - len includes \n or \r\n as appropriate
+      line = trimLineEnding(line)
+      ...
+      if readErr != nil { break }
+  }
+  session.setLastOffset(bytesRead)
+  ```
+- [ ] **Key detail:** count `len(line)` BEFORE `trimLineEnding` — `ReadString('\n')` returns the delimiter included, so the raw length covers LF, CRLF, and no-trailing-newline (final partial read on EOF) correctly. Do NOT compute offset by summing trimmed length + constant — CRLF would be undercounted by 1 byte
+- [ ] add test: `TestLoadProgressFileIntoSession_RecordsOffset_LF` — load file with `\n`-only endings, verify `getLastOffset()` equals file byte size
+- [ ] add test: `TestLoadProgressFileIntoSession_RecordsOffset_CRLF` — load file with `\r\n` endings, verify offset equals byte size (critical regression guard)
+- [ ] add test: `TestLoadProgressFileIntoSession_EmptyFile` — verify offset is 0 (no regression)
+- [ ] add test: `TestLoadProgressFileIntoSession_NoTrailingNewline` — last line lacks `\n`, verify offset still equals byte size
+- [ ] run tests: `go test ./pkg/web/... -run Load` must pass before next task
+
+### Task 5: Reactivate on write in Watcher
+
+**Files:**
+- Modify: `pkg/web/watcher.go`
+- Modify: `pkg/web/watcher_test.go`
+
+- [ ] in `handleProgressFileChange(path)`, after the `Discover` call and the `startTailingIfNeeded` loop:
+  - [ ] look up the session for this path: `id := sessionIDFromPath(path); session := w.sm.Get(id)`
+  - [ ] if session != nil and `session.GetState() == SessionStateCompleted` and `session.IsLoaded()`:
+    - [ ] call `session.Reactivate()`, log any error at WARN level
+  - [ ] the `IsLoaded()` check ensures `loadProgressFileIntoSession` has finished (lastOffset is set) before we reactivate — avoids the race where a mid-load write triggers reactivation with lastOffset=0
+- [ ] keep existing `startTailingIfNeeded(id)` loop unchanged — it handles fresh-active-from-Discover; Reactivate handles the completed case
+- [ ] this design means the post-Discover sequence handles:
+  - already-active session: no-op (startTailingIfNeeded sees tailing, skips; Reactivate sees not-completed, skips)
+  - Discover flipped completed→active: startTailingIfNeeded starts tailing (from start)
+  - Discover kept completed, write event occurred: Reactivate resumes from lastOffset
+- [ ] add test: `TestWatcher_ReactivatesCompletedSessionOnWrite`:
+  - [ ] create progress file, pre-populate with initial content
+  - [ ] start watcher, wait for initial discovery to load content (state=completed, lastOffset > 0)
+  - [ ] append new lines to file (triggers fsnotify Write)
+  - [ ] assert state transitions to `active` and NEW lines arrive via SSE (subscribe and consume events) — verify that the pre-existing content is NOT re-emitted after reactivation
+- [ ] add test: `TestWatcher_DoesNotReactivateActiveSession` — session already active + tailing, write event should not spawn duplicate tailer. Assertion: subscribe to SSE, write a line, verify exactly one event arrives (no duplication). Do NOT rely on tailer pointer identity or goroutine counts — those helpers don't exist and would add test-only APIs
+- [ ] add test: `TestWatcher_OnlyReactivatesWrittenPath` — create two progress files in same dir, both completed; write to one only; verify only that session is reactivated, the other stays completed
+- [ ] run tests: `go test ./pkg/web/... -run Watcher` must pass before next task
+- [ ] **re-run the Task 0 reproduction test** `TestWatcher_ResumesStreamingAfterFlockRace` — it must now pass (this is the green half of red-green-refactor for the bug fix)
+
+### Task 6: Verify acceptance criteria
+
+- [ ] re-read issue #283 and confirm Option B semantics match this implementation
+- [ ] run full test suite: `make test`
+- [ ] verify race-free: `go test -race ./pkg/web/...`
+- [ ] run linter: `make lint` (fix all issues — no "pre-existing" dismissals)
+- [ ] run formatter: `make fmt`
+- [ ] check coverage: `go test -cover ./pkg/web/...` — must be >=80% for touched files, ideally no regression
+
+### Task 7: End-to-end toy-project verification
+
+- [ ] build fresh binary: `make build`
+- [ ] prepare toy project: `./scripts/internal/prep-toy-test.sh`
+- [ ] terminal A: start watch-mode dashboard — `.bin/ralphex -s -w /tmp/ralphex-test`
+- [ ] terminal B: from `/tmp/ralphex-test`, run `.../ralphex docs/plans/fix-issues.md` (without `-s`)
+- [ ] open dashboard in browser, confirm live log streaming
+- [ ] leave running past the 5-second `RefreshStates` tick; confirm streaming does NOT freeze mid-run
+- [ ] confirm session flips back to active after any transient "completed" (check browser devtools or sidebar)
+- [ ] kill executor mid-run; confirm tailing stops cleanly (no zombie tailers) and session shows completed
+
+### Task 8: [Final] Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (only if an existing section describes watcher/session-state behavior)
+
+- [ ] `grep -n "watch" CLAUDE.md` and `grep -n "RefreshStates\|session" CLAUDE.md`; if an existing section describes the affected behavior, append a one-line note about reactivation-on-write. Do NOT add a new section speculatively
+- [ ] `grep -rn "watch mode\|RefreshStates\|flock" docs/` — if any existing doc describes the flock-based detection, update to mention the recovery path
+- [ ] update this plan file: mark all tasks `[x]`
+- [ ] move plan: `mkdir -p docs/plans/completed && git mv docs/plans/20260424-watch-mode-reactivate-tailing.md docs/plans/completed/`
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems — no checkboxes, informational only*
+
+**Manual verification:**
+- pm2 deployment pattern (actual reporter's setup): separate `pm2 start ralphex -s -w /path` + tmux-launched executor
+- verify dashboard survives a long run (>1 hour) without freezing
+
+**External system updates:**
+- after merge, comment on issue #283 linking the PR and asking pkondaurov to verify in his pm2 setup
+- no changelog entry required during development (per project rules — release process handles it)

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -169,9 +169,9 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 - Modify: `pkg/web/session.go`
 - Modify: `pkg/web/session_test.go`
 
-- [ ] add private `lastOffset int64` field on `Session` (guarded by `s.mu`)
-- [ ] add **unexported** `getLastOffset() int64` and `setLastOffset(offset int64)` accessors (thread-safe). Keep them unexported — tests are in-package, loader and StopTailing are in the same package. Per the user's convention: do not export without an out-of-package caller
-- [ ] modify `StopTailing()` — before nilling `stopTailCh`, capture `tailer.Offset()` and store in `s.lastOffset` (under the same write lock). Pseudocode:
+- [x] add private `lastOffset int64` field on `Session` (guarded by `s.mu`)
+- [x] add **unexported** `getLastOffset() int64` and `setLastOffset(offset int64)` accessors (thread-safe). Keep them unexported — tests are in-package, loader and StopTailing are in the same package. Per the user's convention: do not export without an out-of-package caller
+- [x] modify `StopTailing()` — before nilling `stopTailCh`, capture `tailer.Offset()` and store in `s.lastOffset` (under the same write lock). Pseudocode:
   ```go
   s.mu.Lock()
   if s.tailer != nil {
@@ -182,9 +182,9 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
   s.mu.Unlock()
   if tailer != nil { tailer.Stop() }
   ```
-- [ ] add test: `TestSession_LastOffset` — verifies get/set thread-safety via concurrent goroutines (use the in-package unexported names)
-- [ ] add test: `TestSession_StopTailingCapturesOffset` — start tailing, write lines, wait for ingest (poll until events received), stop, verify `getLastOffset()` > 0 and roughly matches bytes written
-- [ ] run tests: `go test ./pkg/web/... -run Session` must pass before next task
+- [x] add test: `TestSession_LastOffset` — verifies get/set thread-safety via concurrent goroutines (use the in-package unexported names)
+- [x] add test: `TestSession_StopTailingCapturesOffset` — start tailing, write lines, wait for ingest (poll until events received), stop, verify `getLastOffset()` > 0 and roughly matches bytes written
+- [x] run tests: `go test ./pkg/web/... -run Session` must pass before next task
 
 ### Task 3: Add Session.Reactivate() method
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -219,7 +219,7 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 - Modify: `pkg/web/session_progress.go`
 - Modify: `pkg/web/session_progress_test.go`
 
-- [ ] in `loadProgressFileIntoSession`, accumulate bytes read during the loop:
+- [x] in `loadProgressFileIntoSession`, accumulate bytes read during the loop:
   ```go
   var bytesRead int64
   for {
@@ -231,12 +231,12 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
   }
   session.setLastOffset(bytesRead)
   ```
-- [ ] **Key detail:** count `len(line)` BEFORE `trimLineEnding` — `ReadString('\n')` returns the delimiter included, so the raw length covers LF, CRLF, and no-trailing-newline (final partial read on EOF) correctly. Do NOT compute offset by summing trimmed length + constant — CRLF would be undercounted by 1 byte
-- [ ] add test: `TestLoadProgressFileIntoSession_RecordsOffset_LF` — load file with `\n`-only endings, verify `getLastOffset()` equals file byte size
-- [ ] add test: `TestLoadProgressFileIntoSession_RecordsOffset_CRLF` — load file with `\r\n` endings, verify offset equals byte size (critical regression guard)
-- [ ] add test: `TestLoadProgressFileIntoSession_EmptyFile` — verify offset is 0 (no regression)
-- [ ] add test: `TestLoadProgressFileIntoSession_NoTrailingNewline` — last line lacks `\n`, verify offset still equals byte size
-- [ ] run tests: `go test ./pkg/web/... -run Load` must pass before next task
+- [x] **Key detail:** count `len(line)` BEFORE `trimLineEnding` — `ReadString('\n')` returns the delimiter included, so the raw length covers LF, CRLF, and no-trailing-newline (final partial read on EOF) correctly. Do NOT compute offset by summing trimmed length + constant — CRLF would be undercounted by 1 byte
+- [x] add test: `TestLoadProgressFileIntoSession_RecordsOffset_LF` — load file with `\n`-only endings, verify `getLastOffset()` equals file byte size
+- [x] add test: `TestLoadProgressFileIntoSession_RecordsOffset_CRLF` — load file with `\r\n` endings, verify offset equals byte size (critical regression guard)
+- [x] add test: `TestLoadProgressFileIntoSession_EmptyFile` — verify offset is 0 (no regression)
+- [x] add test: `TestLoadProgressFileIntoSession_NoTrailingNewline` — last line lacks `\n`, verify offset still equals byte size
+- [x] run tests: `go test ./pkg/web/... -run Load` must pass before next task
 
 ### Task 5: Reactivate on write in Watcher
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -132,16 +132,16 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 **Files:**
 - Modify: `pkg/web/watcher_test.go`
 
-- [ ] add test `TestWatcher_ResumesStreamingAfterFlockRace`:
-  - [ ] create a temp dir + progress file, write the standard header and some initial lines
-  - [ ] create SessionManager + Watcher (real fsnotify), start with context
-  - [ ] wait for initial discovery (poll session state until non-nil, sanity check)
-  - [ ] simulate the flock race: force the session state to `SessionStateCompleted` via `session.SetState(SessionStateCompleted)` and stop tailing via `session.StopTailing()` (this models what `RefreshStates` does when TryLockFile transiently succeeds)
-  - [ ] append new lines to the progress file
-  - [ ] assert within a generous timeout (~500ms) that the session state returns to `SessionStateActive` and the new lines arrive via SSE — tests poll for state and consume from `session.SSE` subscription or use the tail/event interface existing tests use
-  - [ ] run the test: `go test ./pkg/web/... -run TestWatcher_ResumesStreamingAfterFlockRace` — **MUST FAIL on master** (this confirms the bug is reproducible)
-- [ ] document the expected failure in the test with a comment referencing issue #283
-- [ ] **Do NOT commit the failing test as a separate commit** — it would land a red commit on the branch and break bisect. Keep the test uncommitted (or bundle with Task 5 commit) until it passes. If TDD hygiene is desired, `t.Skip` the test in its own commit then un-skip in Task 5
+- [x] add test `TestWatcher_ResumesStreamingAfterFlockRace`:
+  - [x] create a temp dir + progress file, write the standard header and some initial lines
+  - [x] create SessionManager + Watcher (real fsnotify), start with context
+  - [x] wait for initial discovery (poll session state until non-nil, sanity check)
+  - [x] simulate the flock race: force the session state to `SessionStateCompleted` via `session.SetState(SessionStateCompleted)` and stop tailing via `session.StopTailing()` (this models what `RefreshStates` does when TryLockFile transiently succeeds)
+  - [x] append new lines to the progress file
+  - [x] assert within a generous timeout (~500ms) that the session state returns to `SessionStateActive` and the new lines arrive via SSE — tests poll for state and consume from `session.SSE` subscription or use the tail/event interface existing tests use
+  - [x] run the test: `go test ./pkg/web/... -run TestWatcher_ResumesStreamingAfterFlockRace` — **MUST FAIL on master** (this confirms the bug is reproducible)
+- [x] document the expected failure in the test with a comment referencing issue #283
+- [x] **Do NOT commit the failing test as a separate commit** — it would land a red commit on the branch and break bisect. Keep the test uncommitted (or bundle with Task 5 commit) until it passes. If TDD hygiene is desired, `t.Skip` the test in its own commit then un-skip in Task 5
 
 ### Task 1: Expose offset and seek-to-offset on Tailer
 

--- a/docs/plans/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/20260424-watch-mode-reactivate-tailing.md
@@ -192,26 +192,26 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 - Modify: `pkg/web/session.go`
 - Modify: `pkg/web/session_test.go`
 
-- [ ] define private enum `tailerStartMode` with values `modeFromStart`, `modeFromEnd`, `modeResume` (type int, const block)
-- [ ] extract a private helper `startTailerLocked(mode tailerStartMode, offset int64) error` with **lock-held contract** (caller must hold `s.mu` write lock). Behavior:
+- [x] define private enum `tailerStartMode` with values `modeFromStart`, `modeFromEnd`, `modeResume` (type int, const block)
+- [x] extract a private helper `startTailerLocked(mode tailerStartMode, offset int64) error` with **lock-held contract** (caller must hold `s.mu` write lock). Behavior:
   - create new `Tailer` at `s.Path`
   - dispatch on mode: `modeFromStart` → `tailer.Start(true)`, `modeFromEnd` → `tailer.Start(false)`, `modeResume` → `tailer.StartFromOffset(offset)`
   - on error, return error; do not store tailer or allocate stopTailCh
   - on success, set `s.tailer`, create `s.stopTailCh = make(chan struct{})`, launch `go s.feedEvents()` (goroutine acquires its own RLock; safe because caller unlocks after return)
-- [ ] refactor existing `StartTailing(fromStart bool) error` to use `startTailerLocked(modeFromStart or modeFromEnd, 0)` — keep public signature and behavior identical, existing tests still pass
-- [ ] add `Reactivate() error` on `Session`:
-  - [ ] `s.mu.Lock(); defer s.mu.Unlock()`
-  - [ ] if `s.tailer != nil && s.tailer.IsRunning()`, return nil (idempotent)
-  - [ ] capture `offset := s.lastOffset`
-  - [ ] choose mode: if `offset > 0` use `modeResume`, else use `modeFromEnd` (NOT `modeFromStart` — that would re-emit the whole file if lastOffset was never set; `modeFromEnd` is safe because the loader already loaded historical content into SSE replay)
-  - [ ] call `startTailerLocked(mode, offset)` — if it returns error, return it without touching state
-  - [ ] on success: `s.state = SessionStateActive` (only after tailer confirmed started — avoids lying about state if tailer-start fails)
-- [ ] add godoc on `Reactivate` explaining: called when a completed session receives a write event; resumes from `lastOffset` to avoid duplicating events already in SSE replay buffer
-- [ ] add test: `TestSession_Reactivate_ResumesFromOffset` — start tailing, stop (records offset), write more lines, Reactivate, verify SSE receives only new lines (no duplicates from before stop)
-- [ ] add test: `TestSession_Reactivate_Idempotent` — call Reactivate twice in quick succession, verify only one tailer exists and no duplicate events
-- [ ] add test: `TestSession_Reactivate_OnClosedSession` — call after Close, verify graceful error (no panic) and state not flipped to active
-- [ ] add test: `TestSession_Reactivate_FailedStartLeavesStateUnchanged` — use a session with non-existent path, verify Reactivate returns error and state stays completed
-- [ ] run tests: `go test ./pkg/web/... -run Session` must pass before next task
+- [x] refactor existing `StartTailing(fromStart bool) error` to use `startTailerLocked(modeFromStart or modeFromEnd, 0)` — keep public signature and behavior identical, existing tests still pass
+- [x] add `Reactivate() error` on `Session`:
+  - [x] `s.mu.Lock(); defer s.mu.Unlock()`
+  - [x] if `s.tailer != nil && s.tailer.IsRunning()`, return nil (idempotent)
+  - [x] capture `offset := s.lastOffset`
+  - [x] choose mode: if `offset > 0` use `modeResume`, else use `modeFromEnd` (NOT `modeFromStart` — that would re-emit the whole file if lastOffset was never set; `modeFromEnd` is safe because the loader already loaded historical content into SSE replay)
+  - [x] call `startTailerLocked(mode, offset)` — if it returns error, return it without touching state
+  - [x] on success: `s.state = SessionStateActive` (only after tailer confirmed started — avoids lying about state if tailer-start fails)
+- [x] add godoc on `Reactivate` explaining: called when a completed session receives a write event; resumes from `lastOffset` to avoid duplicating events already in SSE replay buffer
+- [x] add test: `TestSession_Reactivate_ResumesFromOffset` — start tailing, stop (records offset), write more lines, Reactivate, verify SSE receives only new lines (no duplicates from before stop)
+- [x] add test: `TestSession_Reactivate_Idempotent` — call Reactivate twice in quick succession, verify only one tailer exists and no duplicate events
+- [x] add test: `TestSession_Reactivate_OnClosedSession` — call after Close, verify graceful error (no panic) and state not flipped to active
+- [x] add test: `TestSession_Reactivate_FailedStartLeavesStateUnchanged` — use a session with non-existent path, verify Reactivate returns error and state stays completed
+- [x] run tests: `go test ./pkg/web/... -run Session` must pass before next task
 
 ### Task 4: Record offset after loadProgressFileIntoSession
 

--- a/docs/plans/completed/20260424-watch-mode-reactivate-tailing.md
+++ b/docs/plans/completed/20260424-watch-mode-reactivate-tailing.md
@@ -289,10 +289,10 @@ The feedEvents goroutine acquires its own `RLock` once running — no deadlock b
 **Files:**
 - Modify: `CLAUDE.md` (only if an existing section describes watcher/session-state behavior)
 
-- [ ] `grep -n "watch" CLAUDE.md` and `grep -n "RefreshStates\|session" CLAUDE.md`; if an existing section describes the affected behavior, append a one-line note about reactivation-on-write. Do NOT add a new section speculatively
-- [ ] `grep -rn "watch mode\|RefreshStates\|flock" docs/` — if any existing doc describes the flock-based detection, update to mention the recovery path
-- [ ] update this plan file: mark all tasks `[x]`
-- [ ] move plan: `mkdir -p docs/plans/completed && git mv docs/plans/20260424-watch-mode-reactivate-tailing.md docs/plans/completed/`
+- [x] `grep -n "watch" CLAUDE.md` and `grep -n "RefreshStates\|session" CLAUDE.md`; if an existing section describes the affected behavior, append a one-line note about reactivation-on-write. Do NOT add a new section speculatively
+- [x] `grep -rn "watch mode\|RefreshStates\|flock" docs/` — if any existing doc describes the flock-based detection, update to mention the recovery path
+- [x] update this plan file: mark all tasks `[x]`
+- [x] move plan: `mkdir -p docs/plans/completed && git mv docs/plans/20260424-watch-mode-reactivate-tailing.md docs/plans/completed/`
 
 ## Post-Completion
 

--- a/pkg/web/flock_helper_unix_test.go
+++ b/pkg/web/flock_helper_unix_test.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package web
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// holdFileLockForTest opens path and acquires a blocking exclusive flock,
+// returning a release function that unlocks and closes the file. used by
+// watcher tests that need IsActive(path) to report true (cross-process
+// flock detection). on Windows there is no flock, so the helper is unix-only;
+// callers must skip via runtime.GOOS == "windows".
+func holdFileLockForTest(t *testing.T, path string) func() {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600) //nolint:gosec // test-controlled path from t.TempDir
+	require.NoError(t, err)
+	require.NoError(t, syscall.Flock(int(f.Fd()), syscall.LOCK_EX))
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+}

--- a/pkg/web/flock_helper_windows_test.go
+++ b/pkg/web/flock_helper_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package web
+
+import "testing"
+
+// holdFileLockForTest is a no-op on Windows since the package's flock-based
+// activity detection is disabled there (IsActive always returns false).
+// callers that need a real cross-process active state must skip on Windows.
+func holdFileLockForTest(t *testing.T, _ string) func() {
+	t.Helper()
+	t.Skip("flock-based active detection is unix-only")
+	return func() {}
+}

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -119,6 +119,17 @@ type Session struct {
 	// it. empty string means nothing is pending.
 	lastPendingSection string
 	lastPendingPhase   status.Phase
+
+	// stopping is true while StopTailing is mid-flight (between the first
+	// locked section that captures tailer/stopCh/feedDone and the final
+	// locked section that records lastOffset/lastPhase). during that window
+	// s.mu is released so tailer.Stop() and feedEvents drain can run without
+	// blocking other readers; without this flag a concurrent Reactivate /
+	// StartTailing would see s.tailer.IsRunning()==false (tailer stopped)
+	// with a STALE s.lastOffset (not yet captured) and start a new tailer
+	// from the wrong byte position, duplicating or losing events in the
+	// exact flock-race recovery path this PR is meant to fix.
+	stopping bool
 }
 
 // NewSession creates a new session for the given progress file path.
@@ -333,10 +344,16 @@ func (s *Session) startTailerLocked(mode tailerStartMode, offset int64) error {
 
 // StartTailing begins tailing the progress file and feeding events to SSE clients.
 // if fromStart is true, reads from the beginning of the file.
-// does nothing if already tailing.
+// does nothing if already tailing, or if StopTailing is currently in progress
+// (caller must retry once stopping finishes — the watcher naturally does this
+// on the next Write event).
 func (s *Session) StartTailing(fromStart bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.stopping {
+		return nil // StopTailing mid-flight; caller retries on next event
+	}
 
 	if s.tailer != nil && s.tailer.IsRunning() {
 		return nil // already tailing
@@ -359,12 +376,22 @@ func (s *Session) StartTailing(fromStart bool) error {
 // state as-is (the caller is responsible for having checked it). on
 // tailer-start failure, returns the error and leaves state unchanged.
 //
+// if StopTailing is currently in progress on another goroutine, returns nil
+// without starting a new tailer. lastOffset has not yet been captured at that
+// point, so starting now would use a stale offset and duplicate/lose events.
+// the watcher will re-call Reactivate on the next Write event, which lands
+// after StopTailing completes and observes the correct lastOffset.
+//
 // callers should verify the session is in the SessionStateCompleted state and
 // IsLoaded() before invoking this method; the watcher gates it that way to
 // avoid racing with the initial progress-file loader.
 func (s *Session) Reactivate() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.stopping {
+		return nil // StopTailing mid-flight; watcher retries on next Write event
+	}
 
 	if s.tailer != nil && s.tailer.IsRunning() {
 		return nil
@@ -399,10 +426,23 @@ func (s *Session) Reactivate() error {
 // while their bytes are already accounted for in tailer.Offset(), creating a
 // gap in the SSE stream after Reactivate resumes from lastOffset.
 //
+// concurrency: the s.stopping flag is set under s.mu for the entire duration
+// of tailer.Stop()+feedEvents drain, so a concurrent Reactivate/StartTailing
+// that acquires s.mu during the unlocked drain window observes stopping=true
+// and returns without starting a new tailer on a stale lastOffset. the final
+// locked section clears stopping and nils out s.tailer so subsequent calls
+// see a clean slate.
+//
 // if no tailer is running, all last* fields are preserved. safe to call
-// concurrently and repeatedly.
+// concurrently and repeatedly; if two StopTailing calls race, the second
+// observes s.tailer==nil and returns without touching captured fields.
 func (s *Session) StopTailing() {
 	s.mu.Lock()
+	if s.tailer == nil {
+		s.mu.Unlock()
+		return
+	}
+	s.stopping = true
 	tailer := s.tailer
 	stopCh := s.stopTailCh
 	feedDone := s.feedDoneCh
@@ -412,9 +452,7 @@ func (s *Session) StopTailing() {
 
 	// stop the tailer first so no more events are pushed into eventCh.
 	// tailer.Stop() is idempotent and blocks until the tail loop has exited.
-	if tailer != nil {
-		tailer.Stop()
-	}
+	tailer.Stop()
 
 	// signal feedEvents to drain any remaining buffered events and exit.
 	// stopCh is only closed once because it was nil-swapped under the lock.
@@ -429,13 +467,13 @@ func (s *Session) StopTailing() {
 		<-feedDone
 	}
 
-	if tailer != nil {
-		s.mu.Lock()
-		s.lastOffset = tailer.Offset()
-		s.lastPhase = tailer.Phase()
-		s.lastPendingSection, s.lastPendingPhase = tailer.PendingSection()
-		s.mu.Unlock()
-	}
+	s.mu.Lock()
+	s.lastOffset = tailer.Offset()
+	s.lastPhase = tailer.Phase()
+	s.lastPendingSection, s.lastPendingPhase = tailer.PendingSection()
+	s.tailer = nil
+	s.stopping = false
+	s.mu.Unlock()
 }
 
 // getLastOffset returns the byte offset of the last ingested content.

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/tmaxmax/go-sse"
+
+	"github.com/umputun/ralphex/pkg/status"
 )
 
 // DefaultReplayerSize is the maximum number of events to keep for replay to late-joining clients.
@@ -84,6 +86,15 @@ type Session struct {
 	// stopTailCh signals the tail feeder goroutine to stop
 	stopTailCh chan struct{}
 
+	// feedDoneCh is closed by the tail feeder goroutine when it returns.
+	// StopTailing waits on this channel so that by the time it returns, the
+	// feeder has drained any remaining events from the tailer's eventCh and
+	// published them. without this wait, events buffered in eventCh between
+	// tailer.Offset() advancing (in readNewLines) and feedEvents consuming
+	// them could be silently dropped when stopTailCh is closed, leaving a
+	// gap between lastOffset and what was actually published to SSE.
+	feedDoneCh chan struct{}
+
 	// loaded tracks whether historical data has been loaded into the SSE server
 	loaded bool
 
@@ -91,6 +102,23 @@ type Session struct {
 	// already ingested (via the loader or a previous tailer). used by Reactivate
 	// to resume tailing without re-emitting events into the SSE replay buffer.
 	lastOffset int64
+
+	// lastPhase is the parser phase after the last ingested byte (from the
+	// loader or a previous tailer). used by Reactivate so a new tailer picks
+	// up the correct phase for subsequent lines, rather than defaulting to
+	// PhaseTask until the next section header. empty string means "unknown",
+	// in which case the tailer's configured default phase is used.
+	lastPhase status.Phase
+
+	// lastPendingSection / lastPendingPhase carry a deferred section header
+	// that a previous tailer read but never emitted (the section/task-start
+	// event is only published when the next timestamped/output line arrives).
+	// used by Reactivate so that if a tailer is stopped between reading a
+	// section header and reading the following line, the new tailer still
+	// emits the section event on the next line instead of silently dropping
+	// it. empty string means nothing is pending.
+	lastPendingSection string
+	lastPendingPhase   status.Phase
 }
 
 // NewSession creates a new session for the given progress file path.
@@ -221,6 +249,27 @@ func (s *Session) MarkLoadedIfNot() bool {
 	return true
 }
 
+// resetForNewRun clears per-run state for a progress file that was truncated
+// and re-initialized by a new ralphex invocation. callers must have observed
+// that the header's Started: timestamp changed, indicating the stored offset
+// and loader state no longer correspond to current file content. callers are
+// also responsible for stopping any ongoing tailer before invoking this method
+// so offset capture in StopTailing does not race with the reset.
+//
+// SSE replay buffer is intentionally not cleared: the go-sse FiniteReplayer
+// has no clear primitive, and stale events from the previous run will age out
+// of the fixed-size buffer as the new run publishes events.
+func (s *Session) resetForNewRun() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastOffset = 0
+	s.lastPhase = ""
+	s.lastPendingSection = ""
+	s.lastPendingPhase = ""
+	s.loaded = false
+	s.diffStats = nil
+}
+
 // tailerStartMode selects how startTailerLocked begins tailing.
 type tailerStartMode int
 
@@ -236,8 +285,27 @@ const (
 // blocks on s.mu.RLock() until the caller releases s.mu, then picks up the
 // newly assigned s.tailer/s.stopTailCh. on error, s.tailer and s.stopTailCh
 // are left unchanged.
+//
+// for modeResume and modeFromEnd, the tailer is pre-seeded with s.lastPhase
+// (if set) so lines emitted after resume carry the correct phase. modeFromStart
+// uses the tailer's default phase because it re-reads the whole file and will
+// encounter section headers that update the phase naturally.
+//
+// for modeResume, the tailer is additionally pre-seeded with any pending
+// section state captured when the previous tailer was stopped (see
+// StopTailing). this ensures a section header read but not yet emitted by
+// the previous tailer is still emitted by the resumed tailer on the next
+// line, instead of being silently dropped across the restart.
 func (s *Session) startTailerLocked(mode tailerStartMode, offset int64) error {
-	tailer := NewTailer(s.Path, DefaultTailerConfig())
+	cfg := DefaultTailerConfig()
+	if mode != modeFromStart && s.lastPhase != "" {
+		cfg.InitialPhase = s.lastPhase
+	}
+	if mode == modeResume {
+		cfg.PendingSection = s.lastPendingSection
+		cfg.PendingPhase = s.lastPendingPhase
+	}
+	tailer := NewTailer(s.Path, cfg)
 
 	var err error
 	switch mode {
@@ -254,9 +322,12 @@ func (s *Session) startTailerLocked(mode tailerStartMode, offset int64) error {
 		return err
 	}
 
+	stopCh := make(chan struct{})
+	feedDone := make(chan struct{})
 	s.tailer = tailer
-	s.stopTailCh = make(chan struct{})
-	go s.feedEvents()
+	s.stopTailCh = stopCh
+	s.feedDoneCh = feedDone
+	go s.feedEvents(tailer, stopCh, feedDone)
 	return nil
 }
 
@@ -313,24 +384,57 @@ func (s *Session) Reactivate() error {
 	return nil
 }
 
-// StopTailing stops the tailer and event feeder goroutine.
-// captures the tailer's current byte offset into lastOffset before stopping,
-// so a subsequent Reactivate can resume from the exact byte where tailing stopped.
-// if no tailer is running, lastOffset is preserved.
+// StopTailing stops the tailer and event feeder goroutine, then captures the
+// tailer's final byte offset, parser phase, and any deferred section state
+// into lastOffset, lastPhase, and lastPendingSection/Phase so a subsequent
+// Reactivate can resume from the exact byte where tailing stopped with the
+// correct phase AND still emit any section header event the previous tailer
+// had read but not yet published.
+//
+// ordering matters: the tailer is stopped first (blocking until its tail loop
+// has exited, so eventCh receives no more writes), then stopTailCh is closed
+// and feedEvents drains any remaining buffered events before returning. only
+// then is lastOffset captured. without this synchronization, events buffered
+// in the tailer's eventCh could be dropped by a racing select on stopTailCh
+// while their bytes are already accounted for in tailer.Offset(), creating a
+// gap in the SSE stream after Reactivate resumes from lastOffset.
+//
+// if no tailer is running, all last* fields are preserved. safe to call
+// concurrently and repeatedly.
 func (s *Session) StopTailing() {
 	s.mu.Lock()
-	if s.tailer != nil {
-		s.lastOffset = s.tailer.Offset()
-	}
-	if s.stopTailCh != nil {
-		close(s.stopTailCh)
-		s.stopTailCh = nil
-	}
 	tailer := s.tailer
+	stopCh := s.stopTailCh
+	feedDone := s.feedDoneCh
+	s.stopTailCh = nil
+	s.feedDoneCh = nil
 	s.mu.Unlock()
 
+	// stop the tailer first so no more events are pushed into eventCh.
+	// tailer.Stop() is idempotent and blocks until the tail loop has exited.
 	if tailer != nil {
 		tailer.Stop()
+	}
+
+	// signal feedEvents to drain any remaining buffered events and exit.
+	// stopCh is only closed once because it was nil-swapped under the lock.
+	if stopCh != nil {
+		close(stopCh)
+	}
+
+	// wait for feedEvents to finish draining. after this returns, every event
+	// the tailer produced has been published to SSE, so capturing tailer.Offset()
+	// below gives a resume point whose bytes have all been published.
+	if feedDone != nil {
+		<-feedDone
+	}
+
+	if tailer != nil {
+		s.mu.Lock()
+		s.lastOffset = tailer.Offset()
+		s.lastPhase = tailer.Phase()
+		s.lastPendingSection, s.lastPendingPhase = tailer.PendingSection()
+		s.mu.Unlock()
 	}
 }
 
@@ -348,6 +452,23 @@ func (s *Session) setLastOffset(offset int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastOffset = offset
+}
+
+// getLastPhase returns the parser phase after the last ingested byte, or an
+// empty phase if nothing has been ingested yet. package-internal accessor,
+// thread-safe.
+func (s *Session) getLastPhase() status.Phase {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastPhase
+}
+
+// setLastPhase updates the parser phase after the last ingested byte.
+// package-internal accessor, thread-safe.
+func (s *Session) setLastPhase(phase status.Phase) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastPhase = phase
 }
 
 // IsTailing returns whether the session is currently tailing its progress file.
@@ -368,33 +489,54 @@ func (s *Session) Publish(event Event) error {
 }
 
 // feedEvents reads events from the tailer and publishes them to SSE clients.
-func (s *Session) feedEvents() {
-	s.mu.RLock()
-	tailer := s.tailer
-	stopCh := s.stopTailCh
-	s.mu.RUnlock()
+// the tailer, stopCh, and feedDone are captured at spawn time in startTailerLocked
+// and passed explicitly so the goroutine is not subject to field reassignment
+// races. when stopCh is signaled, feedEvents drains any remaining events from
+// the tailer's eventCh before returning, so published bytes match tailer.Offset()
+// (StopTailing guarantees the tailer is stopped before closing stopCh, so the
+// pending events in eventCh are a bounded final set).
+func (s *Session) feedEvents(tailer *Tailer, stopCh, feedDone chan struct{}) {
+	defer close(feedDone)
 
 	if tailer == nil {
 		return
 	}
 
 	eventCh := tailer.Events()
+	publish := func(event Event) {
+		if event.Type == EventTypeOutput {
+			if stats, ok := parseDiffStats(event.Text); ok {
+				s.SetDiffStats(stats)
+			}
+		}
+		if err := s.Publish(event); err != nil {
+			log.Printf("[WARN] failed to publish tailed event: %v", err)
+		}
+	}
+
 	for {
 		select {
 		case <-stopCh:
-			return
+			// stopCh is closed only after tailer.Stop() has returned (see
+			// StopTailing), so no more events will be pushed into eventCh.
+			// drain the remaining buffered events so that offsets captured
+			// from the tailer match bytes actually published to SSE.
+			for {
+				select {
+				case event, ok := <-eventCh:
+					if !ok {
+						return
+					}
+					publish(event)
+				default:
+					return
+				}
+			}
 		case event, ok := <-eventCh:
 			if !ok {
 				return
 			}
-			if event.Type == EventTypeOutput {
-				if stats, ok := parseDiffStats(event.Text); ok {
-					s.SetDiffStats(stats)
-				}
-			}
-			if err := s.Publish(event); err != nil {
-				log.Printf("[WARN] failed to publish tailed event: %v", err)
-			}
+			publish(event)
 		}
 	}
 }

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -221,6 +221,44 @@ func (s *Session) MarkLoadedIfNot() bool {
 	return true
 }
 
+// tailerStartMode selects how startTailerLocked begins tailing.
+type tailerStartMode int
+
+const (
+	modeFromStart tailerStartMode = iota // read from beginning of file
+	modeFromEnd                          // seek to end (only new writes are emitted)
+	modeResume                           // resume from a stored byte offset
+)
+
+// startTailerLocked creates and starts a new tailer according to mode.
+// the caller MUST hold s.mu as a write lock. on success, the new tailer is
+// stored on the session and a feedEvents goroutine is launched; the goroutine
+// acquires its own RLock and is safe because the caller releases s.mu after
+// this helper returns. on error, no state is mutated.
+func (s *Session) startTailerLocked(mode tailerStartMode, offset int64) error {
+	tailer := NewTailer(s.Path, DefaultTailerConfig())
+
+	var err error
+	switch mode {
+	case modeFromStart:
+		err = tailer.Start(true)
+	case modeFromEnd:
+		err = tailer.Start(false)
+	case modeResume:
+		err = tailer.StartFromOffset(offset)
+	default:
+		return fmt.Errorf("unknown tailer start mode: %d", mode)
+	}
+	if err != nil {
+		return err
+	}
+
+	s.tailer = tailer
+	s.stopTailCh = make(chan struct{})
+	go s.feedEvents()
+	return nil
+}
+
 // StartTailing begins tailing the progress file and feeding events to SSE clients.
 // if fromStart is true, reads from the beginning of the file.
 // does nothing if already tailing.
@@ -232,15 +270,44 @@ func (s *Session) StartTailing(fromStart bool) error {
 		return nil // already tailing
 	}
 
-	s.tailer = NewTailer(s.Path, DefaultTailerConfig())
-	if err := s.tailer.Start(fromStart); err != nil {
-		s.tailer = nil
+	mode := modeFromEnd
+	if fromStart {
+		mode = modeFromStart
+	}
+	return s.startTailerLocked(mode, 0)
+}
+
+// Reactivate resumes tailing a session that was previously marked completed,
+// e.g. after a flock race in RefreshStates that briefly observed the progress
+// file as unlocked. it resumes from the stored lastOffset so events already
+// in the SSE replay buffer (from the loader or a previous tailer) are not
+// re-emitted. on success, the session state is flipped back to active.
+//
+// idempotent: if a tailer is already running, returns nil without changing
+// state. on tailer-start failure, returns the error and leaves state unchanged.
+//
+// callers should verify the session is in the SessionStateCompleted state and
+// IsLoaded() before invoking this method; the watcher gates it that way to
+// avoid racing with the initial progress-file loader.
+func (s *Session) Reactivate() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.tailer != nil && s.tailer.IsRunning() {
+		return nil
+	}
+
+	offset := s.lastOffset
+	mode := modeFromEnd
+	if offset > 0 {
+		mode = modeResume
+	}
+
+	if err := s.startTailerLocked(mode, offset); err != nil {
 		return err
 	}
 
-	s.stopTailCh = make(chan struct{})
-	go s.feedEvents()
-
+	s.state = SessionStateActive
 	return nil
 }
 

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -233,8 +233,9 @@ const (
 // startTailerLocked creates and starts a new tailer according to mode.
 // the caller MUST hold s.mu as a write lock. on success, the new tailer is
 // stored on the session and a feedEvents goroutine is launched; the goroutine
-// acquires its own RLock and is safe because the caller releases s.mu after
-// this helper returns. on error, no state is mutated.
+// blocks on s.mu.RLock() until the caller releases s.mu, then picks up the
+// newly assigned s.tailer/s.stopTailCh. on error, s.tailer and s.stopTailCh
+// are left unchanged.
 func (s *Session) startTailerLocked(mode tailerStartMode, offset int64) error {
 	tailer := NewTailer(s.Path, DefaultTailerConfig())
 
@@ -281,10 +282,11 @@ func (s *Session) StartTailing(fromStart bool) error {
 // e.g. after a flock race in RefreshStates that briefly observed the progress
 // file as unlocked. it resumes from the stored lastOffset so events already
 // in the SSE replay buffer (from the loader or a previous tailer) are not
-// re-emitted. on success, the session state is flipped back to active.
+// re-emitted. on success, the session state is flipped to active.
 //
-// idempotent: if a tailer is already running, returns nil without changing
-// state. on tailer-start failure, returns the error and leaves state unchanged.
+// idempotent: if a tailer is already running, returns nil and leaves the
+// state as-is (the caller is responsible for having checked it). on
+// tailer-start failure, returns the error and leaves state unchanged.
 //
 // callers should verify the session is in the SessionStateCompleted state and
 // IsLoaded() before invoking this method; the watcher gates it that way to
@@ -314,6 +316,7 @@ func (s *Session) Reactivate() error {
 // StopTailing stops the tailer and event feeder goroutine.
 // captures the tailer's current byte offset into lastOffset before stopping,
 // so a subsequent Reactivate can resume from the exact byte where tailing stopped.
+// if no tailer is running, lastOffset is preserved.
 func (s *Session) StopTailing() {
 	s.mu.Lock()
 	if s.tailer != nil {

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -300,10 +300,11 @@ const (
 
 // startTailerLocked creates and starts a new tailer according to mode.
 // the caller MUST hold s.mu as a write lock. on success, the new tailer is
-// stored on the session and a feedEvents goroutine is launched; the goroutine
-// blocks on s.mu.RLock() until the caller releases s.mu, then picks up the
-// newly assigned s.tailer/s.stopTailCh. on error, s.tailer and s.stopTailCh
-// are left unchanged.
+// stored on the session, stopTailCh and feedDoneCh are allocated, and a
+// feedEvents goroutine is launched. the goroutine receives tailer, stopCh,
+// and feedDone as arguments captured at spawn time, so it does not depend on
+// reading session fields after launch and does not need to acquire s.mu.
+// on error, s.tailer, s.stopTailCh, and s.feedDoneCh are left unchanged.
 //
 // for modeResume and modeFromEnd, the tailer is pre-seeded with s.lastPhase
 // (if set) so lines emitted after resume carry the correct phase. modeFromStart

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -86,6 +86,11 @@ type Session struct {
 
 	// loaded tracks whether historical data has been loaded into the SSE server
 	loaded bool
+
+	// lastOffset is the byte offset into the progress file of the last byte
+	// already ingested (via the loader or a previous tailer). used by Reactivate
+	// to resume tailing without re-emitting events into the SSE replay buffer.
+	lastOffset int64
 }
 
 // NewSession creates a new session for the given progress file path.
@@ -240,8 +245,13 @@ func (s *Session) StartTailing(fromStart bool) error {
 }
 
 // StopTailing stops the tailer and event feeder goroutine.
+// captures the tailer's current byte offset into lastOffset before stopping,
+// so a subsequent Reactivate can resume from the exact byte where tailing stopped.
 func (s *Session) StopTailing() {
 	s.mu.Lock()
+	if s.tailer != nil {
+		s.lastOffset = s.tailer.Offset()
+	}
 	if s.stopTailCh != nil {
 		close(s.stopTailCh)
 		s.stopTailCh = nil
@@ -252,6 +262,22 @@ func (s *Session) StopTailing() {
 	if tailer != nil {
 		tailer.Stop()
 	}
+}
+
+// getLastOffset returns the byte offset of the last ingested content.
+// package-internal accessor, thread-safe.
+func (s *Session) getLastOffset() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastOffset
+}
+
+// setLastOffset updates the byte offset of the last ingested content.
+// package-internal accessor, thread-safe.
+func (s *Session) setLastOffset(offset int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastOffset = offset
 }
 
 // IsTailing returns whether the session is currently tailing its progress file.

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -68,6 +68,14 @@ const defaultTopic = "events"
 type Session struct {
 	mu sync.RWMutex
 
+	// stopMu serializes concurrent StopTailing invocations so that two callers
+	// cannot both observe s.tailer != nil, capture the same tailer reference,
+	// and race in the final critical section. without this, the second caller
+	// could clear stopping/tailer fields before the first caller's feedEvents
+	// drain completes — letting a Reactivate slip in on a stale lastOffset and
+	// then having the first caller's final lock clobber the new tailer.
+	stopMu sync.Mutex
+
 	// set once at creation, immutable after
 	ID   string      // unique identifier (derived from progress filename)
 	Path string      // full path to progress file
@@ -434,9 +442,16 @@ func (s *Session) Reactivate() error {
 // see a clean slate.
 //
 // if no tailer is running, all last* fields are preserved. safe to call
-// concurrently and repeatedly; if two StopTailing calls race, the second
-// observes s.tailer==nil and returns without touching captured fields.
+// concurrently and repeatedly; concurrent calls are serialized via stopMu so
+// the second caller observes s.tailer==nil after the first finishes and returns
+// without touching captured fields.
 func (s *Session) StopTailing() {
+	// serialize concurrent StopTailing calls; the unlocked drain window
+	// (between the first and final mu critical sections) cannot otherwise
+	// safely overlap, see stopMu doc on Session.
+	s.stopMu.Lock()
+	defer s.stopMu.Unlock()
+
 	s.mu.Lock()
 	if s.tailer == nil {
 		s.mu.Unlock()

--- a/pkg/web/session_manager.go
+++ b/pkg/web/session_manager.go
@@ -135,7 +135,46 @@ func (m *SessionManager) DiscoverRecursive(root string) ([]string, error) {
 
 // updateSession refreshes a session's state and metadata from its progress file.
 // handles starting/stopping tailing based on state transitions.
+//
+// the header's Started: timestamp is compared against the previously stored
+// metadata to detect a new ralphex run that reused the progress file (truncate
+// + rewrite). when a restart is detected, per-run state (lastOffset, loaded,
+// phase, pending section, diff stats) is reset before the state-transition
+// path runs, so the subsequent loader / tailer reads the fresh file from byte
+// 0 rather than seeking to the stale offset from the previous run. this
+// closes the truncation race where StartFromOffset's `offset > fileSize` check
+// misses the case where the new run has already grown past the old offset.
+//
+// the restart check and stored-metadata update are both gated on the header
+// being complete (terminating separator observed). a mid-write read can return
+// incomplete metadata with a zero StartTime; overwriting the stored value with
+// that zero would erase the previous run's StartTime and defeat the restart
+// detection on a later event when the full header is finally visible.
 func (m *SessionManager) updateSession(session *Session) error {
+	// parse header first so we can detect a new ralphex run that reused this
+	// progress file. a changed "Started:" timestamp means the file was
+	// truncated and re-initialized: the stored lastOffset is from the
+	// previous run and no longer corresponds to current content.
+	meta, headerComplete, err := ParseProgressHeader(session.Path)
+	if err != nil {
+		return fmt.Errorf("parse header: %w", err)
+	}
+	if headerComplete {
+		oldMeta := session.GetMetadata()
+		if !oldMeta.StartTime.IsZero() && !meta.StartTime.IsZero() &&
+			!oldMeta.StartTime.Equal(meta.StartTime) {
+			// new run on same file: stop any ongoing tailer (captures no useful
+			// offset since the file was replaced), then reset per-run state so
+			// handleStateTransition / MarkLoadedIfNot pick up the fresh content
+			// from byte 0 regardless of how far the new run has grown.
+			if session.IsTailing() {
+				session.StopTailing()
+			}
+			session.resetForNewRun()
+		}
+		session.SetMetadata(meta)
+	}
+
 	prevState := session.GetState()
 
 	// check if file is locked (active session)
@@ -151,31 +190,31 @@ func (m *SessionManager) updateSession(session *Session) error {
 	session.SetState(newState)
 
 	// handle state transitions for tailing
-	if prevState != newState {
-		if newState == SessionStateActive && !session.IsTailing() {
-			// session became active, start tailing from beginning to capture existing content
-			if tailErr := session.StartTailing(true); tailErr != nil {
-				log.Printf("[WARN] failed to start tailing for session %s: %v", session.ID, tailErr)
-			}
-		} else if newState == SessionStateCompleted && session.IsTailing() {
-			// session completed, stop tailing
-			session.StopTailing()
-		}
-	}
+	m.handleStateTransition(session, prevState, newState)
 
-	// for completed sessions that haven't been loaded yet, load the file content once
+	// for completed sessions that haven't been loaded yet, load the file content once.
 	// this handles sessions discovered after they finished.
 	// MarkLoadedIfNot is atomic to prevent double-loading from concurrent goroutines.
-	if newState == SessionStateCompleted && session.MarkLoadedIfNot() {
-		m.loadProgressFileIntoSession(session.Path, session)
+	// the lastOffset==0 guard prevents re-reading content a previous tailer already
+	// ingested: an active session tailed from the start can be marked completed by a
+	// RefreshStates flock race that captures the tailer's offset into lastOffset; if
+	// IsActive races false a second time here, newState stays completed and the
+	// loader would otherwise re-emit events the tailer has already published. we
+	// still mark the session loaded in that case so the watcher's IsLoaded gate
+	// allows Reactivate to resume tailing from the captured offset.
+	//
+	// gated on headerComplete so that a mid-write discovery (e.g. Windows, where
+	// IsActive is always false, or a rare Unix race where IsActive momentarily
+	// returns false) does not mark the session loaded and record a lastOffset
+	// pointing inside an unfinished header. without this gate, a later Reactivate
+	// would resume from mid-header and emit the remaining header lines as output
+	// events. the loader will run on a later updateSession call once the header
+	// separator is visible.
+	if newState == SessionStateCompleted && headerComplete && session.MarkLoadedIfNot() {
+		if session.getLastOffset() == 0 {
+			m.loadProgressFileIntoSession(session.Path, session)
+		}
 	}
-
-	// parse metadata from file header
-	meta, err := ParseProgressHeader(session.Path)
-	if err != nil {
-		return fmt.Errorf("parse header: %w", err)
-	}
-	session.SetMetadata(meta)
 
 	// update last modified time
 	info, err := os.Stat(session.Path)
@@ -185,6 +224,45 @@ func (m *SessionManager) updateSession(session *Session) error {
 	session.SetLastModified(info.ModTime())
 
 	return nil
+}
+
+// handleStateTransition starts or stops tailing for a session whose state just
+// changed. when a session becomes active with content already ingested
+// (lastOffset > 0), resumption goes through Reactivate so the SSE replay buffer
+// is not filled with duplicates; fresh-active sessions read from the beginning.
+// completed→no-op and active→active transitions do nothing.
+func (m *SessionManager) handleStateTransition(session *Session, prevState, newState SessionState) {
+	if prevState == newState {
+		return
+	}
+	switch {
+	case newState == SessionStateActive && !session.IsTailing():
+		m.activateSession(session)
+	case newState == SessionStateCompleted && session.IsTailing():
+		session.StopTailing()
+	}
+}
+
+// activateSession starts tailing for a session that just became active.
+// chooses between Reactivate (resume from stored offset) and StartTailing(true)
+// (read from the beginning) based on whether content has already been ingested.
+func (m *SessionManager) activateSession(session *Session) {
+	if session.getLastOffset() > 0 {
+		// content already in SSE replay (loader ran previously, or a
+		// previous tailer captured an offset before StopTailing). resume
+		// from the stored offset to avoid re-emitting events. this covers
+		// the flock-race recovery path: RefreshStates falsely marks a live
+		// session completed and captures the tailer offset; a later Write
+		// event triggers this transition back to active.
+		if err := session.Reactivate(); err != nil {
+			log.Printf("[WARN] failed to reactivate session %s: %v", session.ID, err)
+		}
+		return
+	}
+	// fresh discovery of an active session, read from the beginning
+	if err := session.StartTailing(true); err != nil {
+		log.Printf("[WARN] failed to start tailing for session %s: %v", session.ID, err)
+	}
 }
 
 // Get returns a session by ID, or nil if not found.

--- a/pkg/web/session_manager_test.go
+++ b/pkg/web/session_manager_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -434,6 +435,391 @@ Started: 2026-01-22 10:00:00
 
 	// verify the session is marked as loaded (content was published to SSE server)
 	assert.True(t, session.IsLoaded(), "completed session should be marked as loaded")
+}
+
+// TestSessionManager_UpdateSession_CompletedToActiveResumesFromOffset verifies
+// that when updateSession observes a completed -> active transition on a session
+// with content already ingested (lastOffset > 0), it resumes from the stored
+// offset via Reactivate rather than re-tailing the whole file from byte 0.
+// this is the flock-race recovery path: RefreshStates falsely marks a live
+// session completed and captures the offset, then Discover sees the flock
+// re-held and flips the state back to active.
+func TestSessionManager_UpdateSession_CompletedToActiveResumesFromOffset(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	require.NoError(t, os.WriteFile(planPath, []byte("# plan"), 0o600))
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	holder := &status.PhaseHolder{}
+	logger, err := progress.NewLogger(progress.Config{
+		PlanFile: planPath,
+		Mode:     "full",
+		Branch:   "main",
+	}, testColors(), holder)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	progressPath := logger.Path()
+
+	// write some content into the progress file so there is a non-trivial
+	// offset to resume from.
+	f, err := os.OpenFile(progressPath, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	_, err = f.WriteString("[26-01-22 10:00:01] early line\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	preRaceSize, err := os.Stat(progressPath)
+	require.NoError(t, err)
+
+	// set up a completed+loaded session with the pre-race offset, as if
+	// RefreshStates had just observed a transient flock release and stopped
+	// the tailer.
+	id := sessionIDFromPath(progressPath)
+	session := NewSession(id, progressPath)
+	session.SetState(SessionStateCompleted)
+	require.True(t, session.MarkLoadedIfNot())
+	session.setLastOffset(preRaceSize.Size())
+
+	m := NewSessionManager()
+	m.Register(session)
+
+	// the logger still holds the flock, so IsActive returns true.
+	active, err := IsActive(progressPath)
+	require.NoError(t, err)
+	require.True(t, active, "logger should still hold the flock")
+
+	// drive updateSession directly - this is the entry point for the
+	// completed -> active transition that the flock race exposes.
+	require.NoError(t, m.updateSession(session))
+
+	assert.Equal(t, SessionStateActive, session.GetState(),
+		"session should transition back to active")
+
+	// tailer must have resumed from the stored lastOffset, not rewound to 0.
+	require.Eventually(t, func() bool {
+		return session.IsTailing() && session.GetTailer() != nil
+	}, time.Second, 10*time.Millisecond, "tailer should be running after transition")
+
+	tailerOffset := session.GetTailer().Offset()
+	assert.GreaterOrEqual(t, tailerOffset, preRaceSize.Size(),
+		"tailer offset must be at or past the stored lastOffset; got %d, want >= %d",
+		tailerOffset, preRaceSize.Size())
+}
+
+// TestSessionManager_UpdateSession_CompletedKeepsOffsetSkipsLoader verifies that
+// when updateSession observes a completed session whose lastOffset > 0 (content
+// already ingested by a prior tailer) and the flock races false a second time
+// so newState stays completed, the historical-file loader is NOT run. otherwise
+// the loader would re-emit every event the tailer already published, duplicating
+// them in the SSE replay buffer. exercises the tailer-first / loader-second race
+// path that sits alongside the loader-first / tailer-second race the plan calls
+// out in its Concurrent loadProgressFileIntoSession design note.
+func TestSessionManager_UpdateSession_CompletedKeepsOffsetSkipsLoader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress-completed-with-offset.txt")
+
+	content := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+--- Task 1 ---
+[26-01-22 10:00:01] early line
+[26-01-22 10:00:02] another line
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	// model the state that a RefreshStates flock race would leave behind for
+	// an active session that was being tailed from the start:
+	//   - state = completed (RefreshStates saw a transient flock release)
+	//   - loaded = false (StartTailing(true) never marks loaded)
+	//   - lastOffset > 0 (StopTailing captured the tailer's byte offset)
+	id := sessionIDFromPath(path)
+	session := NewSession(id, path)
+	session.SetState(SessionStateCompleted)
+	const preRaceOffset int64 = 100
+	session.setLastOffset(preRaceOffset)
+	require.False(t, session.IsLoaded())
+
+	m := NewSessionManager()
+	m.Register(session)
+	t.Cleanup(func() { m.Close() })
+
+	// file is not locked, so IsActive returns false - this models the second
+	// flock race where updateSession observes the file as completed again.
+	active, err := IsActive(path)
+	require.NoError(t, err)
+	require.False(t, active, "file must not be locked to reproduce the race")
+
+	require.NoError(t, m.updateSession(session))
+
+	assert.Equal(t, SessionStateCompleted, session.GetState(),
+		"newState must stay completed when IsActive races false")
+	assert.True(t, session.IsLoaded(),
+		"session must be marked loaded so the watcher's Reactivate gate can fire")
+	assert.Equal(t, preRaceOffset, session.getLastOffset(),
+		"loader must not run: it would overwrite lastOffset with the file size and re-emit events")
+}
+
+// TestSessionManager_UpdateSession_DetectsFileRestart verifies that when a
+// progress file is reused by a new ralphex run (truncated + re-initialized
+// with a new Started: timestamp), updateSession resets per-run state so the
+// subsequent loader or tailer reads the fresh file from byte 0 rather than
+// seeking to the stale offset from the previous run. this closes the
+// truncation race where the new run can grow past the old offset before
+// StartFromOffset's `offset > fileSize` check would fire.
+func TestSessionManager_UpdateSession_DetectsFileRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress-restart.txt")
+
+	// simulate previous run: session has stored metadata, lastOffset > 0,
+	// loaded=true. then the progress file is rewritten with new content
+	// whose header carries a different Started: timestamp, and (critically)
+	// the new file has ALREADY grown past the previous lastOffset, so the
+	// offset>size fallback in StartFromOffset would not trigger.
+	oldContent := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] run 1 line
+`
+	require.NoError(t, os.WriteFile(path, []byte(oldContent), 0o600))
+
+	id := sessionIDFromPath(path)
+	session := NewSession(id, path)
+	// establish stored metadata from the original file before it gets rewritten
+	m := NewSessionManager()
+	m.Register(session)
+	t.Cleanup(func() { m.Close() })
+	require.NoError(t, m.updateSession(session))
+	require.Equal(t, "2026-01-22 10:00:00",
+		session.GetMetadata().StartTime.Format("2006-01-02 15:04:05"),
+		"precondition: stored metadata reflects run 1 header")
+	require.True(t, session.IsLoaded(), "precondition: run 1 content loaded")
+	run1Offset := session.getLastOffset()
+	require.Positive(t, run1Offset, "precondition: run 1 recorded an offset")
+
+	// rewrite the file with run 2 content (truncate + new header + enough
+	// bytes so the new file exceeds run1Offset without hitting offset>size).
+	var newContent strings.Builder
+	newContent.WriteString(`# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 11:00:00
+------------------------------------------------------------
+
+`)
+	for i := 0; newContent.Len() <= int(run1Offset)+200; i++ {
+		fmt.Fprintf(&newContent, "[26-01-22 11:00:%02d] run 2 line %d\n", i%60, i)
+	}
+	require.NoError(t, os.WriteFile(path, []byte(newContent.String()), 0o600))
+	stat, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), run1Offset,
+		"precondition: new file has grown past run1Offset to defeat offset>size fallback")
+
+	// drive updateSession again - this models the watcher picking up a Write
+	// event after the file restart.
+	require.NoError(t, m.updateSession(session))
+
+	assert.Equal(t, "2026-01-22 11:00:00",
+		session.GetMetadata().StartTime.Format("2006-01-02 15:04:05"),
+		"metadata should reflect the new run's header")
+	assert.Equal(t, stat.Size(), session.getLastOffset(),
+		"after restart detection, loader should re-run on fresh file and record new offset")
+	assert.True(t, session.IsLoaded(),
+		"session remains marked loaded after loader processes the new run")
+}
+
+// TestSessionManager_UpdateSession_PartialHeaderPreservesMetadata verifies that
+// a mid-write observation of a truncate+rewrite (header lines streaming in, but
+// terminating separator not yet written) does NOT clobber the previously stored
+// StartTime. writeHeader issues several writes and fsnotify can deliver a Write
+// event between them; if updateSession replaced stored metadata with the zero
+// StartTime from that partial read, the next event with the full header would
+// compare against a zero oldMeta.StartTime and skip the restart reset, leaving
+// stale lastOffset/loaded in place for the new run.
+func TestSessionManager_UpdateSession_PartialHeaderPreservesMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress-partial.txt")
+
+	// run 1: full header seen, metadata + offset recorded
+	run1Content := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] run 1 line
+`
+	require.NoError(t, os.WriteFile(path, []byte(run1Content), 0o600))
+
+	id := sessionIDFromPath(path)
+	session := NewSession(id, path)
+	m := NewSessionManager()
+	m.Register(session)
+	t.Cleanup(func() { m.Close() })
+	require.NoError(t, m.updateSession(session))
+	require.Equal(t, "2026-01-22 10:00:00",
+		session.GetMetadata().StartTime.Format("2006-01-02 15:04:05"))
+	run1Offset := session.getLastOffset()
+	require.Positive(t, run1Offset)
+
+	// simulate a mid-write observation: header lines but no separator yet.
+	// Started: is still missing at this point — writeHeader writes lines in
+	// order, so a Write event between writeFile("Mode:") and writeFile("Started:")
+	// delivers this exact content.
+	partial := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+`
+	require.NoError(t, os.WriteFile(path, []byte(partial), 0o600))
+	require.NoError(t, m.updateSession(session))
+
+	// the partial parse must NOT have overwritten the run 1 StartTime; otherwise
+	// the next event cannot detect the restart.
+	assert.Equal(t, "2026-01-22 10:00:00",
+		session.GetMetadata().StartTime.Format("2006-01-02 15:04:05"),
+		"partial header parse must not clobber previously stored StartTime")
+
+	// now the full run 2 header lands. restart detection must fire here and
+	// reset per-run state (lastOffset, loaded) before the loader runs on the
+	// new content.
+	var run2 strings.Builder
+	run2.WriteString(`# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 11:00:00
+------------------------------------------------------------
+
+`)
+	// grow past run1Offset so the StartFromOffset>size fallback cannot rescue us
+	for i := 0; run2.Len() <= int(run1Offset)+200; i++ {
+		fmt.Fprintf(&run2, "[26-01-22 11:00:%02d] run 2 line %d\n", i%60, i)
+	}
+	require.NoError(t, os.WriteFile(path, []byte(run2.String()), 0o600))
+	stat, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), run1Offset)
+
+	require.NoError(t, m.updateSession(session))
+
+	assert.Equal(t, "2026-01-22 11:00:00",
+		session.GetMetadata().StartTime.Format("2006-01-02 15:04:05"),
+		"metadata should reflect the new run once the full header is visible")
+	assert.Equal(t, stat.Size(), session.getLastOffset(),
+		"restart reset must run so loader re-ingests from byte 0, recording the new file size")
+}
+
+// TestSessionManager_UpdateSession_PartialHeaderSkipsLoader verifies that a
+// fresh-discovery observation of a partial header (no separator yet written)
+// does NOT invoke loadProgressFileIntoSession and does NOT mark the session
+// loaded. without the headerComplete gate, the loader would record a
+// lastOffset pointing inside the unfinished header; a later Reactivate
+// triggered by the rest of the header arriving would then resume mid-header
+// and emit the remaining header lines as output events. this is primarily
+// a Windows concern (IsActive is a no-op so every new discovery is marked
+// completed immediately), but the gate also protects Unix against the rare
+// race where IsActive momentarily returns false mid-write.
+func TestSessionManager_UpdateSession_PartialHeaderSkipsLoader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress-partial-new.txt")
+
+	// simulate a mid-write observation: header lines streaming in but the
+	// terminating separator not yet written. writeHeader issues several
+	// writeFile calls, and fsnotify can deliver a Write event between any two
+	// of them.
+	partial := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+`
+	require.NoError(t, os.WriteFile(path, []byte(partial), 0o600))
+
+	id := sessionIDFromPath(path)
+	session := NewSession(id, path)
+	m := NewSessionManager()
+	m.Register(session)
+	t.Cleanup(func() { m.Close() })
+
+	require.NoError(t, m.updateSession(session))
+
+	// partial-header discovery must not load or set an offset; otherwise a later
+	// Reactivate would resume inside the header.
+	assert.False(t, session.IsLoaded(),
+		"partial-header discovery must not mark session loaded")
+	assert.Zero(t, session.getLastOffset(),
+		"partial-header discovery must not record a lastOffset inside the header")
+
+	// once the full header arrives, the loader must run and record the correct
+	// offset (total file size) since header lines are skipped but still counted
+	// toward bytesRead.
+	full := partial + `Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] first content line
+`
+	require.NoError(t, os.WriteFile(path, []byte(full), 0o600))
+	require.NoError(t, m.updateSession(session))
+
+	assert.True(t, session.IsLoaded(),
+		"session must be marked loaded once header is complete")
+	stat, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, stat.Size(), session.getLastOffset(),
+		"lastOffset must match total file size after full-header load")
+}
+
+// TestSessionManager_UpdateSession_SameStartTimeNoReset verifies that repeated
+// updateSession calls on the same run (same Started: timestamp) do not reset
+// per-run state. this is the normal flock-race recovery path: updateSession
+// must be a no-op for stored state when the file has not been restarted.
+func TestSessionManager_UpdateSession_SameStartTimeNoReset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress-same.txt")
+
+	content := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] some line
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	id := sessionIDFromPath(path)
+	session := NewSession(id, path)
+	m := NewSessionManager()
+	m.Register(session)
+	t.Cleanup(func() { m.Close() })
+
+	require.NoError(t, m.updateSession(session))
+	offset1 := session.getLastOffset()
+	require.Positive(t, offset1)
+	require.True(t, session.IsLoaded())
+
+	// second updateSession with the file unchanged: per-run state must be preserved
+	require.NoError(t, m.updateSession(session))
+	assert.Equal(t, offset1, session.getLastOffset(),
+		"lastOffset must not change when Started: timestamp is unchanged")
+	assert.True(t, session.IsLoaded(),
+		"loaded flag must remain set when Started: timestamp is unchanged")
 }
 
 func TestSessionManager_EvictOldCompleted(t *testing.T) {

--- a/pkg/web/session_progress.go
+++ b/pkg/web/session_progress.go
@@ -23,14 +23,19 @@ import (
 //	Mode: full
 //	Started: 2026-01-22 10:30:00
 //	------------------------------------------------------------
-func ParseProgressHeader(path string) (SessionMetadata, error) {
+//
+// the second return value reports whether the terminating separator line was
+// observed, which means the header is fully written. during a truncate+rewrite
+// the header is emitted across several writes, so a mid-write read can return
+// incomplete metadata (zero StartTime, missing fields); callers should use the
+// complete flag to decide whether to trust the parsed metadata.
+func ParseProgressHeader(path string) (meta SessionMetadata, complete bool, err error) {
 	f, err := os.Open(path) //nolint:gosec // path from user-controlled glob pattern, acceptable for session discovery
 	if err != nil {
-		return SessionMetadata{}, fmt.Errorf("open file: %w", err)
+		return SessionMetadata{}, false, fmt.Errorf("open file: %w", err)
 	}
 	defer f.Close()
 
-	var meta SessionMetadata
 	reader := bufio.NewReader(f)
 
 	for {
@@ -40,8 +45,9 @@ func ParseProgressHeader(path string) (SessionMetadata, error) {
 		// stop at separator line; check readErr even when breaking
 		if line != "" && strings.HasPrefix(line, "---") {
 			if readErr != nil && !errors.Is(readErr, io.EOF) {
-				return SessionMetadata{}, fmt.Errorf("read file: %w", readErr)
+				return SessionMetadata{}, false, fmt.Errorf("read file: %w", readErr)
 			}
+			complete = true
 			break
 		}
 
@@ -62,13 +68,13 @@ func ParseProgressHeader(path string) (SessionMetadata, error) {
 
 		if readErr != nil {
 			if !errors.Is(readErr, io.EOF) {
-				return SessionMetadata{}, fmt.Errorf("read file: %w", readErr)
+				return SessionMetadata{}, false, fmt.Errorf("read file: %w", readErr)
 			}
 			break // EOF after processing final line
 		}
 	}
 
-	return meta, nil
+	return meta, complete, nil
 }
 
 // loadProgressFileIntoSession reads a progress file and publishes events to the session's SSE server.
@@ -112,6 +118,9 @@ func (m *SessionManager) loadProgressFileIntoSession(path string, session *Sessi
 	}
 
 	session.setLastOffset(bytesRead)
+	// record the phase the parser ended on so a later Reactivate resumes with
+	// the correct phase rather than the tailer's default (PhaseTask).
+	session.setLastPhase(phase)
 }
 
 // processProgressLine handles a single parsed progress line,

--- a/pkg/web/session_progress.go
+++ b/pkg/web/session_progress.go
@@ -97,8 +97,18 @@ func (m *SessionManager) loadProgressFileIntoSession(path string, session *Sessi
 
 	for {
 		line, readErr := reader.ReadString('\n')
+		// a partial trailing line (no newline delimiter) means the writer is
+		// mid-write — the flock-race recovery path is the realistic case where
+		// loader is invoked on a still-being-written file. counting and
+		// publishing the partial would advance lastOffset past the partial
+		// bytes; a later Reactivate would then resume reading the suffix of
+		// the writer's eventual completed line as if it were a separate event,
+		// reintroducing the corruption this PR is meant to eliminate.
+		if readErr != nil && line != "" {
+			break
+		}
 		// count raw bytes including the delimiter before trimming, so LF, CRLF,
-		// and the final no-trailing-newline read all count correctly
+		// and the final empty read all count correctly
 		bytesRead += int64(len(line))
 		line = trimLineEnding(line)
 

--- a/pkg/web/session_progress.go
+++ b/pkg/web/session_progress.go
@@ -74,6 +74,8 @@ func ParseProgressHeader(path string) (SessionMetadata, error) {
 // loadProgressFileIntoSession reads a progress file and publishes events to the session's SSE server.
 // used for completed sessions that were discovered after they finished.
 // errors are silently ignored since this is best-effort loading.
+// records the total bytes consumed into session.lastOffset so a later Reactivate()
+// can resume tailing from after the loaded content instead of re-emitting it.
 func (m *SessionManager) loadProgressFileIntoSession(path string, session *Session) {
 	f, err := os.Open(path) //nolint:gosec // path from user-controlled glob pattern, acceptable for session discovery
 	if err != nil {
@@ -85,9 +87,13 @@ func (m *SessionManager) loadProgressFileIntoSession(path string, session *Sessi
 	inHeader := true
 	phase := status.PhaseTask
 	var pendingSection string // section header waiting for first timestamped event
+	var bytesRead int64
 
 	for {
 		line, readErr := reader.ReadString('\n')
+		// count raw bytes including the delimiter before trimming, so LF, CRLF,
+		// and the final no-trailing-newline read all count correctly
+		bytesRead += int64(len(line))
 		line = trimLineEnding(line)
 
 		if line != "" {
@@ -104,6 +110,8 @@ func (m *SessionManager) loadProgressFileIntoSession(path string, session *Sessi
 	if pendingSection != "" {
 		m.emitPendingSection(session, pendingSection, phase, time.Now())
 	}
+
+	session.setLastOffset(bytesRead)
 }
 
 // processProgressLine handles a single parsed progress line,

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -29,8 +29,9 @@ Started: 2026-01-22 10:30:00
 `
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-		meta, err := ParseProgressHeader(path)
+		meta, complete, err := ParseProgressHeader(path)
 		require.NoError(t, err)
+		assert.True(t, complete, "separator observed, header should be marked complete")
 
 		assert.Equal(t, "docs/plans/my-plan.md", meta.PlanPath)
 		assert.Equal(t, "feature-branch", meta.Branch)
@@ -51,8 +52,9 @@ Started: 2026-01-22 11:00:00
 `
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-		meta, err := ParseProgressHeader(path)
+		meta, complete, err := ParseProgressHeader(path)
 		require.NoError(t, err)
+		assert.True(t, complete)
 
 		assert.Equal(t, "(no plan - review only)", meta.PlanPath)
 		assert.Equal(t, "review", meta.Mode)
@@ -68,8 +70,9 @@ Branch: main
 `
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-		meta, err := ParseProgressHeader(path)
+		meta, complete, err := ParseProgressHeader(path)
 		require.NoError(t, err)
+		assert.True(t, complete, "separator present → complete even with missing fields")
 
 		assert.Empty(t, meta.PlanPath)
 		assert.Equal(t, "main", meta.Branch)
@@ -78,8 +81,29 @@ Branch: main
 	})
 
 	t.Run("returns error for missing file", func(t *testing.T) {
-		_, err := ParseProgressHeader("/nonexistent/path")
+		_, _, err := ParseProgressHeader("/nonexistent/path")
 		assert.Error(t, err)
+	})
+
+	t.Run("reports incomplete when separator not yet written", func(t *testing.T) {
+		// models a mid-write observation: header lines written but terminating
+		// separator still pending. updateSession must not clobber previously
+		// stored metadata with the partial parse returned here.
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: docs/plans/my-plan.md
+Branch: feature-branch
+Mode: full
+`
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		meta, complete, err := ParseProgressHeader(path)
+		require.NoError(t, err)
+		assert.False(t, complete, "no separator → header should be marked incomplete")
+		assert.True(t, meta.StartTime.IsZero(), "Started: not yet written")
+		assert.Equal(t, "docs/plans/my-plan.md", meta.PlanPath, "already-written fields still parsed")
 	})
 }
 
@@ -423,8 +447,9 @@ Started: 2026-01-22 10:30:00
 `
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-		meta, err := ParseProgressHeader(path)
+		meta, complete, err := ParseProgressHeader(path)
 		require.NoError(t, err)
+		assert.True(t, complete)
 
 		assert.Equal(t, "docs/plans/my-plan.md", meta.PlanPath)
 		assert.Equal(t, "feature-branch", meta.Branch)
@@ -445,8 +470,9 @@ Started: 2026-01-22 10:30:00
 			"[26-01-22 10:30:05] " + hugeLine + "\n"
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-		meta, err := ParseProgressHeader(path)
+		meta, complete, err := ParseProgressHeader(path)
 		require.NoError(t, err)
+		assert.True(t, complete)
 
 		assert.Equal(t, "docs/plans/huge.md", meta.PlanPath)
 		assert.Equal(t, "huge-branch", meta.Branch)

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -177,6 +177,114 @@ Started: 2026-01-22 10:00:00
 	})
 }
 
+func TestSessionManager_LoadProgressFileIntoSession_RecordsOffset(t *testing.T) {
+	t.Run("LF endings offset equals file size", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-lf.txt")
+
+		content := "# Ralphex Progress Log\n" +
+			"Plan: docs/plan.md\n" +
+			"Branch: main\n" +
+			"Mode: full\n" +
+			"Started: 2026-01-22 10:00:00\n" +
+			"------------------------------------------------------------\n" +
+			"\n" +
+			"[26-01-22 10:00:01] first line\n" +
+			"[26-01-22 10:00:02] second line\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		m := NewSessionManager()
+		defer m.Close()
+		session := NewSession("test-lf", path)
+		defer session.Close()
+
+		m.loadProgressFileIntoSession(path, session)
+
+		assert.Equal(t, int64(len(content)), session.getLastOffset(),
+			"lastOffset must equal total byte size for LF-terminated content")
+	})
+
+	t.Run("CRLF endings offset equals file size", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-crlf.txt")
+
+		content := "# Ralphex Progress Log\r\n" +
+			"Plan: docs/plan.md\r\n" +
+			"Branch: main\r\n" +
+			"Mode: full\r\n" +
+			"Started: 2026-01-22 10:00:00\r\n" +
+			"------------------------------------------------------------\r\n" +
+			"\r\n" +
+			"[26-01-22 10:00:01] first line\r\n" +
+			"[26-01-22 10:00:02] second line\r\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		m := NewSessionManager()
+		defer m.Close()
+		session := NewSession("test-crlf", path)
+		defer session.Close()
+
+		m.loadProgressFileIntoSession(path, session)
+
+		assert.Equal(t, int64(len(content)), session.getLastOffset(),
+			"lastOffset must equal total byte size for CRLF-terminated content (regression guard)")
+	})
+
+	t.Run("empty file records zero offset", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-empty.txt")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+		m := NewSessionManager()
+		defer m.Close()
+		session := NewSession("test-empty", path)
+		defer session.Close()
+
+		m.loadProgressFileIntoSession(path, session)
+
+		assert.Equal(t, int64(0), session.getLastOffset(), "empty file must record zero offset")
+	})
+
+	t.Run("no trailing newline offset equals file size", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-no-newline.txt")
+
+		content := "# Ralphex Progress Log\n" +
+			"Plan: docs/plan.md\n" +
+			"Branch: main\n" +
+			"Mode: full\n" +
+			"Started: 2026-01-22 10:00:00\n" +
+			"------------------------------------------------------------\n" +
+			"\n" +
+			"[26-01-22 10:00:01] first line\n" +
+			"[26-01-22 10:00:02] last line without newline"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		m := NewSessionManager()
+		defer m.Close()
+		session := NewSession("test-no-newline", path)
+		defer session.Close()
+
+		m.loadProgressFileIntoSession(path, session)
+
+		assert.Equal(t, int64(len(content)), session.getLastOffset(),
+			"lastOffset must equal total byte size when final line lacks a newline")
+	})
+
+	t.Run("missing file leaves lastOffset unchanged", func(t *testing.T) {
+		m := NewSessionManager()
+		defer m.Close()
+		session := NewSession("test-missing", "/nonexistent/progress.txt")
+		defer session.Close()
+
+		session.setLastOffset(42)
+		m.loadProgressFileIntoSession("/nonexistent/progress.txt", session)
+
+		assert.Equal(t, int64(42), session.getLastOffset(),
+			"missing file must not overwrite pre-existing lastOffset")
+	})
+}
+
 func TestSessionManager_EmitPendingSection(t *testing.T) {
 	t.Run("task iteration section emits task_start event", func(t *testing.T) {
 		dir := t.TempDir()

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -269,30 +269,38 @@ func TestSessionManager_LoadProgressFileIntoSession_RecordsOffset(t *testing.T) 
 		assert.Equal(t, int64(0), session.getLastOffset(), "empty file must record zero offset")
 	})
 
-	t.Run("no trailing newline offset equals file size", func(t *testing.T) {
+	t.Run("partial trailing line skipped to avoid mid-write corruption", func(t *testing.T) {
+		// the loader runs on the flock-race recovery path where the writer is
+		// still active; a trailing line without a newline is a mid-write
+		// fragment. counting and publishing it would advance lastOffset past
+		// the partial bytes, so a later Reactivate would resume mid-line and
+		// emit the suffix as a separate event after the writer completes the
+		// line. lastOffset must point to the end of the last fully-terminated
+		// line, NOT to file size.
 		dir := t.TempDir()
-		path := filepath.Join(dir, "progress-no-newline.txt")
+		path := filepath.Join(dir, "progress-partial.txt")
 
-		content := "# Ralphex Progress Log\n" +
+		header := "# Ralphex Progress Log\n" +
 			"Plan: docs/plan.md\n" +
 			"Branch: main\n" +
 			"Mode: full\n" +
 			"Started: 2026-01-22 10:00:00\n" +
 			"------------------------------------------------------------\n" +
 			"\n" +
-			"[26-01-22 10:00:01] first line\n" +
-			"[26-01-22 10:00:02] last line without newline"
-		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+			"[26-01-22 10:00:01] first line\n"
+		partial := "[26-01-22 10:00:02] last line without newline"
+		require.NoError(t, os.WriteFile(path, []byte(header+partial), 0o600))
 
 		m := NewSessionManager()
 		defer m.Close()
-		session := NewSession("test-no-newline", path)
+		session := NewSession("test-partial", path)
 		defer session.Close()
 
 		m.loadProgressFileIntoSession(path, session)
 
-		assert.Equal(t, int64(len(content)), session.getLastOffset(),
-			"lastOffset must equal total byte size when final line lacks a newline")
+		assert.Equal(t, int64(len(header)), session.getLastOffset(),
+			"lastOffset must skip the partial trailing line so a later "+
+				"Reactivate resumes from the end of the last complete line")
 	})
 
 	t.Run("missing file leaves lastOffset unchanged", func(t *testing.T) {

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -381,6 +381,143 @@ Started: 2026-01-22 10:30:00
 	})
 }
 
+func TestSession_Reactivate_ResumesFromOffset(t *testing.T) {
+	tmpDir := t.TempDir()
+	progressFile := tmpDir + "/progress-test.txt"
+
+	header := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+`
+	initial := "[26-01-22 10:30:01] line one\n[26-01-22 10:30:02] line two\n"
+	require.NoError(t, os.WriteFile(progressFile, []byte(header+initial), 0o600))
+
+	s := NewSession("test", progressFile)
+	defer s.Close()
+
+	// start from beginning, wait for tailer to consume the whole file
+	require.NoError(t, s.StartTailing(true))
+	expected := int64(len(header + initial))
+	require.Eventually(t, func() bool {
+		return s.GetTailer() != nil && s.GetTailer().Offset() == expected
+	}, 2*time.Second, 20*time.Millisecond, "tailer should reach EOF")
+
+	// stop - this captures lastOffset
+	s.StopTailing()
+	require.Eventually(t, func() bool { return !s.IsTailing() }, time.Second, 10*time.Millisecond)
+	require.Equal(t, expected, s.getLastOffset())
+
+	// simulate watcher seeing completed state, then reactivating after new write
+	s.SetState(SessionStateCompleted)
+
+	// append new content after stop - these lines MUST appear
+	newLines := "[26-01-22 10:30:03] line three\n[26-01-22 10:30:04] line four\n"
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+	require.NoError(t, err)
+	_, err = f.WriteString(newLines)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, s.Reactivate())
+
+	// state flipped to active, tailer running
+	assert.Equal(t, SessionStateActive, s.GetState())
+	assert.True(t, s.IsTailing())
+
+	// tailer advanced to new EOF
+	finalExpected := expected + int64(len(newLines))
+	require.Eventually(t, func() bool {
+		return s.GetTailer() != nil && s.GetTailer().Offset() == finalExpected
+	}, 2*time.Second, 20*time.Millisecond, "tailer should resume and reach new EOF")
+
+	// stop to capture offset again; confirms we really resumed from the stored offset
+	s.StopTailing()
+	require.Eventually(t, func() bool { return !s.IsTailing() }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, finalExpected, s.getLastOffset())
+}
+
+func TestSession_Reactivate_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	progressFile := tmpDir + "/progress-test.txt"
+
+	content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] line one
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+	s := NewSession("test", progressFile)
+	defer s.Close()
+
+	s.setLastOffset(int64(len(content)))
+	s.SetState(SessionStateCompleted)
+
+	require.NoError(t, s.Reactivate())
+	first := s.GetTailer()
+	require.NotNil(t, first)
+	require.True(t, first.IsRunning())
+
+	// second call must not replace the running tailer
+	require.NoError(t, s.Reactivate())
+	second := s.GetTailer()
+	assert.Same(t, first, second, "reactivate must be idempotent while tailer is running")
+	assert.True(t, second.IsRunning())
+}
+
+func TestSession_Reactivate_OnClosedSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	progressFile := tmpDir + "/progress-test.txt"
+	content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+	s := NewSession("test", progressFile)
+	s.setLastOffset(int64(len(content)))
+	s.SetState(SessionStateCompleted)
+
+	// close the session - removes the underlying file scenario is simulated next
+	s.Close()
+
+	// delete the progress file to force tailer start failure
+	require.NoError(t, os.Remove(progressFile))
+
+	// reactivate on a closed session whose file is gone should return an error
+	// and must not panic or flip state to active
+	err := s.Reactivate()
+	require.Error(t, err)
+	assert.Equal(t, SessionStateCompleted, s.GetState())
+}
+
+func TestSession_Reactivate_FailedStartLeavesStateUnchanged(t *testing.T) {
+	s := NewSession("test", "/nonexistent/ralphex-reactivate-path.txt")
+	defer s.Close()
+
+	s.SetState(SessionStateCompleted)
+	s.setLastOffset(100)
+
+	err := s.Reactivate()
+	require.Error(t, err)
+
+	// state stays completed, no tailer stored
+	assert.Equal(t, SessionStateCompleted, s.GetState())
+	assert.False(t, s.IsTailing())
+	assert.Nil(t, s.GetTailer())
+}
+
 func TestAllEventsReplayer_Replay(t *testing.T) {
 	t.Run("empty LastEventID is replaced with 0", func(t *testing.T) {
 		// create a FiniteReplayer and wrap it in allEventsReplayer

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -279,6 +280,104 @@ Started: 2026-01-22 10:30:00
 		s.StopTailing()
 
 		assert.False(t, s.IsTailing())
+	})
+}
+
+func TestSession_LastOffset(t *testing.T) {
+	t.Run("default is zero", func(t *testing.T) {
+		s := NewSession("test", "/tmp/test.txt")
+		defer s.Close()
+		assert.Equal(t, int64(0), s.getLastOffset())
+	})
+
+	t.Run("set and get", func(t *testing.T) {
+		s := NewSession("test", "/tmp/test.txt")
+		defer s.Close()
+
+		s.setLastOffset(1234)
+		assert.Equal(t, int64(1234), s.getLastOffset())
+
+		s.setLastOffset(0)
+		assert.Equal(t, int64(0), s.getLastOffset())
+	})
+
+	t.Run("concurrent access is safe", func(t *testing.T) {
+		s := NewSession("test", "/tmp/test.txt")
+		defer s.Close()
+
+		const workers = 20
+		const iterations = 200
+
+		var wg sync.WaitGroup
+		wg.Add(workers * 2)
+
+		for i := range workers {
+			go func(base int64) {
+				defer wg.Done()
+				for j := range iterations {
+					s.setLastOffset(base + int64(j))
+				}
+			}(int64(i) * 1000)
+		}
+		for range workers {
+			go func() {
+				defer wg.Done()
+				for range iterations {
+					_ = s.getLastOffset()
+				}
+			}()
+		}
+
+		wg.Wait()
+		// final value is non-deterministic but must be within the written range
+		final := s.getLastOffset()
+		assert.GreaterOrEqual(t, final, int64(0))
+	})
+}
+
+func TestSession_StopTailingCapturesOffset(t *testing.T) {
+	t.Run("captures offset from running tailer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := tmpDir + "/progress-test.txt"
+
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] line one
+[26-01-22 10:30:02] line two
+[26-01-22 10:30:03] line three
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		s := NewSession("test", progressFile)
+		defer s.Close()
+
+		require.NoError(t, s.StartTailing(true))
+
+		// wait until the tailer has consumed the whole file
+		expected := int64(len(content))
+		require.Eventually(t, func() bool {
+			return s.GetTailer() != nil && s.GetTailer().Offset() == expected
+		}, 2*time.Second, 20*time.Millisecond, "tailer should advance to EOF")
+
+		s.StopTailing()
+		assert.Eventually(t, func() bool { return !s.IsTailing() }, time.Second, 10*time.Millisecond)
+
+		assert.Equal(t, expected, s.getLastOffset(), "lastOffset should match bytes read before stop")
+	})
+
+	t.Run("nil tailer leaves lastOffset unchanged", func(t *testing.T) {
+		s := NewSession("test", "/tmp/test.txt")
+		defer s.Close()
+
+		s.setLastOffset(42)
+		s.StopTailing()
+
+		assert.Equal(t, int64(42), s.getLastOffset(), "stopping without a tailer must not overwrite lastOffset")
 	})
 }
 

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -1,7 +1,9 @@
 package web
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -9,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmaxmax/go-sse"
+
+	"github.com/umputun/ralphex/pkg/status"
 )
 
 func TestNewSession(t *testing.T) {
@@ -382,6 +386,79 @@ Started: 2026-01-22 10:30:00
 
 		assert.Equal(t, int64(42), s.getLastOffset(), "stopping without a tailer must not overwrite lastOffset")
 	})
+
+	t.Run("drains buffered events into SSE before returning", func(t *testing.T) {
+		// regression test: before the StopTailing drain fix, events that the
+		// tailer had read (and whose bytes were accounted for in tailer.Offset)
+		// but not yet drained by feedEvents could be silently dropped when
+		// stopTailCh was closed. with the drain, every event the tailer produced
+		// must be visible on the SSE stream by the time StopTailing returns, and
+		// lastOffset must equal the file size — this is the guarantee Reactivate
+		// relies on to avoid a gap across stop/reactivate cycles.
+		tmpDir := t.TempDir()
+		progressFile := tmpDir + "/progress-test.txt"
+
+		// seed with header and one line so the SSE server has an event in its
+		// replay buffer when we subscribe — without it, http.Do blocks waiting
+		// for response headers that Joe only flushes on the first event.
+		initial := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:00] seed line
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(initial), 0o600))
+
+		s := NewSession("test", progressFile)
+		defer s.Close()
+
+		require.NoError(t, s.StartTailing(true))
+		require.Eventually(t, func() bool {
+			return s.GetTailer() != nil && s.GetTailer().Offset() == int64(len(initial))
+		}, 2*time.Second, 20*time.Millisecond, "tailer should read seed content")
+
+		events, cleanup := subscribeSSEEvents(t, s)
+		defer cleanup()
+
+		// drain replay of seed line so only live-post-subscription events remain
+		_ = drainChannel(events, 200*time.Millisecond)
+
+		// append many lines in one write to maximize the chance of events being
+		// queued in eventCh when StopTailing fires
+		const lineCount = 200
+		var body strings.Builder
+		for i := range lineCount {
+			fmt.Fprintf(&body, "[26-01-22 10:30:%02d] line %d\n", i%60, i)
+		}
+		f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test path from t.TempDir
+		require.NoError(t, err)
+		_, err = f.WriteString(body.String())
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		expected := int64(len(initial) + body.Len())
+		require.Eventually(t, func() bool {
+			return s.GetTailer() != nil && s.GetTailer().Offset() == expected
+		}, 2*time.Second, 20*time.Millisecond, "tailer should read appended content")
+
+		// stop — with the drain fix, every event the tailer pushed to eventCh
+		// must be published to SSE before StopTailing returns.
+		s.StopTailing()
+		require.Equal(t, expected, s.getLastOffset(), "lastOffset must equal bytes read after StopTailing")
+
+		delivered := drainChannel(events, 1500*time.Millisecond)
+		outputs := 0
+		for _, ev := range delivered {
+			if strings.Contains(ev, "\"type\":\"output\"") && strings.Contains(ev, "\"text\":\"line ") {
+				outputs++
+			}
+		}
+		assert.Equal(t, lineCount, outputs,
+			"every line the tailer read must be published to SSE — no drops between offset advance and feedEvents drain")
+	})
 }
 
 func TestSession_Reactivate_ResumesFromOffset(t *testing.T) {
@@ -519,6 +596,165 @@ func TestSession_Reactivate_FailedStartLeavesStateUnchanged(t *testing.T) {
 	assert.Equal(t, SessionStateCompleted, s.GetState())
 	assert.False(t, s.IsTailing())
 	assert.Nil(t, s.GetTailer())
+}
+
+func TestSession_Reactivate_PreservesPhase(t *testing.T) {
+	// regression test for codex finding: resuming mid-phase must carry over
+	// the parser phase so new lines are tagged correctly, rather than defaulting
+	// to PhaseTask until the next section header.
+	tmpDir := t.TempDir()
+	progressFile := tmpDir + "/progress-test.txt"
+
+	content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+--- task iteration 1 ---
+[26-01-22 10:30:01] task line
+--- review iteration 1 ---
+[26-01-22 10:30:02] review line
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+	s := NewSession("test", progressFile)
+	defer s.Close()
+
+	// start from beginning, let the tailer process the full file so its
+	// internal phase advances to review.
+	require.NoError(t, s.StartTailing(true))
+	expected := int64(len(content))
+	require.Eventually(t, func() bool {
+		return s.GetTailer() != nil && s.GetTailer().Offset() == expected
+	}, 2*time.Second, 20*time.Millisecond, "tailer should reach EOF")
+
+	// stop captures offset and phase. StopTailing is synchronous and drains
+	// feedEvents, so the tailer phase observed here is the committed one.
+	s.StopTailing()
+	require.Equal(t, status.PhaseReview, s.getLastPhase(),
+		"StopTailing must capture the tailer's current phase")
+
+	// simulate flock-race recovery: state was flipped to completed, then a
+	// write event arrives with a new line (no new section header).
+	s.SetState(SessionStateCompleted)
+	events, cleanup := subscribeSSEEvents(t, s)
+	defer cleanup()
+
+	// drain any replay from the pre-stop tailer so we only inspect post-reactivate events
+	_ = drainChannel(events, 200*time.Millisecond)
+
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+	require.NoError(t, err)
+	_, err = f.WriteString("[26-01-22 10:30:03] still in review\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, s.Reactivate())
+
+	// the post-reactivate line must carry PhaseReview, not the tailer's default
+	postReactivate := drainChannel(events, 800*time.Millisecond)
+	var sawStillInReview bool
+	for _, ev := range postReactivate {
+		if strings.Contains(ev, "still in review") {
+			sawStillInReview = true
+			assert.Contains(t, ev, "\"phase\":\""+string(status.PhaseReview)+"\"",
+				"post-reactivate event must carry preserved phase")
+		}
+	}
+	assert.True(t, sawStillInReview, "should have received the post-reactivate event; got %v", postReactivate)
+}
+
+func TestSession_Reactivate_PreservesPendingSection(t *testing.T) {
+	// regression test: StopTailing must capture the tailer's deferred section
+	// state (a section header read from the file but whose section/task-start
+	// event has not yet been emitted because emission is deferred until the
+	// next timestamped/output line arrives). Reactivate must then re-seed a
+	// fresh tailer with that pending state so the section event still fires
+	// on the next line instead of being silently dropped across the restart.
+	tmpDir := t.TempDir()
+	progressFile := tmpDir + "/progress-test.txt"
+
+	// file ends with a section header - the section event is deferred inside
+	// the tailer and will only fire when the next line is read.
+	initial := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] before section
+--- task iteration 5 ---
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(initial), 0o600))
+
+	s := NewSession("test", progressFile)
+	defer s.Close()
+
+	require.NoError(t, s.StartTailing(true))
+	expected := int64(len(initial))
+	require.Eventually(t, func() bool {
+		return s.GetTailer() != nil && s.GetTailer().Offset() == expected
+	}, 2*time.Second, 20*time.Millisecond, "tailer should reach EOF")
+
+	// wait for the tailer's pending section to be set (consumed the section
+	// header but not yet the following line, so pendingSection is populated)
+	require.Eventually(t, func() bool {
+		name, _ := s.GetTailer().PendingSection()
+		return name == "task iteration 5"
+	}, 2*time.Second, 20*time.Millisecond, "tailer should have deferred section before stop")
+
+	// stop captures lastOffset AND pending section state into the session
+	s.StopTailing()
+	require.Eventually(t, func() bool { return !s.IsTailing() }, time.Second, 10*time.Millisecond)
+	require.Equal(t, "task iteration 5", s.lastPendingSection,
+		"StopTailing must capture pending section name")
+	require.Equal(t, status.PhaseTask, s.lastPendingPhase,
+		"StopTailing must capture pending section phase")
+
+	// simulate flock-race recovery: state flipped to completed, then subscribe
+	// to SSE so we catch the events published after reactivation.
+	s.SetState(SessionStateCompleted)
+	events, cleanup := subscribeSSEEvents(t, s)
+	defer cleanup()
+
+	// drain any replay from before reactivation (the "before section" line was
+	// already published by the pre-stop tailer and lives in the replay buffer)
+	preReactivate := drainChannel(events, 200*time.Millisecond)
+	for _, ev := range preReactivate {
+		require.NotContains(t, ev, "\"section\":\"task iteration 5\"",
+			"precondition: section event must not have been published before reactivate")
+	}
+
+	// append the first line of iteration 5 - the write event plus the tailer
+	// reading it should flush the deferred section.
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+	require.NoError(t, err)
+	_, err = f.WriteString("[26-01-22 10:30:02] first line of iteration 5\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, s.Reactivate())
+
+	// collect post-reactivate events via SSE
+	postReactivate := drainChannel(events, 800*time.Millisecond)
+	var sawTaskStart, sawSection, sawOutput bool
+	for _, ev := range postReactivate {
+		if strings.Contains(ev, "\"type\":\"task_start\"") && strings.Contains(ev, "\"task_num\":5") {
+			sawTaskStart = true
+		}
+		if strings.Contains(ev, "\"type\":\"section\"") && strings.Contains(ev, "\"section\":\"task iteration 5\"") {
+			sawSection = true
+		}
+		if strings.Contains(ev, "first line of iteration 5") {
+			sawOutput = true
+		}
+	}
+	assert.True(t, sawTaskStart, "expected TaskStart event for deferred section; got %v", postReactivate)
+	assert.True(t, sawSection, "expected Section event for deferred section; got %v", postReactivate)
+	assert.True(t, sawOutput, "expected output event for new post-reactivate line; got %v", postReactivate)
 }
 
 func TestAllEventsReplayer_Replay(t *testing.T) {

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -598,6 +598,91 @@ func TestSession_Reactivate_FailedStartLeavesStateUnchanged(t *testing.T) {
 	assert.Nil(t, s.GetTailer())
 }
 
+func TestSession_Reactivate_SkipsWhileStopping(t *testing.T) {
+	// regression test: StopTailing releases s.mu during the tailer.Stop() +
+	// feedEvents drain phase. without the stopping flag, a concurrent
+	// Reactivate call acquiring s.mu during that window would observe
+	// s.tailer.IsRunning()==false (Stop already returned) with lastOffset
+	// not yet captured, start a new tailer from stale byte position, and
+	// duplicate or lose events — the exact failure mode the flock-race
+	// recovery path is meant to avoid.
+	t.Run("reactivate is a no-op when stopping flag is set", func(t *testing.T) {
+		s := NewSession("test", "/nonexistent/ralphex-stopping-path.txt")
+		defer s.Close()
+
+		s.setLastOffset(100)
+		s.SetState(SessionStateCompleted)
+
+		// simulate StopTailing mid-flight by asserting the stopping flag under lock
+		s.mu.Lock()
+		s.stopping = true
+		s.mu.Unlock()
+
+		// Reactivate must return nil without starting a tailer or flipping state.
+		// if it ignored the stopping flag, startTailerLocked would fail to open
+		// the non-existent path and return an error — proving that the guard
+		// runs before any work that could touch a stale lastOffset.
+		err := s.Reactivate()
+		require.NoError(t, err)
+		assert.Nil(t, s.GetTailer(), "no tailer must be created while stopping")
+		assert.Equal(t, SessionStateCompleted, s.GetState(), "state must not flip to active while stopping")
+
+		// clear flag and confirm reactivate resumes normal behavior (path missing → error)
+		s.mu.Lock()
+		s.stopping = false
+		s.mu.Unlock()
+
+		err = s.Reactivate()
+		require.Error(t, err, "after stopping clears, Reactivate resumes normal path and surfaces tailer-start errors")
+	})
+
+	t.Run("starttailing is a no-op when stopping flag is set", func(t *testing.T) {
+		s := NewSession("test", "/nonexistent/ralphex-stopping-start.txt")
+		defer s.Close()
+
+		s.mu.Lock()
+		s.stopping = true
+		s.mu.Unlock()
+
+		err := s.StartTailing(true)
+		require.NoError(t, err, "StartTailing must no-op under stopping flag, not surface tailer-start errors")
+		assert.Nil(t, s.GetTailer(), "no tailer must be created while stopping")
+	})
+
+	t.Run("stoptailing clears stopping flag and tailer pointer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := tmpDir + "/progress-test.txt"
+
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] line
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		s := NewSession("test", progressFile)
+		defer s.Close()
+
+		require.NoError(t, s.StartTailing(true))
+		require.Eventually(t, func() bool {
+			return s.GetTailer() != nil && s.GetTailer().Offset() == int64(len(content))
+		}, 2*time.Second, 20*time.Millisecond)
+
+		s.StopTailing()
+
+		s.mu.RLock()
+		stopping := s.stopping
+		tailer := s.tailer
+		s.mu.RUnlock()
+		assert.False(t, stopping, "stopping flag must be cleared after StopTailing returns")
+		assert.Nil(t, tailer, "tailer pointer must be nil after StopTailing returns")
+	})
+}
+
 func TestSession_Reactivate_PreservesPhase(t *testing.T) {
 	// regression test for codex finding: resuming mid-phase must carry over
 	// the parser phase so new lines are tagged correctly, rather than defaulting

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -681,6 +681,58 @@ Started: 2026-01-22 10:30:00
 		assert.False(t, stopping, "stopping flag must be cleared after StopTailing returns")
 		assert.Nil(t, tailer, "tailer pointer must be nil after StopTailing returns")
 	})
+
+	t.Run("concurrent stoptailing calls do not clobber a reactivated tailer", func(t *testing.T) {
+		// regression test: without stopMu serialization, two concurrent
+		// StopTailing calls could both capture the same tailer reference.
+		// the second caller would skip the (already-nil-swapped) feedDone wait,
+		// reach the final critical section first, clear stopping/tailer, and
+		// allow a Reactivate to start a NEW tailer — which the first caller
+		// would then nil out when its drain finally completed, leaving the
+		// session in "active state but no tailer running."
+		tmpDir := t.TempDir()
+		progressFile := tmpDir + "/progress-test.txt"
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] line one
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		s := NewSession("test", progressFile)
+		defer s.Close()
+
+		require.NoError(t, s.StartTailing(true))
+		require.Eventually(t, func() bool {
+			return s.GetTailer() != nil && s.GetTailer().Offset() == int64(len(content))
+		}, 2*time.Second, 20*time.Millisecond)
+
+		// fire two StopTailing calls concurrently; stopMu must serialize them
+		// so the second observes s.tailer == nil and is a no-op.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); s.StopTailing() }()
+		go func() { defer wg.Done(); s.StopTailing() }()
+		wg.Wait()
+
+		s.mu.RLock()
+		stopping := s.stopping
+		tailer := s.tailer
+		offset := s.lastOffset
+		s.mu.RUnlock()
+		assert.False(t, stopping, "stopping flag cleared after both StopTailing calls return")
+		assert.Nil(t, tailer, "tailer pointer nil after concurrent StopTailing")
+		assert.Equal(t, int64(len(content)), offset, "lastOffset preserved at the captured value, not clobbered by the second caller")
+
+		// a Reactivate after the concurrent stop must start a real tailer that
+		// is NOT subsequently clobbered by a still-draining StopTailing goroutine.
+		require.NoError(t, s.Reactivate())
+		require.NotNil(t, s.GetTailer(), "Reactivate must start a tailer that survives the prior concurrent stop")
+	})
 }
 
 func TestSession_Reactivate_PreservesPhase(t *testing.T) {

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -329,9 +329,12 @@ func TestSession_LastOffset(t *testing.T) {
 		}
 
 		wg.Wait()
-		// final value is non-deterministic but must be within the written range
+		// final value is non-deterministic but must be one of the written values:
+		// writer i writes base+j where base = i*1000 and j in [0, iterations),
+		// so final % 1000 must be < iterations and final / 1000 must be < workers.
 		final := s.getLastOffset()
-		assert.GreaterOrEqual(t, final, int64(0))
+		assert.Less(t, final%1000, int64(iterations), "final must be a value written by some worker")
+		assert.Less(t, final/1000, int64(workers), "final must come from a known worker")
 	})
 }
 

--- a/pkg/web/tail.go
+++ b/pkg/web/tail.go
@@ -120,6 +120,67 @@ func (t *Tailer) Start(fromStart bool) error {
 	return nil
 }
 
+// Offset returns the current byte offset into the tailed file.
+// safe to call concurrently with tailer operations.
+func (t *Tailer) Offset() int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.offset
+}
+
+// StartFromOffset begins tailing the file seeking to the given byte offset.
+// if offset <= 0, behaves like Start(false) (seeks to end).
+// if offset exceeds file size, it is clamped to file size (no spurious replay).
+// the caller must guarantee offset points past the header block; offset>0 disables
+// header detection, so a misplaced offset may leave subsequent header lines treated as output.
+// note: Tailer is not reusable after Stop() - create a new instance instead.
+func (t *Tailer) StartFromOffset(offset int64) error {
+	if offset <= 0 {
+		return t.Start(false)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.running {
+		return nil
+	}
+
+	f, err := os.Open(t.path)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return fmt.Errorf("stat file: %w", err)
+	}
+
+	clamped := min(offset, stat.Size())
+
+	if _, err := f.Seek(clamped, io.SeekStart); err != nil {
+		f.Close()
+		return fmt.Errorf("seek to offset %d: %w", clamped, err)
+	}
+
+	t.offset = clamped
+	t.inHeader = false
+	t.deferSections = false
+	t.pendingSection = ""
+	t.pendingPhase = ""
+
+	t.file = f
+	t.reader = bufio.NewReader(f)
+	t.running = true
+	t.stopCh = make(chan struct{})
+	t.doneCh = make(chan struct{})
+
+	go t.tailLoop()
+
+	return nil
+}
+
 // Stop stops the tailer and closes resources.
 // blocks until the tail loop has fully stopped.
 // safe to call multiple times concurrently.

--- a/pkg/web/tail.go
+++ b/pkg/web/tail.go
@@ -19,6 +19,16 @@ import (
 type TailerConfig struct {
 	PollInterval time.Duration // how often to check for new content (default: 100ms)
 	InitialPhase status.Phase  // phase to use for events (default: PhaseTask)
+
+	// PendingSection and PendingPhase carry over a deferred section that was
+	// read by a previous tailer but not yet emitted (a section header whose
+	// section/task-start event is pending the next timestamped/output line).
+	// only honored by StartFromOffset: when PendingSection is non-empty, the
+	// resumed tailer starts with deferSections=true and emits the pending
+	// section event when the next line arrives, matching the original tailer's
+	// behavior across a restart (e.g. after a flock-race Reactivate).
+	PendingSection string
+	PendingPhase   status.Phase
 }
 
 // DefaultTailerConfig returns default configuration.
@@ -128,24 +138,51 @@ func (t *Tailer) Offset() int64 {
 	return t.offset
 }
 
+// Phase returns the tailer's current parser phase.
+// callers can persist this across tailer restarts (e.g., reactivation) so
+// lines emitted after resume carry the correct phase without waiting for
+// the next section header.
+func (t *Tailer) Phase() status.Phase {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.phase
+}
+
+// PendingSection returns any section header that has been read but whose
+// section/task-start event has not yet been emitted (because deferred
+// emission is waiting for the next timestamped/output line). returns the
+// section name and the parsed phase for that section, or zero values if
+// nothing is pending. callers can persist this across tailer restarts so
+// the deferred section event is not lost when a tailer is stopped between
+// reading the section header and reading the following line.
+func (t *Tailer) PendingSection() (string, status.Phase) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.pendingSection, t.pendingPhase
+}
+
 // StartFromOffset begins tailing the file seeking to the given byte offset.
 // if offset <= 0, behaves like Start(false) (seeks to end).
-// if offset exceeds file size, it is clamped to file size (no spurious replay).
+// if offset exceeds current file size the file has been truncated/replaced
+// (progress logger reuses "Completed:" files by truncating them for a fresh
+// run), so the method resets to the beginning of the new file via Start(true)
+// and the caller's stored lastOffset is discarded for this resume. in that
+// case the parser phase is also reset to the default (status.PhaseTask) so a
+// stale phase seeded from a previous run's config.InitialPhase does not leak
+// into the fresh file's pre-section-header lines.
 // the caller must guarantee offset points past the header block; offset>0 disables
 // header detection, so a misplaced offset may leave subsequent header lines treated as output.
+// if config.PendingSection is set, the resumed tailer preserves the deferred
+// section so its section/task-start event fires on the next line instead of
+// being dropped across the restart.
 // note: Tailer is not reusable after Stop() - create a new instance instead.
 func (t *Tailer) StartFromOffset(offset int64) error {
 	if offset <= 0 {
 		return t.Start(false)
 	}
 
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if t.running {
-		return nil
-	}
-
+	// open the file and inspect size before taking t.mu so a truncation
+	// fallback can delegate to Start(true) without nested locking.
 	f, err := os.Open(t.path)
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)
@@ -157,18 +194,46 @@ func (t *Tailer) StartFromOffset(offset int64) error {
 		return fmt.Errorf("stat file: %w", err)
 	}
 
-	clamped := min(offset, stat.Size())
-
-	if _, err := f.Seek(clamped, io.SeekStart); err != nil {
+	if offset > stat.Size() {
+		// file was truncated/replaced since offset was recorded; start over
+		// from the beginning of the new file contents. reset the parser phase
+		// to the default so a stale phase from the previous run (seeded via
+		// config.InitialPhase for the resume case) does not color lines
+		// emitted before the new run's first section header.
 		f.Close()
-		return fmt.Errorf("seek to offset %d: %w", clamped, err)
+		t.mu.Lock()
+		t.phase = status.PhaseTask
+		t.mu.Unlock()
+		return t.Start(true)
 	}
 
-	t.offset = clamped
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.running {
+		f.Close()
+		return nil
+	}
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		f.Close()
+		return fmt.Errorf("seek to offset %d: %w", offset, err)
+	}
+
+	t.offset = offset
 	t.inHeader = false
-	t.deferSections = false
-	t.pendingSection = ""
-	t.pendingPhase = ""
+	if t.config.PendingSection != "" {
+		// carry over a deferred section from a previous tailer so its
+		// section/task-start event is emitted when the next line arrives,
+		// instead of being silently lost across the restart.
+		t.deferSections = true
+		t.pendingSection = t.config.PendingSection
+		t.pendingPhase = t.config.PendingPhase
+	} else {
+		t.deferSections = false
+		t.pendingSection = ""
+		t.pendingPhase = ""
+	}
 
 	t.file = f
 	t.reader = bufio.NewReader(f)

--- a/pkg/web/tail_test.go
+++ b/pkg/web/tail_test.go
@@ -792,11 +792,25 @@ Started: 2026-01-22 10:30:00
 		assert.True(t, found, "should have received 'after resume' event")
 	})
 
-	t.Run("clamps offset beyond file size without panic", func(t *testing.T) {
+	t.Run("offset beyond file size falls back to reading from beginning", func(t *testing.T) {
+		// models the case where a progress file was truncated for reuse
+		// (executor drops "Completed:" files and restarts). the stored
+		// lastOffset from the previous run is larger than the new file
+		// size, so StartFromOffset must treat this as "new file generation"
+		// and read from the start rather than seeking to EOF and skipping
+		// the new run's header and early lines.
 		tmpDir := t.TempDir()
 		progressFile := filepath.Join(tmpDir, "progress-test.txt")
 
-		content := "[26-01-22 10:30:01] hello\n"
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] hello
+`
 		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
 
 		tailer := NewTailer(progressFile, TailerConfig{
@@ -804,18 +818,25 @@ Started: 2026-01-22 10:30:00
 			InitialPhase: status.PhaseTask,
 		})
 
-		// offset way past EOF should be clamped, no panic, no events
 		require.NoError(t, tailer.StartFromOffset(99999))
 		defer tailer.Stop()
 
-		select {
-		case ev := <-tailer.Events():
-			t.Fatalf("expected no events, got %+v", ev)
-		case <-time.After(100 * time.Millisecond):
+		var got string
+		timeout := time.After(500 * time.Millisecond)
+	loop:
+		for {
+			select {
+			case ev := <-tailer.Events():
+				if ev.Text == "hello" {
+					got = ev.Text
+					break loop
+				}
+			case <-timeout:
+				break loop
+			}
 		}
-
-		assert.Equal(t, int64(len(content)), tailer.Offset(),
-			"offset should be clamped to file size")
+		assert.Equal(t, "hello", got,
+			"expected tailer to read from beginning after detecting truncation")
 	})
 
 	t.Run("zero offset falls back to seek-to-end", func(t *testing.T) {
@@ -904,6 +925,306 @@ Started: 2026-01-22 10:30:00
 
 		tailer.Stop()
 	})
+}
+
+func TestTailer_Phase(t *testing.T) {
+	t.Run("phase reflects last section header processed", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+--- task iteration 1 ---
+[26-01-22 10:30:01] working on task
+--- review iteration 1 ---
+[26-01-22 10:30:05] reviewing
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.Start(true))
+		defer tailer.Stop()
+
+		// consume events until both sections are seen, then check phase
+		deadline := time.After(500 * time.Millisecond)
+		var sawReview bool
+		for !sawReview {
+			select {
+			case ev := <-tailer.Events():
+				if ev.Phase == status.PhaseReview {
+					sawReview = true
+				}
+			case <-deadline:
+				t.Fatalf("tailer never advanced to review phase; got phase=%q", tailer.Phase())
+			}
+		}
+		assert.Equal(t, status.PhaseReview, tailer.Phase(),
+			"tailer phase should reflect last section header")
+	})
+
+	t.Run("phase defaults to configured initial phase before any section", func(t *testing.T) {
+		tailer := NewTailer("/tmp/nonexistent", TailerConfig{
+			InitialPhase: status.PhaseCodex,
+		})
+		assert.Equal(t, status.PhaseCodex, tailer.Phase())
+	})
+}
+
+func TestTailer_StartFromOffset_TruncationResetsStalePhase(t *testing.T) {
+	// models the Reactivate-after-truncation case: the previous run ended in
+	// PhaseCodex, Session.lastPhase was captured, startTailerLocked seeded
+	// InitialPhase=PhaseCodex into the new tailer, then the progress file was
+	// truncated for a fresh run. StartFromOffset's truncation fallback must
+	// reset the parser phase so pre-section lines in the new file carry
+	// PhaseTask, not the stale PhaseCodex.
+	tmpDir := t.TempDir()
+	progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+	content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] starting task execution phase
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+	tailer := NewTailer(progressFile, TailerConfig{
+		PollInterval: 10 * time.Millisecond,
+		InitialPhase: status.PhaseCodex, // stale phase from previous run
+	})
+
+	require.NoError(t, tailer.StartFromOffset(99999))
+	defer tailer.Stop()
+
+	var got Event
+	timeout := time.After(500 * time.Millisecond)
+loop:
+	for {
+		select {
+		case ev := <-tailer.Events():
+			if ev.Text == "starting task execution phase" {
+				got = ev
+				break loop
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+	require.Equal(t, "starting task execution phase", got.Text,
+		"expected tailer to emit fresh-file line after truncation fallback")
+	assert.Equal(t, status.PhaseTask, got.Phase,
+		"truncation fallback must reset stale phase to PhaseTask for fresh file")
+}
+
+func TestTailer_PendingSection_Accessor(t *testing.T) {
+	t.Run("returns pending section and phase when deferred", func(t *testing.T) {
+		// file ends with a section header but no subsequent line, so the
+		// section event remains pending inside the tailer until the next line.
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] before section
+--- review iteration 2 ---
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.Start(true))
+		defer tailer.Stop()
+
+		// wait until the tailer has consumed the whole file
+		expected := int64(len(content))
+		require.Eventually(t, func() bool { return tailer.Offset() == expected },
+			2*time.Second, 20*time.Millisecond, "tailer should advance to EOF")
+
+		// drain any deferred events that did fire (e.g. "before section") so
+		// we can later confirm pendingSection was not flushed
+		drainEvents(tailer, 80*time.Millisecond)
+
+		section, phase := tailer.PendingSection()
+		assert.Equal(t, "review iteration 2", section,
+			"expected deferred section header to remain pending")
+		assert.Equal(t, status.PhaseReview, phase,
+			"expected pending phase to reflect the deferred section header")
+	})
+
+	t.Run("returns empty when nothing pending", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+		require.NoError(t, os.WriteFile(progressFile, []byte(""), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+		})
+		require.NoError(t, tailer.Start(true))
+		defer tailer.Stop()
+
+		section, phase := tailer.PendingSection()
+		assert.Empty(t, section)
+		assert.Empty(t, phase)
+	})
+}
+
+func TestTailer_StartFromOffset_PreservesPendingSection(t *testing.T) {
+	// models the flock-race recovery path: a previous tailer read a section
+	// header (pendingSection set) but was stopped before the next line
+	// arrived. the resumed tailer must emit the pending section/task-start
+	// events when new content arrives, instead of silently dropping them.
+	tmpDir := t.TempDir()
+	progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+	header := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] pre-section line
+--- task iteration 7 ---
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(header), 0o600))
+
+	// simulate resume: pending section pre-seeded via config
+	tailer := NewTailer(progressFile, TailerConfig{
+		PollInterval:   10 * time.Millisecond,
+		InitialPhase:   status.PhaseTask,
+		PendingSection: "task iteration 7",
+		PendingPhase:   status.PhaseTask,
+	})
+	require.NoError(t, tailer.StartFromOffset(int64(len(header))))
+	defer tailer.Stop()
+
+	// nothing should arrive until a new line appears
+	select {
+	case ev := <-tailer.Events():
+		t.Fatalf("unexpected event before new line: %+v", ev)
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	// append a timestamped line after the pending section header
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+	require.NoError(t, err)
+	_, err = f.WriteString("[26-01-22 10:30:02] post-section line\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	var sawTaskStart, sawSection, sawPostLine bool
+	timeout := time.After(1 * time.Second)
+loop:
+	for !sawTaskStart || !sawSection || !sawPostLine {
+		select {
+		case ev := <-tailer.Events():
+			switch ev.Type { //nolint:exhaustive // only interested in these event types
+			case EventTypeTaskStart:
+				assert.Equal(t, 7, ev.TaskNum)
+				assert.Equal(t, status.PhaseTask, ev.Phase)
+				sawTaskStart = true
+			case EventTypeSection:
+				assert.Equal(t, "task iteration 7", ev.Section)
+				sawSection = true
+			case EventTypeOutput:
+				if ev.Text == "post-section line" {
+					sawPostLine = true
+				}
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+	assert.True(t, sawTaskStart, "expected TaskStart event for pending section")
+	assert.True(t, sawSection, "expected Section event for pending section")
+	assert.True(t, sawPostLine, "expected post-section output event")
+}
+
+func TestTailer_StartFromOffset_NoPendingSectionDoesNotDefer(t *testing.T) {
+	// regression guard: when config.PendingSection is empty, StartFromOffset
+	// must behave as before - deferSections=false, section headers parsed
+	// inline. previously this was unconditional; now it's gated by config.
+	tmpDir := t.TempDir()
+	progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+	header := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] before offset
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(header), 0o600))
+
+	tailer := NewTailer(progressFile, TailerConfig{
+		PollInterval: 10 * time.Millisecond,
+		InitialPhase: status.PhaseTask,
+		// intentionally no PendingSection
+	})
+	require.NoError(t, tailer.StartFromOffset(int64(len(header))))
+	defer tailer.Stop()
+
+	// append a section header followed by a line - section should emit
+	// immediately (not deferred) because no pending-section carryover.
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+	require.NoError(t, err)
+	_, err = f.WriteString("--- task iteration 3 ---\n[26-01-22 10:30:02] after\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// collect up to 5 events or until we see the expected ones
+	var sawSection, sawOutput bool
+	timeout := time.After(500 * time.Millisecond)
+loop:
+	for !sawSection || !sawOutput {
+		select {
+		case ev := <-tailer.Events():
+			if ev.Type == EventTypeSection && ev.Section == "task iteration 3" {
+				sawSection = true
+			}
+			if ev.Type == EventTypeOutput && ev.Text == "after" {
+				sawOutput = true
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+	assert.True(t, sawSection, "expected Section event to fire inline when no pending carryover")
+	assert.True(t, sawOutput, "expected output event after the section header")
+}
+
+// drainEvents consumes any events waiting on the tailer's channel for the
+// given window, discarding them. used by tests that need to inspect tailer
+// state (e.g. PendingSection) without stalling on the event buffer.
+func drainEvents(tailer *Tailer, window time.Duration) {
+	deadline := time.After(window)
+	for {
+		select {
+		case <-tailer.Events():
+		case <-deadline:
+			return
+		}
+	}
 }
 
 func TestNormalizeTokenSignal(t *testing.T) {

--- a/pkg/web/tail_test.go
+++ b/pkg/web/tail_test.go
@@ -658,6 +658,254 @@ func TestIsPriorityEvent(t *testing.T) {
 	}
 }
 
+func TestTailer_Offset(t *testing.T) {
+	t.Run("offset reflects bytes consumed with LF endings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] line one
+[26-01-22 10:30:02] line two
+`
+		err := os.WriteFile(progressFile, []byte(content), 0o600)
+		require.NoError(t, err)
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.Start(true))
+		defer tailer.Stop()
+
+		// wait for events to be consumed
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			if tailer.Offset() == int64(len(content)) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		assert.Equal(t, int64(len(content)), tailer.Offset(),
+			"offset should match raw file size including LF bytes")
+	})
+
+	t.Run("offset reflects bytes consumed with CRLF endings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		// deliberately use CRLF line endings
+		content := "# Ralphex Progress Log\r\n" +
+			"Plan: test.md\r\n" +
+			"------------------------------------------------------------\r\n" +
+			"\r\n" +
+			"[26-01-22 10:30:01] line one\r\n" +
+			"[26-01-22 10:30:02] line two\r\n"
+
+		err := os.WriteFile(progressFile, []byte(content), 0o600)
+		require.NoError(t, err)
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.Start(true))
+		defer tailer.Stop()
+
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			if tailer.Offset() == int64(len(content)) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		assert.Equal(t, int64(len(content)), tailer.Offset(),
+			"offset should include CR+LF bytes, not just LF")
+	})
+
+	t.Run("offset is zero before start", func(t *testing.T) {
+		tailer := NewTailer("/tmp/nonexistent", DefaultTailerConfig())
+		assert.Equal(t, int64(0), tailer.Offset())
+	})
+}
+
+func TestTailer_StartFromOffset(t *testing.T) {
+	t.Run("resumes from byte offset and only emits new content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		prefix := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] before resume
+`
+		err := os.WriteFile(progressFile, []byte(prefix), 0o600)
+		require.NoError(t, err)
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.StartFromOffset(int64(len(prefix))))
+		defer tailer.Stop()
+
+		// nothing pre-existing should appear
+		select {
+		case ev := <-tailer.Events():
+			t.Fatalf("unexpected event before append: %+v", ev)
+		case <-time.After(80 * time.Millisecond):
+		}
+
+		// append new content
+		f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+		require.NoError(t, err)
+		_, err = f.WriteString("[26-01-22 10:30:02] after resume\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		var found bool
+		timeout := time.After(500 * time.Millisecond)
+	loop:
+		for !found {
+			select {
+			case ev := <-tailer.Events():
+				assert.NotEqual(t, "before resume", ev.Text,
+					"pre-offset content should not be emitted")
+				if ev.Text == "after resume" {
+					found = true
+				}
+			case <-timeout:
+				break loop
+			}
+		}
+		assert.True(t, found, "should have received 'after resume' event")
+	})
+
+	t.Run("clamps offset beyond file size without panic", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		content := "[26-01-22 10:30:01] hello\n"
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+
+		// offset way past EOF should be clamped, no panic, no events
+		require.NoError(t, tailer.StartFromOffset(99999))
+		defer tailer.Stop()
+
+		select {
+		case ev := <-tailer.Events():
+			t.Fatalf("expected no events, got %+v", ev)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		assert.Equal(t, int64(len(content)), tailer.Offset(),
+			"offset should be clamped to file size")
+	})
+
+	t.Run("zero offset falls back to seek-to-end", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: test.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+
+[26-01-22 10:30:01] existing line
+`
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.StartFromOffset(0))
+		defer tailer.Stop()
+
+		// existing content should not be emitted (seek to end)
+		select {
+		case ev := <-tailer.Events():
+			t.Fatalf("unexpected event: %+v", ev)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		// appended content should appear
+		f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test file path
+		require.NoError(t, err)
+		_, err = f.WriteString("[26-01-22 10:30:02] new line\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		select {
+		case ev := <-tailer.Events():
+			assert.Equal(t, "new line", ev.Text)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected 'new line' event")
+		}
+	})
+
+	t.Run("negative offset falls back to seek-to-end", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+
+		content := "[26-01-22 10:30:01] preexisting\n"
+		require.NoError(t, os.WriteFile(progressFile, []byte(content), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{
+			PollInterval: 10 * time.Millisecond,
+			InitialPhase: status.PhaseTask,
+		})
+		require.NoError(t, tailer.StartFromOffset(-42))
+		defer tailer.Stop()
+
+		select {
+		case ev := <-tailer.Events():
+			t.Fatalf("unexpected event on negative-offset start: %+v", ev)
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+
+	t.Run("fails on non-existent file", func(t *testing.T) {
+		tailer := NewTailer("/nonexistent/file.txt", DefaultTailerConfig())
+
+		err := tailer.StartFromOffset(10)
+		require.Error(t, err)
+		assert.False(t, tailer.IsRunning())
+	})
+
+	t.Run("start is idempotent", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		progressFile := filepath.Join(tmpDir, "progress-test.txt")
+		require.NoError(t, os.WriteFile(progressFile, []byte("hello\n"), 0o600))
+
+		tailer := NewTailer(progressFile, TailerConfig{PollInterval: 10 * time.Millisecond})
+
+		require.NoError(t, tailer.StartFromOffset(1))
+		// second call while running should be a no-op
+		require.NoError(t, tailer.StartFromOffset(3))
+
+		tailer.Stop()
+	})
+}
+
 func TestNormalizeTokenSignal(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/web/watcher.go
+++ b/pkg/web/watcher.go
@@ -193,6 +193,23 @@ func (w *Watcher) handleProgressFileChange(path string) {
 	for _, id := range ids {
 		w.startTailingIfNeeded(id)
 	}
+
+	// recover from the RefreshStates flock race: if the session for the written
+	// path is still marked completed (flock briefly observed unlocked) but new
+	// bytes just arrived, reactivate it so streaming resumes. scoped to the
+	// exact written path so other completed sessions in the same directory are
+	// not affected. gated on IsLoaded to avoid racing the initial loader.
+	id := sessionIDFromPath(path)
+	session := w.sm.Get(id)
+	if session == nil {
+		return
+	}
+	if session.GetState() != SessionStateCompleted || !session.IsLoaded() {
+		return
+	}
+	if err := session.Reactivate(); err != nil {
+		log.Printf("[WARN] failed to reactivate session %s: %v", id, err)
+	}
 }
 
 // startTailingIfNeeded starts tailing for a session if it's active and not already tailing.

--- a/pkg/web/watcher.go
+++ b/pkg/web/watcher.go
@@ -213,6 +213,15 @@ func (w *Watcher) handleProgressFileChange(path string) {
 }
 
 // startTailingIfNeeded starts tailing for a session if it's active and not already tailing.
+// delegates to SessionManager.activateSession so the Reactivate-vs-StartTailing(true)
+// choice is based on whether lastOffset has already been captured. this matters for
+// the RefreshStates/Discover race: RefreshStates can set state=completed and call
+// StopTailing, and a concurrent Write-event-driven Discover can flip state back to
+// active while the old tailer is still being stopped. handleStateTransition's
+// `!IsTailing()` guard then skips activateSession, leaving the session in
+// "active but not tailing" with lastOffset captured. the next write event reaches
+// this function — using StartTailing(true) would replay from byte 0 and duplicate
+// events the previous tailer already published; Reactivate resumes from lastOffset.
 func (w *Watcher) startTailingIfNeeded(id string) {
 	session := w.sm.Get(id)
 	if session == nil {
@@ -221,9 +230,7 @@ func (w *Watcher) startTailingIfNeeded(id string) {
 	if session.GetState() != SessionStateActive || session.IsTailing() {
 		return
 	}
-	if err := session.StartTailing(true); err != nil {
-		log.Printf("[WARN] failed to start tailing for session %s: %v", id, err)
-	}
+	w.sm.activateSession(session)
 }
 
 // refreshLoop periodically checks for session state changes (active->completed).

--- a/pkg/web/watcher_test.go
+++ b/pkg/web/watcher_test.go
@@ -496,6 +496,67 @@ Started: 2026-01-22 10:00:00
 	assert.Equal(t, "new-plan.md", session.GetMetadata().PlanPath)
 }
 
+// TestWatcher_ResumesStreamingAfterFlockRace is the TDD reproduction test for issue #283.
+// It simulates the flock race where RefreshStates transiently marks a running session as
+// completed (because TryLockFile briefly succeeds), then appends new progress lines to the
+// file and expects the watcher to reactivate the session so streaming resumes.
+//
+// Expected to FAIL on master (before the fix in Task 5) and PASS once the reactivation
+// logic in Watcher.handleProgressFileChange is implemented. Skipped for now so the
+// initial commit stays green; un-skipped in Task 5 after the fix lands.
+func TestWatcher_ResumesStreamingAfterFlockRace(t *testing.T) {
+	t.Skip("issue #283: reactivation-on-write not implemented yet — un-skip in Task 5")
+
+	tmpDir := t.TempDir()
+	progressFile := filepath.Join(tmpDir, "progress-reactivate-test.txt")
+	header := `# Ralphex Progress Log
+Plan: reactivate-plan.md
+Branch: reactivate-branch
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] initial line 1
+[26-01-22 10:00:02] initial line 2
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(header), 0o600))
+
+	sm := NewSessionManager()
+	w, err := NewWatcher([]string{tmpDir}, sm)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	go func() { _ = w.Start(ctx) }()
+
+	// wait for initial discovery
+	sessionID := sessionIDFromPath(progressFile)
+	require.Eventually(t, func() bool {
+		return sm.Get(sessionID) != nil
+	}, time.Second, 10*time.Millisecond, "session should be discovered")
+
+	session := sm.Get(sessionID)
+	require.NotNil(t, session)
+
+	// simulate the flock race: force state to completed and stop tailing
+	// (models what RefreshStates does when TryLockFile transiently succeeds)
+	session.SetState(SessionStateCompleted)
+	session.StopTailing()
+	assert.Eventually(t, func() bool { return !session.IsTailing() }, time.Second, 10*time.Millisecond)
+	require.Equal(t, SessionStateCompleted, session.GetState())
+
+	// append new lines — simulates the still-running executor writing after the race
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test-controlled path from t.TempDir
+	require.NoError(t, err)
+	_, err = f.WriteString("[26-01-22 10:00:03] line after reactivation\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// expect watcher to reactivate the session on the Write event
+	assert.Eventually(t, func() bool {
+		return session.GetState() == SessionStateActive && session.IsTailing()
+	}, 2*time.Second, 20*time.Millisecond, "session should reactivate and resume tailing after write")
+}
+
 func TestWatcher_Close(t *testing.T) {
 	tmpDir := t.TempDir()
 	sm := NewSessionManager()

--- a/pkg/web/watcher_test.go
+++ b/pkg/web/watcher_test.go
@@ -834,7 +834,6 @@ Started: 2026-01-22 10:00:00
 		"session B should NOT be tailing - no write event arrived for its path")
 }
 
-
 func TestWatcher_Close(t *testing.T) {
 	tmpDir := t.TempDir()
 	sm := NewSessionManager()

--- a/pkg/web/watcher_test.go
+++ b/pkg/web/watcher_test.go
@@ -2,13 +2,18 @@ package web
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tmaxmax/go-sse"
 )
 
 // resolveSymlinks resolves symlinks in the given path for test comparison.
@@ -500,13 +505,7 @@ Started: 2026-01-22 10:00:00
 // It simulates the flock race where RefreshStates transiently marks a running session as
 // completed (because TryLockFile briefly succeeds), then appends new progress lines to the
 // file and expects the watcher to reactivate the session so streaming resumes.
-//
-// Expected to FAIL on master (before the fix in Task 5) and PASS once the reactivation
-// logic in Watcher.handleProgressFileChange is implemented. Skipped for now so the
-// initial commit stays green; un-skipped in Task 5 after the fix lands.
 func TestWatcher_ResumesStreamingAfterFlockRace(t *testing.T) {
-	t.Skip("issue #283: reactivation-on-write not implemented yet — un-skip in Task 5")
-
 	tmpDir := t.TempDir()
 	progressFile := filepath.Join(tmpDir, "progress-reactivate-test.txt")
 	header := `# Ralphex Progress Log
@@ -556,6 +555,285 @@ Started: 2026-01-22 10:00:00
 		return session.GetState() == SessionStateActive && session.IsTailing()
 	}, 2*time.Second, 20*time.Millisecond, "session should reactivate and resume tailing after write")
 }
+
+// subscribeSSEEvents opens an SSE subscription on the session and returns a
+// channel that receives every Event.Data string until the returned cancel is
+// called. used by watcher tests to verify event delivery without relying on
+// internal tailer state.
+func subscribeSSEEvents(t *testing.T, session *Session) (<-chan string, func()) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(session.SSE.ServeHTTP))
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	events := make(chan string, 64)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer func() { _ = resp.Body.Close() }()
+		for ev, readErr := range sse.Read(resp.Body, nil) {
+			if readErr != nil {
+				return
+			}
+			select {
+			case events <- ev.Data:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	cleanup := func() {
+		cancelCtx()
+		ts.Close()
+		wg.Wait()
+	}
+	return events, cleanup
+}
+
+// drainChannel collects any events already available on ch without blocking
+// beyond the specified settle window. used to capture the final set of events
+// delivered during a test step.
+func drainChannel(ch <-chan string, settle time.Duration) []string {
+	var got []string
+	timer := time.NewTimer(settle)
+	defer timer.Stop()
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return got
+			}
+			got = append(got, ev)
+			// reset settle window for follow-up events
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(settle)
+		case <-timer.C:
+			return got
+		}
+	}
+}
+
+func TestWatcher_ReactivatesCompletedSessionOnWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	progressFile := filepath.Join(tmpDir, "progress-reactivate-write.txt")
+	initial := `# Ralphex Progress Log
+Plan: reactivate-plan.md
+Branch: reactivate-branch
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] initial line alpha
+[26-01-22 10:00:02] initial line beta
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(initial), 0o600))
+
+	sm := NewSessionManager()
+	w, err := NewWatcher([]string{tmpDir}, sm)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	go func() { _ = w.Start(ctx) }()
+
+	sessionID := sessionIDFromPath(progressFile)
+	require.Eventually(t, func() bool {
+		s := sm.Get(sessionID)
+		return s != nil && s.IsLoaded() && s.getLastOffset() == int64(len(initial))
+	}, 2*time.Second, 20*time.Millisecond, "session should be discovered, loaded, with offset set")
+
+	session := sm.Get(sessionID)
+	require.NotNil(t, session)
+	require.Equal(t, SessionStateCompleted, session.GetState())
+
+	// subscribe AFTER initial load so replay includes the initial two lines
+	events, cleanup := subscribeSSEEvents(t, session)
+	defer cleanup()
+
+	// drain the replay (initial published lines)
+	replayed := drainChannel(events, 300*time.Millisecond)
+	require.NotEmpty(t, replayed, "SSE replay should contain initial events")
+	preCount := len(replayed)
+
+	// append a new line - simulates a still-running executor writing after a flock race
+	newLine := "[26-01-22 10:00:03] line after reactivate\n"
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test path from t.TempDir
+	require.NoError(t, err)
+	_, err = f.WriteString(newLine)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// watcher should reactivate the session
+	require.Eventually(t, func() bool {
+		return session.GetState() == SessionStateActive && session.IsTailing()
+	}, 2*time.Second, 20*time.Millisecond, "session should reactivate on write event")
+
+	// collect events that arrive after reactivation
+	newEvents := drainChannel(events, 500*time.Millisecond)
+	require.NotEmpty(t, newEvents, "new line event should arrive after reactivation")
+
+	// verify the new line arrived exactly once and pre-existing lines were NOT re-emitted
+	var newLineMatches int
+	for _, ev := range newEvents {
+		if strings.Contains(ev, "line after reactivate") {
+			newLineMatches++
+		}
+		require.NotContains(t, ev, "initial line alpha", "pre-existing content must not be re-emitted")
+		require.NotContains(t, ev, "initial line beta", "pre-existing content must not be re-emitted")
+	}
+	assert.Equal(t, 1, newLineMatches, "new line should be delivered exactly once")
+	assert.GreaterOrEqual(t, preCount, 1, "replay should include the initial events")
+}
+
+func TestWatcher_DoesNotReactivateActiveSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	progressFile := filepath.Join(tmpDir, "progress-active-no-reactivate.txt")
+	initial := `# Ralphex Progress Log
+Plan: active-plan.md
+Branch: active-branch
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] initial active line
+`
+	require.NoError(t, os.WriteFile(progressFile, []byte(initial), 0o600))
+
+	sm := NewSessionManager()
+	sessionID := sessionIDFromPath(progressFile)
+
+	// register an active session directly (simulate a session that is already
+	// tailing, bypassing flock-based discovery which would mark it completed)
+	session := NewSession(sessionID, progressFile)
+	sm.Register(session)
+	require.True(t, session.MarkLoadedIfNot(), "simulate loader has completed")
+	session.SetState(SessionStateActive)
+	require.NoError(t, session.StartTailing(true))
+	require.Eventually(t, func() bool { return session.IsTailing() },
+		time.Second, 10*time.Millisecond)
+
+	// wait for the tailer to consume the initial content so SSE replayer has
+	// at least one event; this lets the SSE server flush headers on subscribe.
+	require.Eventually(t, func() bool {
+		tl := session.GetTailer()
+		return tl != nil && tl.Offset() >= int64(len(initial))
+	}, 2*time.Second, 20*time.Millisecond, "tailer should read initial content")
+
+	w, err := NewWatcher([]string{tmpDir}, sm)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	go func() { _ = w.Start(ctx) }()
+
+	// allow initial startup (watcher may trigger one Discover cycle)
+	time.Sleep(150 * time.Millisecond)
+
+	events, cleanup := subscribeSSEEvents(t, session)
+	defer cleanup()
+
+	// drain any replayed events from the pre-subscription window
+	_ = drainChannel(events, 200*time.Millisecond)
+
+	// append exactly one new line and expect exactly one event to reach SSE
+	newLine := "[26-01-22 10:00:02] active mode new line\n"
+	f, err := os.OpenFile(progressFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test path from t.TempDir
+	require.NoError(t, err)
+	_, err = f.WriteString(newLine)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// give the tailer time to read the line and the Write event to be processed
+	delivered := drainChannel(events, 500*time.Millisecond)
+
+	var matches int
+	for _, ev := range delivered {
+		if strings.Contains(ev, "active mode new line") {
+			matches++
+		}
+	}
+	assert.Equal(t, 1, matches, "new line must be delivered exactly once (no duplicate tailer)")
+
+	// state must still be active (not cycled through completed -> active)
+	assert.Equal(t, SessionStateActive, session.GetState())
+}
+
+func TestWatcher_OnlyReactivatesWrittenPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fileA := filepath.Join(tmpDir, "progress-reactivate-a.txt")
+	fileB := filepath.Join(tmpDir, "progress-reactivate-b.txt")
+	contentA := `# Ralphex Progress Log
+Plan: plan-a.md
+Branch: branch-a
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] a initial
+`
+	contentB := `# Ralphex Progress Log
+Plan: plan-b.md
+Branch: branch-b
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+[26-01-22 10:00:01] b initial
+`
+	require.NoError(t, os.WriteFile(fileA, []byte(contentA), 0o600))
+	require.NoError(t, os.WriteFile(fileB, []byte(contentB), 0o600))
+
+	sm := NewSessionManager()
+	w, err := NewWatcher([]string{tmpDir}, sm)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	go func() { _ = w.Start(ctx) }()
+
+	idA := sessionIDFromPath(fileA)
+	idB := sessionIDFromPath(fileB)
+
+	require.Eventually(t, func() bool {
+		a := sm.Get(idA)
+		b := sm.Get(idB)
+		return a != nil && a.IsLoaded() && b != nil && b.IsLoaded()
+	}, 2*time.Second, 20*time.Millisecond, "both sessions should be discovered and loaded")
+
+	sessionA := sm.Get(idA)
+	sessionB := sm.Get(idB)
+	require.Equal(t, SessionStateCompleted, sessionA.GetState())
+	require.Equal(t, SessionStateCompleted, sessionB.GetState())
+
+	// write only to file A
+	f, err := os.OpenFile(fileA, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test path from t.TempDir
+	require.NoError(t, err)
+	_, err = f.WriteString("[26-01-22 10:00:02] a extra line\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// sessionA must reactivate
+	require.Eventually(t, func() bool {
+		return sessionA.GetState() == SessionStateActive && sessionA.IsTailing()
+	}, 2*time.Second, 20*time.Millisecond, "session A should be reactivated")
+
+	// sessionB must stay completed (give the watcher ample time to misbehave)
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, SessionStateCompleted, sessionB.GetState(),
+		"session B should NOT be reactivated - no write event arrived for its path")
+	assert.False(t, sessionB.IsTailing(),
+		"session B should NOT be tailing - no write event arrived for its path")
+}
+
 
 func TestWatcher_Close(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/pkg/web/watcher_test.go
+++ b/pkg/web/watcher_test.go
@@ -663,7 +663,6 @@ Started: 2026-01-22 10:00:00
 	// drain the replay (initial published lines)
 	replayed := drainChannel(events, 300*time.Millisecond)
 	require.NotEmpty(t, replayed, "SSE replay should contain initial events")
-	preCount := len(replayed)
 
 	// append a new line - simulates a still-running executor writing after a flock race
 	newLine := "[26-01-22 10:00:03] line after reactivate\n"
@@ -692,7 +691,6 @@ Started: 2026-01-22 10:00:00
 		require.NotContains(t, ev, "initial line beta", "pre-existing content must not be re-emitted")
 	}
 	assert.Equal(t, 1, newLineMatches, "new line should be delivered exactly once")
-	assert.GreaterOrEqual(t, preCount, 1, "replay should include the initial events")
 }
 
 func TestWatcher_DoesNotReactivateActiveSession(t *testing.T) {

--- a/pkg/web/watcher_test.go
+++ b/pkg/web/watcher_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmaxmax/go-sse"
+
+	"github.com/umputun/ralphex/pkg/progress"
+	"github.com/umputun/ralphex/pkg/status"
 )
 
 // resolveSymlinks resolves symlinks in the given path for test comparison.
@@ -830,6 +833,80 @@ Started: 2026-01-22 10:00:00
 		"session B should NOT be reactivated - no write event arrived for its path")
 	assert.False(t, sessionB.IsTailing(),
 		"session B should NOT be tailing - no write event arrived for its path")
+}
+
+// TestWatcher_StartTailingIfNeededReactivatesWithStoredOffset verifies the fix
+// for the RefreshStates/Discover race where handleStateTransition skipped
+// activateSession because IsTailing() was transiently true during StopTailing.
+// the race leaves the session in "active but not tailing" with lastOffset
+// captured. on the next write event startTailingIfNeeded must resume from the
+// stored offset, not replay from byte 0 (StartTailing(true)) — otherwise every
+// event the previous tailer published would be re-emitted into the SSE stream.
+func TestWatcher_StartTailingIfNeededReactivatesWithStoredOffset(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	require.NoError(t, os.WriteFile(planPath, []byte("# plan"), 0o600))
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	holder := &status.PhaseHolder{}
+	logger, err := progress.NewLogger(progress.Config{
+		PlanFile: planPath,
+		Mode:     "full",
+		Branch:   "main",
+	}, testColors(), holder)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	progressPath := logger.Path()
+
+	// seed the progress file with content so there is a non-trivial offset
+	// to resume from.
+	appendF, err := os.OpenFile(progressPath, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	_, err = appendF.WriteString("[26-01-22 10:00:01] pre-race line\n")
+	require.NoError(t, err)
+	require.NoError(t, appendF.Close())
+
+	preRaceSize, err := os.Stat(progressPath)
+	require.NoError(t, err)
+
+	// construct the state the RefreshStates/Discover race leaves behind:
+	//   - state = active (Discover flipped completed->active on write)
+	//   - tailer = nil (RefreshStates finished StopTailing after Discover's
+	//     IsTailing() check had already returned true)
+	//   - lastOffset > 0 (StopTailing captured the previous tailer's offset)
+	id := sessionIDFromPath(progressPath)
+	session := NewSession(id, progressPath)
+	session.SetState(SessionStateActive)
+	require.True(t, session.MarkLoadedIfNot())
+	session.setLastOffset(preRaceSize.Size())
+
+	sm := NewSessionManager()
+	sm.Register(session)
+
+	w, err := NewWatcher([]string{dir}, sm)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	// invoke startTailingIfNeeded directly - models the next Write-event pass
+	// through handleProgressFileChange after the race.
+	w.startTailingIfNeeded(id)
+
+	require.Eventually(t, func() bool {
+		return session.IsTailing() && session.GetTailer() != nil
+	}, time.Second, 10*time.Millisecond, "tailer should be running after reactivation")
+
+	tailerOffset := session.GetTailer().Offset()
+	assert.GreaterOrEqual(t, tailerOffset, preRaceSize.Size(),
+		"tailer must resume from stored lastOffset, not byte 0; got %d, want >= %d",
+		tailerOffset, preRaceSize.Size())
+
+	// state must remain active
+	assert.Equal(t, SessionStateActive, session.GetState())
 }
 
 func TestWatcher_Close(t *testing.T) {

--- a/pkg/web/watcher_test.go
+++ b/pkg/web/watcher_test.go
@@ -710,6 +710,14 @@ Started: 2026-01-22 10:00:00
 `
 	require.NoError(t, os.WriteFile(progressFile, []byte(initial), 0o600))
 
+	// hold an exclusive flock on the progress file so IsActive() reports true
+	// (cross-process detection via TryLockFile). without this, w.Start's initial
+	// DiscoverRecursive would call updateSession -> IsActive=false -> flip the
+	// session to completed and stop tailing, defeating the test's premise.
+	// unix-only; skips on windows.
+	releaseLock := holdFileLockForTest(t, progressFile)
+	defer releaseLock()
+
 	sm := NewSessionManager()
 	sessionID := sessionIDFromPath(progressFile)
 
@@ -736,8 +744,13 @@ Started: 2026-01-22 10:00:00
 	ctx := t.Context()
 	go func() { _ = w.Start(ctx) }()
 
-	// allow initial startup (watcher may trigger one Discover cycle)
+	// allow initial startup; with the flock held, DiscoverRecursive's
+	// updateSession sees IsActive=true and leaves the active+tailing session
+	// untouched, so the tailer started above continues to own the file.
 	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, SessionStateActive, session.GetState(),
+		"watcher startup must not flip an actively tailing session")
+	require.True(t, session.IsTailing(), "tailer must remain running after Discover")
 
 	events, cleanup := subscribeSSEEvents(t, session)
 	defer cleanup()


### PR DESCRIPTION
Fixes #283.

When the watch-mode dashboard runs as a separate process from the executor (`pm2 start ralphex -s -w /path` + separate `ralphex docs/plans/...`), `RefreshStates` would mark the session `completed` whenever the 5s tick hit a moment where `TryLockFile` won the race against the executor's flock. Once marked completed, `startTailingIfNeeded` refused to restart tailing, so the dashboard froze even though the executor was still writing to the progress file.

**Fix** — option B from the issue thread: on a write event for a `completed` session, reactivate it and resume tailing from a tracked offset. Flock-based detection in `RefreshStates` stays — reactivation is the recovery path, not a replacement.

**Mechanics**

- `Tailer.Offset()` and `Tailer.StartFromOffset(offset)` expose and seek the internal offset
- `Session.lastOffset` captured inside `StopTailing()` before the tailer is stopped
- `Session.Reactivate()` starts a new tailer at `lastOffset` (or `fromEnd` if offset is 0), then flips state to `active` only on success
- `loadProgressFileIntoSession` records bytes read pre-trim, so CRLF/LF/no-newline all count correctly
- `Watcher.handleProgressFileChange` calls `Reactivate()` for the specific written path when the session is `completed` and `IsLoaded()` (avoids racing the loader)

**Windows note** — `flock` is a no-op on Windows so `IsActive` always returns false. Reactivation-on-write becomes the *primary* streaming mechanism on Windows, not just a recovery path. No platform-specific code needed.

**Tests**
- TDD reproduction: `TestWatcher_ResumesStreamingAfterFlockRace` (red without the fix, green with it)
- offset/seek edges: zero-fallback, beyond-file-size, CRLF, LF, no-trailing-newline
- `Reactivate`: idempotent, resume-from-offset (no duplicates), failed-start-leaves-state-unchanged, on-closed-session
- watcher: only the written path is reactivated (sibling completed sessions stay completed)
- 86.9% coverage in `pkg/web`

Verified end-to-end against the toy project — dashboard streaming survives the 5s `RefreshStates` tick mid-run.
