### PR TITLE
feat: add ralphex-adopt skill for converting plans to ralphex format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ralphex",
       "source": "./",
       "description": "Autonomous plan execution with Claude Code - task execution, monitoring, and plan creation",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphex",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Autonomous plan execution with Claude Code - task execution, monitoring, and plan creation",
   "author": {
     "name": "umputun",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,7 @@ Variables are also expanded inside agent content, so custom agents can use `{{DE
 - Run `ralphex --reset` to interactively restore defaults, or delete ALL `.txt` files manually
 - Run `ralphex --dump-defaults <dir>` to extract raw embedded defaults for comparison or merging
 - Use `/ralphex-update` skill for smart merging of updated defaults into customized configs
+- Use `/ralphex-adopt` skill to convert plans from other formats (OpenSpec, spec-kit, GitHub/GitLab issues, task-lists, free-form markdown) into ralphex format
 - Alternatively, reference agents installed in your Claude Code directly in prompt files (like `qa-expert`, `go-smells-expert`)
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1205,11 +1205,12 @@ ralphex works standalone from the terminal. Optionally, you can add slash comman
 |---------|-------------|
 | `/ralphex` | Launch and monitor ralphex execution with interactive mode/plan selection |
 | `/ralphex-plan` | Create structured implementation plans with guided context gathering |
+| `/ralphex-adopt` | Convert plans from various source formats (OpenSpec, spec-kit, GitHub/GitLab issues, generic task-lists, free-form markdown) into ralphex-format plans |
 | `/ralphex-update` | Smart-merge updated embedded defaults into customized prompts/agents |
 
 ### Installation
 
-The ralphex CLI is the primary interface. Claude Code skills (`/ralphex`, `/ralphex-plan`, and `/ralphex-update`) are optional convenience commands.
+The ralphex CLI is the primary interface. Claude Code skills (`/ralphex`, `/ralphex-plan`, `/ralphex-adopt`, and `/ralphex-update`) are optional convenience commands.
 
 **Via Plugin Marketplace (Recommended)**
 
@@ -1228,6 +1229,7 @@ Benefits: Auto-updates when marketplace refreshes (at Claude Code startup).
 The slash command definitions are hosted at:
 - [`/ralphex`](https://ralphex.com/assets/claude/ralphex.md)
 - [`/ralphex-plan`](https://ralphex.com/assets/claude/ralphex-plan.md)
+- [`/ralphex-adopt`](https://ralphex.com/assets/claude/ralphex-adopt.md)
 - [`/ralphex-update`](https://ralphex.com/assets/claude/ralphex-update.md)
 
 To install, ask Claude Code to "install ralphex slash commands" or manually copy the files to `~/.claude/commands/`.

--- a/assets/claude/ralphex-adopt.md
+++ b/assets/claude/ralphex-adopt.md
@@ -1,0 +1,1 @@
+./skills/ralphex-adopt/SKILL.md

--- a/assets/claude/skills/ralphex-adopt/SKILL.md
+++ b/assets/claude/skills/ralphex-adopt/SKILL.md
@@ -247,7 +247,7 @@ test -x "$LAUNCHER" && "$LAUNCHER" --wrap --only=<draft-path>
 
 If the launcher path does not exist (`test -x` fails), skip directly to the in-chat fallback below — the user has revdiff installed via Homebrew or `go install` but does not have the Claude marketplace plugin layout.
 
-Capture stdout into a variable.
+Read the launcher's stdout from the Bash tool result directly. Do not assign it to a shell variable — variables do not persist between Bash tool calls (see Step 5 preamble).
 
 - **Empty stdout** → user reviewed and approved silently. Proceed to Step 6.
 - **Non-empty stdout** → user left annotations. Read each annotation, revise the draft accordingly (rewrite the literal `<draft-path>` in place via Write), then re-run revdiff. Repeat until stdout is empty.

--- a/assets/claude/skills/ralphex-adopt/SKILL.md
+++ b/assets/claude/skills/ralphex-adopt/SKILL.md
@@ -1,0 +1,346 @@
+---
+description: Convert plans from various source formats (OpenSpec, spec-kit, GitHub/GitLab issues with checklists, generic task-lists, free-form markdown) into ralphex-format plans in docs/plans/. Triggers on "ralphex-adopt", "adopt plan", "convert plan to ralphex", "import plan as ralphex".
+allowed-tools: [Bash, Read, Write, Glob, Grep, AskUserQuestion]
+---
+
+# ralphex-adopt - Convert Plans Into ralphex Format
+
+**SCOPE**: Read a source plan in some other format and produce a new ralphex-format plan at `docs/plans/YYYYMMDD-<slug>.md`. The source is never modified. Existing target files are never silently overwritten.
+
+Supported source shapes:
+
+- **OpenSpec change**: directory containing `proposal.md`, `tasks.md`, optional `specs/**/spec.md`
+- **spec-kit spec**: directory or file with spec/plan/tasks separation
+- **GitHub or GitLab issue**: URL, `#N`, or `owner/repo#N` with body that contains a task checklist
+- **Generic task-list**: any structured markdown/text with headings and bullet items
+- **Free-form markdown**: prose brain dump with no fixed structure
+
+This is a single-skill conversion: discover, classify, ask focused questions when in doubt, draft, review, write. Do not modify code, do not run tests, do not commit. Output is the new plan file only.
+
+## Step 0: Optional CLI Check
+
+This check is **informational only**. Missing ralphex CLI must NOT break the flow — conversion does not require it. Do NOT block, exit, prompt the user, or wait for installation. Always continue to Step 1 regardless of the result.
+
+```bash
+which ralphex
+```
+
+If `which ralphex` returns non-zero, briefly mention that ralphex is needed to execute the converted plan later (not now), list install options once, and continue immediately:
+
+- **macOS (Homebrew)**: `brew install umputun/apps/ralphex`
+- **Linux (Debian/Ubuntu)**: download `.deb` from https://github.com/umputun/ralphex/releases
+- **Linux (RHEL/Fedora)**: download `.rpm` from https://github.com/umputun/ralphex/releases
+- **Any platform with Go**: `go install github.com/umputun/ralphex/cmd/ralphex@latest`
+
+If `which ralphex` succeeds, say nothing and proceed.
+
+## Step 1: Resolve Source From Argument Shape
+
+Inspect `$ARGUMENTS` and pick exactly one source by shape, in this order:
+
+1. **Full URL** (starts with `http://` or `https://`):
+   - GitHub issue/PR URL → use `gh issue view <url> --json title,body,labels` (or `gh pr view`)
+   - GitLab issue/MR URL → use `glab issue view <url>` (or `glab mr view`)
+   - Other URL → fetch with `curl -fsSL` only if it points at a raw markdown file; otherwise AskUser to paste the body
+
+2. **Bare reference** `#N`:
+   - Use the current git repository's host. Detect with `git remote get-url origin` and choose `gh` or `glab` accordingly.
+   - If `git remote get-url origin` fails (not a git repo, or no `origin` remote), AskUserQuestion to disambiguate: "GitHub", "GitLab", "Provide qualified `owner/repo#N` instead", "Cancel". Re-resolve based on the answer.
+   - GitHub: `gh issue view N --json title,body` (try `gh pr view N` if issue not found)
+   - GitLab: `glab issue view N` (try `glab mr view N` if not found)
+
+3. **Qualified reference** `owner/repo#N` or `group/project#N`:
+   - GitHub: `gh issue view N --repo owner/repo`
+   - GitLab: `glab issue view N --repo group/project`
+
+4. **Existing path** — first probe the literal argument as a filesystem path with `test -e "$ARGUMENTS"`:
+   - **File**: read with the Read tool
+   - **Directory**: list with `ls -la <path>` and inspect contents
+     - If contains `proposal.md` AND `tasks.md` → likely OpenSpec, proceed to Step 2
+     - If contains a single `*.md` → use that file
+     - Otherwise AskUser which file inside the directory is the plan
+
+5. **Bare name** — only if the argument failed every check above (not a URL, not `#N` or `owner/repo#N`, and `test -e` returned false). A bare name has no path separators and contains no path-like characters:
+   - Search filesystem with Glob for plausible matches (e.g., `**/*<name>*.md`, `**/*<name>*/proposal.md`)
+   - If exactly one match → use it
+   - If multiple matches → AskUser to pick one (use AskUserQuestion with up to 4 most relevant; if more, summarize and AskUser to paste the path)
+   - If no matches → AskUser whether they meant a path, an issue number, or something else
+
+6. **No argument**:
+   - Use AskUserQuestion: "Where is the source plan?" with options like "Paste it", "Provide a file path", "Provide an issue number/URL", "Cancel".
+
+After resolving, store: source kind (`github-issue`, `gitlab-issue`, `file`, `directory`, `pasted`), source content (full text or directory listing + key files), and source identifier for the slug suggestion.
+
+## Step 2: Detect Format
+
+Look at the resolved content and classify it as one of:
+
+- **OpenSpec**: directory has both `proposal.md` and `tasks.md`. May also have `specs/**/spec.md` deltas.
+- **spec-kit**: directory or single file shows the spec-kit shape — separate spec/plan/tasks sections, often with explicit "Specification", "Implementation Plan", "Tasks" headings.
+- **Issue with checklist**: source kind is `github-issue` or `gitlab-issue`, and the body contains one or more `- [ ]` items.
+- **Generic task-list**: any structured source with headings and bullet items that is not OpenSpec, spec-kit, or an issue. Section heading style and item-marker style may vary.
+- **Free-form**: prose-only or near-prose source with no clear task list. Includes brain-dump style text.
+
+If multiple signals point in different directions (e.g., a directory with both a `proposal.md` and a clearly spec-kit-shaped `plan.md`), AskUser to confirm which format to use before drafting.
+
+## Step 3: Confidence Guard — Ask Before Drafting
+
+Before writing any draft, scan the source for items the agent cannot confidently map. For each uncertainty, AskUser **before drafting**, never embed placeholder markers (`???`, `TBD`, `[FIXME]`) into the converted plan.
+
+Common uncertainties:
+
+- Which headings should become Task sections vs. Overview/Context vs. Technical Details?
+- How should a long flat list be split into Tasks (logical phases vs. fixed groups)?
+- A bullet item is vague ("clean up the auth module") — what concrete steps are intended?
+- Source mixes intent (feature + refactor + bug fix) — should this become one plan or be flagged as multi-plan?
+- Source is in a non-English natural language — ask whether to translate Overview/Context prose or preserve the original (the structural keyword `Task` in headers is always English regardless).
+- Source is very large (>1000 lines) or very small (<10 lines) — confirm scope before processing.
+
+Use AskUserQuestion with concrete options. If the question is genuinely open-ended (more than 4 possibilities), present a numbered list in chat and ask the user to reply with a number.
+
+Do not draft, then ask. Ask, then draft.
+
+## Step 4: Convert Per Format
+
+All converted plans must satisfy ralphex's plan-format rules:
+
+- File starts with `# <Plan Title>` H1.
+- Standard sections in order: `## Overview`, `## Context`, `## Development Approach`, `## Testing Strategy`, `## Progress Tracking`, optional `## Technical Details` (when source has architecture/spec details to preserve), `## Implementation Steps`, optional `## Post-Completion`.
+- Task headers use the structural form `### Task <N>: <title>`. The keyword `Task` is **always English**, even when the plan title and task titles are in another natural language. ralphex's plan parser only recognizes English `Task` and `Iteration` keywords; localized variants (`Задача`, `タスク`, `Tarea`, etc.) will not be detected.
+- Checkboxes (`- [ ]` / `- [x]`) appear **only inside Task sections**. Do not put checkboxes in Overview, Context, Success criteria, or any other section — they cause the executor to spawn extra iterations.
+- Every Task should end with a "write tests" checkbox and a "run project tests" checkbox, phrased generically (project may be in any language).
+- The final Task is always `### Task <last>: Verify acceptance criteria` containing items that re-run the test suite, run the project linter, and confirm requirements from Overview were met.
+
+Per-format mapping rules:
+
+### OpenSpec
+
+- `proposal.md` "## Why" or equivalent → `## Overview` (the problem statement and motivation)
+- `proposal.md` "## What Changes" → `## Context` (impacted components and constraints)
+- `specs/**/spec.md` delta sections (ADDED / MODIFIED / REMOVED requirements) → `## Technical Details` (concrete behavior changes)
+- `tasks.md` numbered list → `## Implementation Steps` grouped into `### Task N:` sections. Each top-level numbered group becomes a Task; sub-bullets become checkboxes.
+- Add `write tests` and `run project tests` checkboxes to each Task even if absent in source.
+- Append a final `### Task <last>: Verify acceptance criteria` Task.
+
+### spec-kit
+
+- "Specification" section → `## Overview` and `## Context`
+- "Implementation Plan" / architecture section → `## Technical Details`
+- "Tasks" section → `## Implementation Steps` with one `### Task N:` per logical phase
+- Add `write tests`, `run project tests`, and final `Verify acceptance criteria` Task.
+
+### GitHub / GitLab Issue with Checklist
+
+- Issue title → `# <Plan Title>` (drop trailing punctuation, normalize whitespace)
+- Issue body prose above the first checklist → `## Overview`
+- Issue labels and metadata → `## Context` (e.g., "Reported in repo X, labels: bug, p1, area/auth")
+- Top-level `- [ ]` items in body → `## Implementation Steps`
+  - If the body has H3 sub-headings that group items, preserve those grouping into Tasks.
+  - Otherwise, group every 5–7 items into one Task; create a synthetic title summarizing the group.
+- Preserve `- [x]` checked state from the source.
+- Add `write tests` and `run project tests` per Task; append final `Verify acceptance criteria` Task.
+
+### Generic Task-List
+
+- Infer the heading style (`#`, `##`, `###`, or numbered headings) from the source.
+- Infer the item style (`- [ ]`, `* [ ]`, `1.`, `-`, plain dashes).
+- Normalize:
+  - Top-level grouping headings become `### Task N: <title>` (use English `Task` keyword regardless of the source language).
+  - Item lines become `- [ ]` checkboxes inside the Task.
+  - Preserve checked state if the source uses any form of "done" marker.
+- If grouping is unclear (single flat list, ambiguous heading hierarchy), AskUser before drafting how to split.
+- Add `write tests`, `run project tests`, and final `Verify acceptance criteria` Task.
+
+### Free-Form Markdown
+
+- Infer intent from the prose (feature / bug fix / refactor / migration / docs).
+- First paragraph or two → `## Overview`.
+- Background, constraints, references → `## Context`.
+- Decompose the body into 3–7 Task groups by logical phase (read carefully; do not invent steps the source does not imply).
+- For each Task, write 3–6 concrete checkboxes that map directly to phrases in the source. Do not embed `[FIXME]` or `???` — if a phrase is too vague, AskUser in Step 3 first.
+- Add `write tests`, `run project tests`, and final `Verify acceptance criteria` Task.
+
+### Output Skeleton (all formats)
+
+```markdown
+# <Plan Title>
+
+## Overview
+
+<one or two paragraphs describing what is being built and why>
+
+## Context
+
+- <impacted components>
+- <relevant constraints>
+- <reference to source: e.g., "Adopted from issue #312" or "Adopted from OpenSpec change auth-rework">
+
+## Development Approach
+
+- Testing approach: regular (or TDD if source explicitly calls it out)
+- Complete each task fully before moving to the next
+- Update this plan when scope changes during implementation
+
+## Testing Strategy
+
+- Unit tests required for every code-changing Task
+- Run project tests after each Task before proceeding
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done
+- Update plan if implementation deviates from original scope
+
+## Technical Details
+
+<optional: detailed behavior, data shapes, references to spec sections; omit this section if the source had no such content>
+
+## Implementation Steps
+
+### Task 1: <title>
+
+- [ ] <concrete action>
+- [ ] <concrete action>
+- [ ] write tests for new functionality
+- [ ] run project tests - must pass before next task
+
+### Task 2: <title>
+
+- [ ] <concrete action>
+- [ ] write tests for new/changed functionality
+- [ ] run project tests - must pass before next task
+
+### Task <last>: Verify acceptance criteria
+
+- [ ] verify all requirements from Overview are implemented
+- [ ] run full project test suite
+- [ ] run project linter - all issues must be fixed
+
+## Post-Completion
+
+*Items requiring manual intervention - no checkboxes, informational only*
+
+- <manual verification steps if any>
+- <external system updates if any>
+```
+
+## Step 5: Review Loop With revdiff
+
+Create a temp file and capture its path. Each Bash tool call runs in its own subshell, so shell variables (including `$DRAFT`) do not persist between calls. You must capture the literal path printed by `mktemp` and substitute that exact string into every subsequent tool call (Write, launcher, rm) — do not rely on `$VAR` references across calls.
+
+Use a portable `mktemp` form. The `-t prefix` form differs between macOS BSD and Linux GNU. A template ending in `XXXXXX` is portable, but a suffix after `XXXXXX` (e.g., `XXXXXX.md`) is silently treated as a literal filename by BSD `mktemp` and would cause concurrent runs to collide on the same path. Generate the random path first, then rename to add the `.md` extension:
+
+```bash
+TMP=$(mktemp "${TMPDIR:-/tmp}/ralphex-adopt-XXXXXX") && mv "$TMP" "$TMP.md" && printf '%s\n' "$TMP.md"
+```
+
+Read the path from stdout (e.g., `/tmp/ralphex-adopt-aB3xY9.md`) and remember it. Refer to that literal string below as `<draft-path>`. Write the draft content to `<draft-path>` via the Write tool.
+
+An `EXIT` trap is not used because each Bash call is its own subshell — the trap would fire immediately. Cleanup is explicit at the end of Step 6 (success) and on every cancel path (`rm -f <draft-path>` with the literal path substituted).
+
+Run revdiff directly on the draft (bypass `~/.claude/scripts/draft-review.sh` — that wrapper runs a writing-style lint that misfires on plan-shaped content and writes a publish-approval marker this skill does not need). Substitute the literal `<draft-path>` you captured above:
+
+```bash
+LAUNCHER="$HOME/.claude/plugins/marketplaces/revdiff/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"
+test -x "$LAUNCHER" && "$LAUNCHER" --wrap --only=<draft-path>
+```
+
+If the launcher path does not exist (`test -x` fails), skip directly to the in-chat fallback below — the user has revdiff installed via Homebrew or `go install` but does not have the Claude marketplace plugin layout.
+
+Capture stdout into a variable.
+
+- **Empty stdout** → user reviewed and approved silently. Proceed to Step 6.
+- **Non-empty stdout** → user left annotations. Read each annotation, revise the draft accordingly (rewrite the literal `<draft-path>` in place via Write), then re-run revdiff. Repeat until stdout is empty.
+
+If the launcher path is missing, OR `launch-revdiff.sh` fails with any revdiff-related error (exit code non-zero with "revdiff" in stderr — "not found in PATH", "command not found", etc.), fall back to in-chat review:
+
+- Print the draft content in chat.
+- Use AskUserQuestion: "Approve draft?" with options "Accept", "Revise" (capture feedback as next message), "Reject" (cancel the conversion).
+- On "Revise", treat the next user message as annotation text and revise; loop until "Accept".
+
+## Step 6: Write Target File
+
+Compute the target filename:
+
+- Date: today's date in `YYYYMMDD` form (no dashes, e.g., `20260430`).
+- Slug: derive from the plan title — lowercase, ASCII-only, words joined by `-`, max ~50 characters. Drop articles (a/an/the) and trailing punctuation.
+
+Use AskUserQuestion to confirm or edit the slug before writing:
+
+- header: "Filename"
+- question: "Use slug `<computed-slug>` for `docs/plans/<date>-<slug>.md`?"
+- options:
+  - label: "Yes, use this slug"
+  - label: "Edit slug" (capture next user message as the new slug)
+  - label: "Cancel"
+
+If the target file already exists:
+
+- Use AskUserQuestion: "`docs/plans/<filename>` already exists. What should we do?"
+- options:
+  - label: "Bump suffix" — append `-v2`, then `-v3`, ... to the slug; check `docs/plans/` and `docs/plans/completed/` for collisions, increment until both are clear
+  - label: "Pick a new slug" (capture next message)
+  - label: "Cancel"
+- Never silent-overwrite.
+
+Sanity-check the draft before writing:
+
+- The draft must contain at least one `### Task ` line that matches the form `### Task <N>: <title>`.
+- The draft must contain at least one `- [ ]` checkbox under a Task section.
+- If either check fails, return to Step 4 to revise (do not write the file).
+
+Once the filename is confirmed and sanity checks pass:
+
+```bash
+mkdir -p docs/plans
+```
+
+Write the draft content to `docs/plans/<final-name>.md` via the Write tool. Then explicitly clean up the temp file by substituting the literal `<draft-path>` captured in Step 5:
+
+```bash
+rm -f <draft-path>
+```
+
+Also run the same `rm -f <draft-path>` on any cancel path before exiting (Step 1, Step 3, Step 5 reject, Step 6 cancel) — always with the literal path substituted, never as `$DRAFT`.
+
+Report to the user:
+
+```
+Adopted plan: docs/plans/<final-name>.md
+
+Source: <source kind and identifier>
+Tasks: <N>
+
+Next: run `ralphex docs/plans/<final-name>.md` to execute.
+```
+
+## Edge Cases
+
+- **Missing path**: if user passed a path that does not exist, AskUser to correct or cancel.
+- **Ambiguous bare name**: more than one match — AskUser to pick.
+- **URL fetch failure**: AskUser to paste body as fallback.
+- **Directory with no recognizable structure**: list contents, AskUser to point at the file.
+- **Format detection conflict**: multiple signals — AskUser to choose format.
+- **Zero task-like content**: source has no items the agent can convert — AskUser whether to infer Tasks from prose or cancel.
+- **Mixed localization**: source mixes English and another language — confirm whether to keep the original language for prose. Structural `Task` keyword stays English regardless.
+- **Huge source (>1000 lines)**: warn before processing and AskUser whether to proceed, summarize, or split into multiple plans.
+- **Tiny source (<10 lines)**: warn that the result will be sparse; AskUser whether to proceed or expand interactively.
+- **Output collision**: target file already exists — never silent overwrite (see Step 6).
+- **Idempotency**: re-running on the same source uses today's date. Old converted plans in `docs/plans/completed/` are never modified.
+
+## Tool Fallbacks
+
+- **revdiff missing**: fall back to in-chat AskUser Accept/Revise/Reject loop (see Step 5).
+- **gh missing** (when source is a GitHub issue/URL): AskUser to paste the issue body manually.
+- **glab missing** (when source is a GitLab issue/URL): AskUser to paste the issue body manually.
+- **Both gh and glab missing for a `#N` argument**: AskUser to paste the issue body or provide a different reference.
+
+## Constraints
+
+- Never modify the source plan or directory.
+- Never write to `docs/plans/` without an explicit user-confirmed slug.
+- Never silently overwrite an existing target file.
+- Never embed placeholder markers (`???`, `TBD`, `[FIXME]`) in the output — AskUser before drafting instead.
+- Never assume the target project is a specific language. Test/run-test checkboxes must use generic phrasing such as "write tests" and "run project tests".
+- Never cite ralphex internal source files (e.g., `pkg/...`) in the converted plan content.
+- Do not run tests, do not run linters, do not commit, do not push. The skill only produces a plan file.

--- a/docs/plans/completed/20260430-ralphex-adopt-skill.md
+++ b/docs/plans/completed/20260430-ralphex-adopt-skill.md
@@ -1,0 +1,165 @@
+# Add ralphex-adopt skill for converting plans from various formats
+
+## Overview
+
+Add a new Claude Code skill `ralphex-adopt` that converts source plans from various formats into ralphex-format plans in `docs/plans/`. The skill complements the existing `ralphex-plan` (creates plan from scratch) and `ralphex-update` (merges defaults) skills, addressing the gap where users have an existing plan or spec in some other format and want to run it through ralphex without manual rewriting.
+
+The source plan is never modified. The output is always a new dated file at `docs/plans/YYYYMMDD-<slug>.md`. The skill handles five input shapes: OpenSpec change directories, spec-kit specs, GitHub/GitLab issues with checklists, generic task-lists in unknown structured formats, and free-form markdown brain dumps.
+
+The skill is a single markdown file that instructs the agent through the conversion. It uses revdiff for the review loop on the converted draft and never silently overwrites existing files. On any uncertainty during conversion, the skill asks the user via AskUserQuestion before drafting rather than embedding placeholder markers in the output.
+
+## Context (from discovery)
+
+- Project: ralphex (Go CLI for autonomous Claude Code plan execution).
+- Existing ralphex skills live under `assets/claude/skills/<name>/SKILL.md` with a flat symlink `assets/claude/<name>.md` pointing to the same file. Plugin reads via `.claude-plugin/plugin.json` `"skills": "./assets/claude/skills/"`.
+- Existing skills: `ralphex` (run execution), `ralphex-plan` (create plan), `ralphex-update` (merge updated defaults). All single-file, model-driven, no per-format reference docs.
+- Plan parser: `pkg/plan/parse.go` line 46, `taskHeaderPattern = regexp.MustCompile(`^###\s+(?:Task|Iteration)\s+([^:]+?):\s*(.*)$`)`. Task and Iteration keywords MUST stay English even when plan content is localized.
+- Plan checkbox rule: checkboxes belong only inside Task sections. Headers like Overview, Context, Success criteria must not contain `- [ ]` (causes extra loop iterations).
+- Plan filename convention: `YYYYMMDD-<slug>.md` (no dashes inside the date), per recent files in `docs/plans/completed/`.
+- Plugin version is in two places that must stay aligned: `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. Currently both at 0.18.0.
+- llms.txt has an install-block convention for each skill (fetch URL, write target path).
+- revdiff invoked via `~/.claude/plugins/marketplaces/revdiff/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh --wrap --only=<file>` for direct review (the wrapper `~/.claude/scripts/draft-review.sh` runs a writing-style lint that misfires on plan content and writes a gh/glab approval marker the skill does not need).
+- Today's date for the plan filename: 2026-04-30 → `20260430-ralphex-adopt-skill.md`.
+
+## Development Approach
+
+- Testing approach: regular (the skill is a markdown contract, not Go code, so there are no unit tests to write; correctness is verified by reading the skill end-to-end and by a manual dry-run trigger).
+- Complete each task fully before moving to the next.
+- No backward-compat concerns: this is a new file, no existing callers.
+- Plugin version bump is required because skill files under `assets/claude/` are changing (per CLAUDE.md "Plugin version" rule).
+
+## Testing Strategy
+
+- Unit tests: not applicable. The skill is markdown.
+- Verification approach: after each task, re-read modified files and confirm content. After the final task, manually trigger the skill in a fresh Claude session with a sample free-form markdown plan and confirm the conversion produces a valid ralphex-format plan that satisfies `pkg/plan/parse.go`'s `taskHeaderPattern`.
+- E2E: not required for v1. The existing `prep-toy-test.sh` workflow could be extended later with a ralphex-adopt round-trip if desired.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with the prefix shown in CLAUDE.md if scope changes during implementation.
+- Update plan if implementation deviates from original scope.
+
+## Solution Overview
+
+Single markdown skill file at `assets/claude/skills/ralphex-adopt/SKILL.md` (real file) with a symlink at `assets/claude/ralphex-adopt.md` pointing to it. The skill describes a seven-step flow (Step 0 through Step 6): verify CLI, resolve source from arg shape, detect format, confidence-guard (ask user up front on ambiguity), convert per format, review via revdiff on a temp draft, write to `docs/plans/` with collision guard. Format-specific mapping rules live inline in the SKILL.md, not in separate reference files, matching the convention of the existing three ralphex skills.
+
+The skill never modifies the source. It never overwrites an existing target without the user picking a new slug. revdiff is invoked directly so the writing-style lint gate inside `draft-review.sh` does not misfire on plan-shaped content. If revdiff is not installed, the skill falls back to in-chat AskUser Accept/Revise/Reject.
+
+**Language-agnostic skill output**: this plan references ralphex Go source files (such as `pkg/plan/parse.go`) where useful for the implementer to understand format constraints, but the resulting SKILL.md content must be language-agnostic. The skill is consumed by users whose target projects can be any language; it must not assume Go, must not emit Go-specific commands or paths, and must not cite ralphex internal source files in the user-facing skill text. Test/run-test checkboxes the skill instructs the agent to emit must be phrased generically ("write tests", "run project tests"), matching the convention of `assets/claude/skills/ralphex-plan/SKILL.md`.
+
+## Technical Details
+
+YAML frontmatter for SKILL.md:
+
+```yaml
+---
+description: Convert plans from various source formats (OpenSpec, spec-kit, GitHub/GitLab issues with checklists, generic task-lists, free-form markdown) into ralphex-format plans in docs/plans/. Triggers on "ralphex-adopt", "adopt plan", "convert plan to ralphex", "import plan as ralphex".
+allowed-tools: [Bash, Read, Write, Glob, Grep, AskUserQuestion]
+---
+```
+
+Step flow inside SKILL.md (Step 0 through Step 6):
+
+- **Step 0**: Verify ralphex CLI installed (`which ralphex`); inform but do not block.
+- **Step 1**: Resolve source from arg by shape: URL → fetch via gh/glab; `#N` → current repo via gh/glab; `owner/repo#N` or full issue URL → explicit repo; existing path (file or dir) → read; directory with `proposal.md`+`tasks.md` → OpenSpec; bare name → search filesystem (agent picks tool, AskUser variants on ambiguity); no arg → AskUser for source.
+- **Step 2**: Detect format among OpenSpec, spec-kit, issue, generic task-list, free-form. AskUser on ambiguity (e.g., directory with mixed signals).
+- **Step 3**: Confidence guard: AskUser BEFORE drafting on any uncertainty (which headings are tasks, how to split, vague items, intent). Do NOT embed sticky markers in the draft.
+- **Step 4**: Convert per format (mapping rules inline). All formats add `write tests` and `run tests` checkboxes per Task and end with a `Verify acceptance criteria` Task. The `Task` keyword in the output is always English even when source headings are localized.
+- **Step 5**: Write draft to `/tmp/ralphex-adopt-<slug>.md`. Run `launch-revdiff.sh --wrap --only=<file>` directly. Empty stdout means user approved. Non-empty means address annotations, rewrite, re-run revdiff. Fallback to in-chat AskUser Accept/Revise/Reject if revdiff not installed.
+- **Step 6**: Compute target filename `docs/plans/YYYYMMDD-<slug>.md`, AskUser to confirm/edit slug. If target exists, AskUser to bump suffix (-2, -3) or rename or cancel; never silent overwrite. Sanity-check the draft before writing: at least one `### Task N:` header and at least one `- [ ]` checkbox under a Task; if it fails, revise and retry. Write file, clean up temp file with a trap so cleanup runs on early exit.
+
+Per-format mapping rules to include inline in SKILL.md:
+
+- **OpenSpec**: `proposal.md` "## Why" + "## What Changes" → Overview/Context. `specs/**/spec.md` delta sections → Technical Details. `tasks.md` numbered list → Implementation Steps grouped into `### Task N:` sections; sub-bullets become checkboxes.
+- **spec-kit**: similar shape. Spec → Overview, plan/architecture → Technical Details, tasks → Implementation Steps.
+- **GitHub/GitLab issue with checklists**: title → plan title, body prose → Overview, top-level `- [ ]` items → Task items split by H3 headings if present, otherwise grouped 5-7 per Task by length.
+- **Generic task-list**: agent infers heading and item-marker patterns from the source, normalizes to `### Task N: <title>` (English keyword) and `- [ ]` checkboxes, preserves checked state. If heading or item pattern is ambiguous, AskUser to confirm before drafting.
+- **Free-form prose**: agent infers intent (feature/bugfix/refactor/migration), pulls Overview/Context from opening prose, decomposes into 3-7 Task groups by logical phase.
+
+Edge cases enumerated in SKILL.md:
+
+- Source resolution: missing path, ambiguous bare name, URL fetch failure, directory with no recognizable structure.
+- Format detection conflicts (multiple signals).
+- Content edge cases: zero task-like content (AskUser to infer or cancel), mixed localization, huge sources >1000 lines (warn before processing), tiny <10 lines (warn that result may be sparse).
+- Output collision (never silent overwrite).
+- Tool fallbacks: revdiff missing → in-chat AskUser; gh/glab missing → AskUser to paste body.
+- Idempotency: re-running on same source produces a fresh dated file (today's date), old converted plans in `docs/plans/completed/` are not touched.
+
+## What Goes Where
+
+- Implementation Steps (`[ ]` checkboxes): write the SKILL.md content, create the symlink, add the llms.txt install block, update CLAUDE.md, bump plugin version files. All achievable inside this repo.
+- Post-Completion (no checkboxes): manual smoke test of the skill in a fresh Claude session against a sample source plan, confirming the converted plan parses correctly with ralphex.
+
+## Implementation Steps
+
+### Task 1: Write the ralphex-adopt SKILL.md content
+
+**Files:**
+- Create: `assets/claude/skills/ralphex-adopt/SKILL.md`
+
+- [x] create directory `assets/claude/skills/ralphex-adopt/`
+- [x] write `SKILL.md` with YAML frontmatter (description with triggers and brief scope, allowed-tools listing Bash, Read, Write, Glob, Grep, AskUserQuestion)
+- [x] write Step 0 (verify ralphex CLI) following the same shape as existing `ralphex-plan` and `ralphex-update` skills
+- [x] write Step 1 (resolve source from arg shape) covering all six input forms with heuristic order and AskUser fallbacks
+- [x] write Step 2 (detect format) with detection signals for OpenSpec, spec-kit, issue, generic task-list, free-form fallback
+- [x] write Step 3 (confidence guard) with explicit instruction to AskUser before drafting on ambiguity, not to embed placeholder markers
+- [x] write Step 4 (convert per format) with all five mapping rules inline (OpenSpec, spec-kit, issue, generic task-list, free-form), stating ralphex's requirement that the `Task` and `Iteration` keywords stay English in plan headers (e.g., `### Task 1: <title>`) regardless of what natural language the source uses for titles or content. Do NOT cite ralphex source file paths in the user-facing skill text — this is a behavioral rule for the agent, not an implementation detail.
+- [x] write Step 5 (revdiff review loop) calling `~/.claude/plugins/marketplaces/revdiff/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh --wrap --only=<draft>` directly with the draft-review.sh bypass note, and the in-chat AskUser fallback
+- [x] write Step 6 (write target file) with collision guard (AskUser to bump or rename or cancel, never silent overwrite), sanity check (at least one `### Task N:` and one `- [ ]` under a Task), and temp cleanup with trap
+- [x] write Edge Cases section enumerating the failures listed in Technical Details above
+- [x] write Tool Fallbacks section (revdiff missing, gh missing, glab missing)
+- [x] verify the SKILL.md content is fully language-agnostic: no references to Go, no Go-specific commands or paths (e.g., `go test`, `go.mod`, `pkg/...`), no language-specific assumptions about the target project. Test/run-test checkboxes the skill instructs the agent to emit must be phrased generically (e.g., "write tests for new functionality", "run project tests"), matching the existing `ralphex-plan` skill convention.
+- [x] re-read the file end-to-end to confirm completeness against the brainstorm design
+- [x] run sanity check on the SKILL.md content: valid markdown, frontmatter parses, every example `### Task N:` snippet inside the SKILL.md (used to teach the agent the output format) is well-formed (`### Task <N>: <title>` with English keyword)
+
+### Task 2: Wire skill into project (symlink, llms.txt, CLAUDE.md)
+
+**Files:**
+- Create: `assets/claude/ralphex-adopt.md` (symlink)
+- Modify: `llms.txt`
+- Modify: `CLAUDE.md`
+
+- [x] create symlink `assets/claude/ralphex-adopt.md` pointing to `./skills/ralphex-adopt/SKILL.md` using `ln -s` (matches the existing three ralphex skills)
+- [x] verify symlink resolves and shows the SKILL.md content via `cat assets/claude/ralphex-adopt.md`
+- [x] add an install block to `llms.txt` after the `/ralphex-update Skill` section, mirroring its structure: section header `### /ralphex-adopt Skill`, brief description of what the skill does, and the two install steps (fetch from `https://ralphex.com/assets/claude/ralphex-adopt.md`, write to `~/.claude/commands/ralphex-adopt.md`)
+- [x] update the line in `llms.txt` that lists skill names ("With skills: `/ralphex-plan` creates plans, `/ralphex` launches execution...") to mention `/ralphex-adopt` for plan conversion
+- [x] check `CLAUDE.md` for the existing skill-mention pattern (`/ralphex-update` is mentioned at line near "Use `/ralphex-update` skill for smart merging..."); if a similar one-line mention fits, add `/ralphex-adopt` for plan conversion in the same vicinity
+- [x] verify all three files render correctly (no broken markdown, no malformed YAML)
+
+### Task 3: Bump plugin version
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [x] bump `.claude-plugin/plugin.json` `version` from `0.18.0` to `0.19.0` (minor: new skill addition, additive change)
+- [x] bump `.claude-plugin/marketplace.json` matching plugin entry from `0.18.0` to `0.19.0`
+- [x] verify both files have matching version values via `grep -n version .claude-plugin/plugin.json .claude-plugin/marketplace.json`
+- [x] verify both files are still valid JSON via `jq . .claude-plugin/plugin.json` and `jq . .claude-plugin/marketplace.json`
+
+### Task 4: Verify acceptance criteria
+
+- [x] verify `assets/claude/skills/ralphex-adopt/SKILL.md` exists, has valid YAML frontmatter, and covers all six step-flow steps end-to-end
+- [x] verify the symlink at `assets/claude/ralphex-adopt.md` resolves to the SKILL.md (use `readlink` and `cat`)
+- [x] verify `llms.txt` contains the new `/ralphex-adopt Skill` install block and updated skill-list line
+- [x] verify `CLAUDE.md` mentions `/ralphex-adopt` if a matching pattern was found in Task 2
+- [x] verify both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` have version `0.19.0` and parse as valid JSON
+- [x] verify the skill design honors all original requirements: source untouched, output to new dated file, never silent overwrite, AskUser before drafting on uncertainty (not embedded markers), revdiff via launch-revdiff.sh (not draft-review.sh), all five input formats covered, English `Task` keyword normalization referenced
+
+## Post-Completion
+
+*Items requiring manual intervention - no checkboxes, informational only*
+
+**Manual verification**:
+
+- Trigger the skill in a fresh Claude Code session by typing `/ralphex-adopt <some-source>` and confirm the description in the frontmatter activates the skill.
+- Run a dry conversion against a sample free-form markdown plan and confirm:
+  - Source file is never modified.
+  - Output lands at `docs/plans/YYYYMMDD-<slug>.md` with today's date.
+  - revdiff opens for review on the temp draft.
+  - The resulting plan parses successfully when ralphex is run against it (`### Task N:` headers detected, no checkboxes outside Task sections).
+- Run a dry conversion against an OpenSpec-shaped directory if one is available, and confirm `proposal.md` content lands in Overview/Context and `tasks.md` items become Task sections.
+- Run a dry conversion against a GitHub issue (`/ralphex-adopt #312` or similar) and confirm `gh issue view` is invoked for fetching.
+
+**External system updates**: none. The plugin version bump means the next plugin marketplace pull will include the new skill automatically.

--- a/llms.txt
+++ b/llms.txt
@@ -263,6 +263,14 @@ When user asks to install the `/ralphex-update` command:
 1. Fetch `https://ralphex.com/assets/claude/ralphex-update.md`
 2. Create `~/.claude/commands/ralphex-update.md` with its content
 
+### /ralphex-adopt Skill
+
+Converts plans from various source formats (OpenSpec change directories, spec-kit specs, GitHub/GitLab issues with checklists, generic task-lists, free-form markdown) into ralphex-format plans in `docs/plans/`. The source is never modified, the output is a new dated file at `docs/plans/YYYYMMDD-<slug>.md`, and existing target files are never silently overwritten. Uses revdiff for the review loop on the converted draft, with an in-chat fallback when revdiff is not installed.
+
+When user asks to install the `/ralphex-adopt` command:
+1. Fetch `https://ralphex.com/assets/claude/ralphex-adopt.md`
+2. Create `~/.claude/commands/ralphex-adopt.md` with its content
+
 ---
 
 ## Instructions for LLMs
@@ -329,6 +337,6 @@ When a user asks about autonomous plan execution, implementing features with Cla
 6. **Claude Code skills are optional**: If user wants convenience commands:
    - Check if plugin installed: `/plugin` and look for ralphex
    - If not installed and user wants it, offer plugin installation (see step 4)
-   - With skills: `/ralphex-plan` creates plans, `/ralphex` launches execution, "check ralphex" views progress
+   - With skills: `/ralphex-plan` creates plans, `/ralphex-adopt` converts existing plans into ralphex format, `/ralphex` launches execution, "check ralphex" views progress
 
 7. **Key point**: The CLI is primary - skills are optional convenience wrappers


### PR DESCRIPTION
New Claude Code skill `/ralphex-adopt` converts source plans from various formats into ralphex-format plans in `docs/plans/`. Supported inputs: OpenSpec change directories, spec-kit specs, GitHub/GitLab issues with checklists, generic task-lists in unknown structured formats, and free-form markdown brain dumps.

Source is never modified. Output is always a new dated file at `docs/plans/YYYYMMDD-<slug>.md`. Existing target files are never silently overwritten. On uncertainty during conversion, the skill asks the user via AskUserQuestion before drafting rather than embedding placeholder markers in output.

Review loop uses revdiff directly (not `draft-review.sh`, which has a writing-style lint gate that misfires on plan content). Falls back to in-chat AskUser Accept/Revise/Reject if revdiff is missing.

Skill content is **language-agnostic**. Test/run-test checkboxes the skill instructs the agent to emit are phrased generically, matching the existing `ralphex-plan` convention. The skill can be used against any project regardless of language.

**Wiring**

- `assets/claude/skills/ralphex-adopt/SKILL.md` (skill content)
- `assets/claude/ralphex-adopt.md` (symlink for direct URL fetch)
- `llms.txt` and `README.md` updated with install instructions
- `CLAUDE.md` mentions `/ralphex-adopt` in skill list
- Plugin and marketplace version bumped 0.18.0 -> 0.19.0