### PR TITLE
feat: add --branch flag to override worktree/branch name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Key files:
 
 ### Worktree Isolation Mode
 
-`--worktree` flag or `use_worktree = true` config option runs each plan in an isolated git worktree, enabling parallel execution of multiple plans on the same repo.
+`--worktree` flag or `use_worktree = true` config option runs each plan in an isolated git worktree, enabling parallel execution of multiple plans on the same repo. `--branch` flag overrides the branch name derived from the plan filename (useful when auto-detection is fragile, e.g. generic filenames or spec-driven layouts).
 
 - Worktrees created at `.ralphex/worktrees/<branch-name>` inside main repo
 - Progress logger created before chdir so files land in main repo's `.ralphex/progress/`

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -46,6 +46,7 @@ type opts struct {
 	IdleTimeout           time.Duration `long:"idle-timeout" description:"kill claude session after no output for this duration (e.g. 5m, 10m)"`
 	SkipFinalize          bool          `long:"skip-finalize" description:"skip finalize step even if enabled in config"`
 	Worktree              bool          `long:"worktree" description:"run in isolated git worktree"`
+	Branch                string        `long:"branch" description:"override branch name for worktree/branch creation (default: derived from plan filename)"`
 	PlanDescription       string        `long:"plan" description:"create plan interactively (enter plan description)"`
 	Debug                 bool          `short:"d" long:"debug" description:"enable debug logging"`
 	NoColor               bool          `long:"no-color" description:"disable color output"`
@@ -133,9 +134,10 @@ type executePlanRequest struct {
 	DefaultBranch string // actual default branch for branch/worktree creation (config or auto-detect)
 	BaseRef       string // base reference for review diffs and templates (--base-ref override or DefaultBranch)
 	NotifySvc     *notify.Service
-	WtCleanup     *worktreeCleanupFn  // worktree cleanup for interrupt handler; nil when not in worktree mode
-	ProgressLog   *progress.Logger    // pre-created logger (worktree mode); nil in normal mode
-	PhaseHolder   *status.PhaseHolder // pre-created holder (worktree mode); nil in normal mode
+	BranchOverride string             // branch name override (--branch flag); empty = derive from plan filename
+	WtCleanup      *worktreeCleanupFn  // worktree cleanup for interrupt handler; nil when not in worktree mode
+	ProgressLog    *progress.Logger    // pre-created logger (worktree mode); nil in normal mode
+	PhaseHolder    *status.PhaseHolder // pre-created holder (worktree mode); nil in normal mode
 }
 
 // worktreeCleanupFn holds a worktree cleanup function with mutex for safe cross-goroutine access.
@@ -301,14 +303,15 @@ func run(ctx context.Context, o opts) error {
 	}
 
 	return selectAndExecutePlan(ctx, o, executePlanRequest{
-		Mode:          mode,
-		GitSvc:        gitSvc,
-		Config:        cfg,
-		Colors:        colors,
-		DefaultBranch: defaultBranch,
-		BaseRef:       baseRef,
-		NotifySvc:     notifySvc,
-		WtCleanup:     wtCleanup,
+		Mode:           mode,
+		GitSvc:         gitSvc,
+		Config:         cfg,
+		Colors:         colors,
+		DefaultBranch:  defaultBranch,
+		BaseRef:        baseRef,
+		NotifySvc:      notifySvc,
+		WtCleanup:      wtCleanup,
+		BranchOverride: o.Branch,
 	}, selector)
 }
 
@@ -337,7 +340,7 @@ func selectAndExecutePlan(ctx context.Context, o opts, req executePlanRequest, s
 		return fmt.Errorf("ensure gitignore: %w", err)
 	}
 	if planFile != "" && modeRequiresBranch(req.Mode) {
-		if err := req.GitSvc.CreateBranchForPlan(planFile, req.DefaultBranch); err != nil {
+		if err := req.GitSvc.CreateBranchForPlan(planFile, req.DefaultBranch, req.BranchOverride); err != nil {
 			return fmt.Errorf("create branch for plan: %w", err)
 		}
 	}
@@ -607,7 +610,7 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 // in the main repo), chdirs into the worktree, and runs executePlan. On return the worktree
 // is cleaned up and CWD is restored. req.WtCleanup is populated for interrupt handler use.
 func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err error) {
-	wtPath, planNeedsCommit, err := req.GitSvc.CreateWorktreeForPlan(req.PlanFile, req.DefaultBranch)
+	wtPath, planNeedsCommit, err := req.GitSvc.CreateWorktreeForPlan(req.PlanFile, req.DefaultBranch, req.BranchOverride)
 	if err != nil {
 		return fmt.Errorf("create worktree: %w", err)
 	}
@@ -644,7 +647,10 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 	// create progress logger BEFORE chdir so progress files land in main repo's .ralphex/progress/.
 	// use branch name derived from plan file since gitSvc still points at the main repo (on master).
 	holder := &status.PhaseHolder{}
-	branch := plan.ExtractBranchName(req.PlanFile)
+	branch := req.BranchOverride
+	if branch == "" {
+		branch = plan.ExtractBranchName(req.PlanFile)
+	}
 	baseLog, err := progress.NewLogger(progress.Config{
 		PlanFile: req.PlanFile,
 		Mode:     string(req.Mode),
@@ -1034,20 +1040,21 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 	// worktree mode: create worktree and run from there
 	if req.Config.WorktreeEnabled {
 		return runWithWorktree(ctx, o, executePlanRequest{
-			PlanFile:      planFile,
-			Mode:          processor.ModeFull,
-			GitSvc:        req.GitSvc,
-			Config:        req.Config,
-			Colors:        req.Colors,
-			DefaultBranch: req.DefaultBranch,
-			BaseRef:       req.BaseRef,
-			NotifySvc:     req.NotifySvc,
-			WtCleanup:     req.WtCleanup,
+			PlanFile:       planFile,
+			Mode:           processor.ModeFull,
+			GitSvc:         req.GitSvc,
+			Config:         req.Config,
+			Colors:         req.Colors,
+			DefaultBranch:  req.DefaultBranch,
+			BaseRef:        req.BaseRef,
+			NotifySvc:      req.NotifySvc,
+			WtCleanup:      req.WtCleanup,
+			BranchOverride: req.BranchOverride,
 		})
 	}
 
 	// normal mode: create branch and run in place
-	if err := req.GitSvc.CreateBranchForPlan(planFile, req.DefaultBranch); err != nil {
+	if err := req.GitSvc.CreateBranchForPlan(planFile, req.DefaultBranch, req.BranchOverride); err != nil {
 		return fmt.Errorf("create branch for plan: %w", err)
 	}
 

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -702,21 +702,7 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 
 	// resolve plan file path inside the worktree so Claude operates on the local copy,
 	// not the original in the main repo. the plan was copied by CreateWorktreeForPlan.
-	wtPlanFile := req.PlanFile
-	if filepath.IsAbs(req.PlanFile) {
-		// resolve symlinks on plan path to match GitSvc.Root() which is also resolved
-		// (macOS: /tmp -> /private/tmp); without this, filepath.Rel produces wrong results
-		resolvedPlan := req.PlanFile
-		if resolved, evalErr := filepath.EvalSymlinks(resolvedPlan); evalErr == nil {
-			resolvedPlan = resolved
-		}
-		if rel, relErr := filepath.Rel(req.GitSvc.Root(), resolvedPlan); relErr == nil {
-			abs, absErr := filepath.Abs(rel) // resolve relative to CWD (now the worktree)
-			if absErr == nil {
-				wtPlanFile = abs
-			}
-		}
-	}
+	wtPlanFile := resolveWorktreePlanFile(req.PlanFile, req.GitSvc.Root())
 
 	// commit plan file on the feature branch (inside worktree), not on the default branch
 	if planNeedsCommit {
@@ -739,6 +725,29 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 		ProgressLog:   baseLog,
 		PhaseHolder:   holder,
 	})
+}
+
+// resolveWorktreePlanFile maps an absolute plan path from the main repo into the worktree CWD.
+// It resolves symlinks on the plan path to match the repo root (macOS: /tmp -> /private/tmp),
+// then makes the path relative to the root and absolute within the worktree.
+// Falls back to the original path if any step fails or the path is not absolute.
+func resolveWorktreePlanFile(planFile, repoRoot string) string {
+	if !filepath.IsAbs(planFile) {
+		return planFile
+	}
+	resolved := planFile
+	if r, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = r
+	}
+	rel, err := filepath.Rel(repoRoot, resolved)
+	if err != nil {
+		return planFile
+	}
+	abs, err := filepath.Abs(rel)
+	if err != nil {
+		return planFile
+	}
+	return abs
 }
 
 // openGitService creates a git.Service for the current directory.

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -124,17 +124,17 @@ type startupInfo struct {
 
 // executePlanRequest holds parameters for plan execution.
 type executePlanRequest struct {
-	PlanFile      string
-	MainPlanFile  string // original plan path in main repo (worktree mode); empty in normal mode
-	Mode          processor.Mode
-	GitSvc        *git.Service
-	MainGitSvc    *git.Service // main repo service for cross-boundary ops (worktree mode); nil in normal mode
-	Config        *config.Config
-	Colors        *progress.Colors
-	DefaultBranch string // actual default branch for branch/worktree creation (config or auto-detect)
-	BaseRef       string // base reference for review diffs and templates (--base-ref override or DefaultBranch)
-	NotifySvc     *notify.Service
-	BranchOverride string             // branch name override (--branch flag); empty = derive from plan filename
+	PlanFile       string
+	MainPlanFile   string // original plan path in main repo (worktree mode); empty in normal mode
+	Mode           processor.Mode
+	GitSvc         *git.Service
+	MainGitSvc     *git.Service // main repo service for cross-boundary ops (worktree mode); nil in normal mode
+	Config         *config.Config
+	Colors         *progress.Colors
+	DefaultBranch  string // actual default branch for branch/worktree creation (config or auto-detect)
+	BaseRef        string // base reference for review diffs and templates (--base-ref override or DefaultBranch)
+	NotifySvc      *notify.Service
+	BranchOverride string              // branch name override (--branch flag); empty = derive from plan filename
 	WtCleanup      *worktreeCleanupFn  // worktree cleanup for interrupt handler; nil when not in worktree mode
 	ProgressLog    *progress.Logger    // pre-created logger (worktree mode); nil in normal mode
 	PhaseHolder    *status.PhaseHolder // pre-created holder (worktree mode); nil in normal mode
@@ -291,14 +291,15 @@ func run(ctx context.Context, o opts) error {
 	// plan mode has different flow - doesn't require plan file selection
 	if mode == processor.ModePlan {
 		return runPlanMode(ctx, o, executePlanRequest{
-			Mode:          processor.ModePlan,
-			GitSvc:        gitSvc,
-			Config:        cfg,
-			Colors:        colors,
-			DefaultBranch: defaultBranch,
-			BaseRef:       baseRef,
-			NotifySvc:     notifySvc,
-			WtCleanup:     wtCleanup,
+			Mode:           processor.ModePlan,
+			GitSvc:         gitSvc,
+			Config:         cfg,
+			Colors:         colors,
+			DefaultBranch:  defaultBranch,
+			BaseRef:        baseRef,
+			NotifySvc:      notifySvc,
+			WtCleanup:      wtCleanup,
+			BranchOverride: o.Branch,
 		}, selector)
 	}
 
@@ -647,10 +648,7 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 	// create progress logger BEFORE chdir so progress files land in main repo's .ralphex/progress/.
 	// use branch name derived from plan file since gitSvc still points at the main repo (on master).
 	holder := &status.PhaseHolder{}
-	branch := req.BranchOverride
-	if branch == "" {
-		branch = plan.ExtractBranchName(req.PlanFile)
-	}
+	branch := req.GitSvc.EffectiveBranchName(req.PlanFile, req.BranchOverride)
 	baseLog, err := progress.NewLogger(progress.Config{
 		PlanFile: req.PlanFile,
 		Mode:     string(req.Mode),

--- a/llms.txt
+++ b/llms.txt
@@ -60,6 +60,10 @@ ralphex --tasks-only docs/plans/feature.md
 # run in isolated git worktree (full and tasks-only modes only; ignored for --review/--external-only)
 ralphex --worktree docs/plans/feature.md
 
+# override branch name when auto-detection is fragile (generic filenames, spec-driven layouts)
+ralphex --worktree --branch=my-feature docs/plans/tasks.md
+ralphex --branch=my-feature docs/plans/tasks.md
+
 # override default branch for review diffs (useful for comparing against specific ref)
 ralphex --review --base-ref develop
 ralphex --review --base-ref abc1234 --skip-finalize

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -279,14 +279,7 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch, branchOverride 
 	if earlyBranch == "" {
 		earlyBranch = plan.ExtractBranchName(planFile)
 	}
-	wtBase := filepath.Join(s.repo.root(), ".ralphex", "worktrees")
-	wtPath := filepath.Join(wtBase, earlyBranch)
-	if filepath.IsAbs(earlyBranch) {
-		return "", false, fmt.Errorf("invalid branch name %q: must not be an absolute path", earlyBranch)
-	}
-	if rel, err := filepath.Rel(wtBase, wtPath); err != nil || strings.HasPrefix(rel, "..") {
-		return "", false, fmt.Errorf("invalid branch name %q: must not escape worktrees directory", earlyBranch)
-	}
+	wtPath := filepath.Join(s.repo.root(), ".ralphex", "worktrees", earlyBranch)
 
 	// prune stale worktree entries first
 	if pruneErr := s.repo.pruneWorktrees(); pruneErr != nil {

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -166,7 +166,8 @@ func (s *Service) CreateBranch(name string) error {
 // when requireDefault is true, returns error if not on the default branch.
 // when requireDefault is false, returns empty branch name if not on the default branch (caller should skip).
 // defaultBranch is the resolved default branch name (e.g. "main", "develop", "origin/main").
-func (s *Service) preparePlanBranch(planFile string, requireDefault bool, defaultBranch string) (string, bool, error) {
+// branchOverride, when non-empty, is used directly instead of deriving from planFile.
+func (s *Service) preparePlanBranch(planFile string, requireDefault bool, defaultBranch, branchOverride string) (string, bool, error) {
 	currentBranch, err := s.repo.currentBranch()
 	if err != nil {
 		return "", false, fmt.Errorf("check current branch: %w", err)
@@ -183,7 +184,10 @@ func (s *Service) preparePlanBranch(planFile string, requireDefault bool, defaul
 		return "", false, nil // already on feature branch, caller should skip
 	}
 
-	branchName := plan.ExtractBranchName(planFile)
+	branchName := branchOverride
+	if branchName == "" {
+		branchName = plan.ExtractBranchName(planFile)
+	}
 
 	// check for uncommitted changes to files other than the plan
 	dirtyFiles, err := s.repo.hasChangesOtherThan(planFile)
@@ -220,9 +224,10 @@ func (s *Service) preparePlanBranch(planFile string, requireDefault bool, defaul
 // If on the default branch, extracts branch name from plan file and creates/switches to it.
 // If plan file has uncommitted changes and is the only dirty file, auto-commits it.
 // defaultBranch is the resolved default branch name (e.g. "main", "develop").
-func (s *Service) CreateBranchForPlan(planFile, defaultBranch string) error {
+// branchOverride, when non-empty, is used directly instead of deriving the name from planFile.
+func (s *Service) CreateBranchForPlan(planFile, defaultBranch, branchOverride string) error {
 	planFile = s.resolveFilesystemCase(planFile)
-	branchName, planHasChanges, err := s.preparePlanBranch(planFile, false, defaultBranch)
+	branchName, planHasChanges, err := s.preparePlanBranch(planFile, false, defaultBranch, branchOverride)
 	if err != nil {
 		return err
 	}
@@ -264,12 +269,16 @@ func (s *Service) CreateBranchForPlan(planFile, defaultBranch string) error {
 // must commit the plan file in the worktree context (via CommitPlanFile on the worktree's
 // git service) so the commit lands on the feature branch rather than the default branch.
 // defaultBranch is the resolved default branch name (e.g. "main", "develop").
-func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch string) (string, bool, error) {
+// branchOverride, when non-empty, is used directly instead of deriving the name from planFile.
+func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch, branchOverride string) (string, bool, error) {
 	planFile = s.resolveFilesystemCase(planFile)
 
 	// check worktree existence early, before preparePlanBranch runs hasChangesOtherThan
 	// (an existing worktree dir would show up as untracked and fail the dirty check)
-	earlyBranch := plan.ExtractBranchName(planFile)
+	earlyBranch := branchOverride
+	if earlyBranch == "" {
+		earlyBranch = plan.ExtractBranchName(planFile)
+	}
 	wtPath := filepath.Join(s.repo.root(), ".ralphex", "worktrees", earlyBranch)
 
 	// prune stale worktree entries first
@@ -282,7 +291,7 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch string) (string,
 		return "", false, fmt.Errorf("worktree already exists at %s, another instance may be running", wtPath)
 	}
 
-	branchName, planHasChanges, err := s.preparePlanBranch(planFile, true, defaultBranch)
+	branchName, planHasChanges, err := s.preparePlanBranch(planFile, true, defaultBranch, branchOverride)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -161,6 +161,14 @@ func (s *Service) CreateBranch(name string) error {
 	return nil
 }
 
+// EffectiveBranchName returns branchOverride when set, otherwise derives the branch name from planFile.
+func (s *Service) EffectiveBranchName(planFile, branchOverride string) string {
+	if branchOverride != "" {
+		return branchOverride
+	}
+	return plan.ExtractBranchName(planFile)
+}
+
 // preparePlanBranch validates state, extracts branch name, and checks plan file status.
 // returns branch name and whether the plan file has uncommitted changes.
 // when requireDefault is true, returns error if not on the default branch.
@@ -184,10 +192,7 @@ func (s *Service) preparePlanBranch(planFile string, requireDefault bool, defaul
 		return "", false, nil // already on feature branch, caller should skip
 	}
 
-	branchName := branchOverride
-	if branchName == "" {
-		branchName = plan.ExtractBranchName(planFile)
-	}
+	branchName := s.EffectiveBranchName(planFile, branchOverride)
 
 	// check for uncommitted changes to files other than the plan
 	dirtyFiles, err := s.repo.hasChangesOtherThan(planFile)
@@ -275,10 +280,7 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch, branchOverride 
 
 	// check worktree existence early, before preparePlanBranch runs hasChangesOtherThan
 	// (an existing worktree dir would show up as untracked and fail the dirty check)
-	earlyBranch := branchOverride
-	if earlyBranch == "" {
-		earlyBranch = plan.ExtractBranchName(planFile)
-	}
+	earlyBranch := s.EffectiveBranchName(planFile, branchOverride)
 	wtPath := filepath.Join(s.repo.root(), ".ralphex", "worktrees", earlyBranch)
 
 	// prune stale worktree entries first
@@ -327,7 +329,10 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch, branchOverride 
 // the plan file path is resolved to actual on-disk case before staging
 // to handle case-insensitive filesystems (macOS APFS).
 func (s *Service) CommitPlanFile(planFile, mainRepoRoot string) error {
-	branchName := plan.ExtractBranchName(planFile)
+	branchName, err := s.repo.currentBranch()
+	if err != nil || branchName == "" {
+		branchName = plan.ExtractBranchName(planFile)
+	}
 	s.log.Printf("committing plan file: %s\n", filepath.Base(planFile))
 
 	// compute the plan file's relative path from the main repo root, then resolve

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -279,7 +279,14 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch, branchOverride 
 	if earlyBranch == "" {
 		earlyBranch = plan.ExtractBranchName(planFile)
 	}
-	wtPath := filepath.Join(s.repo.root(), ".ralphex", "worktrees", earlyBranch)
+	wtBase := filepath.Join(s.repo.root(), ".ralphex", "worktrees")
+	wtPath := filepath.Join(wtBase, earlyBranch)
+	if filepath.IsAbs(earlyBranch) {
+		return "", false, fmt.Errorf("invalid branch name %q: must not be an absolute path", earlyBranch)
+	}
+	if rel, err := filepath.Rel(wtBase, wtPath); err != nil || strings.HasPrefix(rel, "..") {
+		return "", false, fmt.Errorf("invalid branch name %q: must not escape worktrees directory", earlyBranch)
+	}
 
 	// prune stale worktree entries first
 	if pruneErr := s.repo.pruneWorktrees(); pruneErr != nil {

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -1270,7 +1270,7 @@ func TestService_RemoveWorktree(t *testing.T) {
 
 		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "my-custom-branch")
 		require.NoError(t, err)
-		defer svc.RemoveWorktree(wtPath) //nolint:errcheck
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup, error irrelevant
 
 		// worktree path should use the override, not the plan filename
 		assert.Contains(t, wtPath, "my-custom-branch")

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -423,6 +423,24 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, hasChanges, "plan file should be committed")
 	})
+
+	t.Run("branch override used instead of plan filename", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, &mockLogger{})
+		require.NoError(t, err)
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "2026-04-30-some-long-generated-name.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		err = svc.CreateBranchForPlan(planFile, "master", "my-custom-branch")
+		require.NoError(t, err)
+
+		branch, err := svc.CurrentBranch()
+		require.NoError(t, err)
+		assert.Equal(t, "my-custom-branch", branch)
+	})
 }
 
 func TestService_MovePlanToCompleted(t *testing.T) {
@@ -1195,6 +1213,26 @@ func TestService_CommitPlanFile(t *testing.T) {
 		// cleanup
 		require.NoError(t, svc.RemoveWorktree(wtPath))
 	})
+
+	t.Run("branch override used instead of plan filename", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, &mockLogger{})
+		require.NoError(t, err)
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "2026-04-30-some-long-generated-name.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "my-custom-branch")
+		require.NoError(t, err)
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup, error irrelevant
+
+		// worktree path should use the override, not the plan filename
+		assert.Contains(t, wtPath, "my-custom-branch")
+		assert.True(t, svc.repo.branchExists("my-custom-branch"))
+		assert.False(t, svc.repo.branchExists("some-long-generated-name"))
+	})
 }
 
 func TestService_RemoveWorktree(t *testing.T) {
@@ -1256,44 +1294,6 @@ func TestService_RemoveWorktree(t *testing.T) {
 
 		// branch should still exist
 		assert.True(t, svc.repo.branchExists("preserve-branch"))
-	})
-
-	t.Run("branch override used instead of plan filename", func(t *testing.T) {
-		dir := setupExternalTestRepo(t)
-		svc, err := NewService(dir, &mockLogger{})
-		require.NoError(t, err)
-
-		plansDir := filepath.Join(dir, "docs", "plans")
-		require.NoError(t, os.MkdirAll(plansDir, 0o750))
-		planFile := filepath.Join(plansDir, "2026-04-30-some-long-generated-name.md")
-		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
-
-		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "my-custom-branch")
-		require.NoError(t, err)
-		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup, error irrelevant
-
-		// worktree path should use the override, not the plan filename
-		assert.Contains(t, wtPath, "my-custom-branch")
-		assert.True(t, svc.repo.branchExists("my-custom-branch"))
-		assert.False(t, svc.repo.branchExists("some-long-generated-name"))
-	})
-
-	t.Run("branch override used in CreateBranchForPlan", func(t *testing.T) {
-		dir := setupExternalTestRepo(t)
-		svc, err := NewService(dir, &mockLogger{})
-		require.NoError(t, err)
-
-		plansDir := filepath.Join(dir, "docs", "plans")
-		require.NoError(t, os.MkdirAll(plansDir, 0o750))
-		planFile := filepath.Join(plansDir, "2026-04-30-some-long-generated-name.md")
-		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
-
-		err = svc.CreateBranchForPlan(planFile, "master", "my-custom-branch")
-		require.NoError(t, err)
-
-		branch, err := svc.CurrentBranch()
-		require.NoError(t, err)
-		assert.Equal(t, "my-custom-branch", branch)
 	})
 }
 
@@ -1426,16 +1426,17 @@ func TestService_CommitWithTrailer(t *testing.T) {
 		require.NoError(t, err)
 		svc.SetCommitTrailer("Co-authored-by: ralphex <noreply@ralphex.com>")
 
-		// create and commit a plan file via CommitPlanFile
+		// create plan file and switch to feature branch (mirrors real worktree flow)
 		plansDir := filepath.Join(svc.Root(), "docs", "plans")
 		require.NoError(t, os.MkdirAll(plansDir, 0o750))
 		planFile := filepath.Join(plansDir, "trailer-test.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+		require.NoError(t, svc.CreateBranch("trailer-test"))
 
 		err = svc.CommitPlanFile(planFile, svc.Root())
 		require.NoError(t, err)
 
-		// verify trailer in commit message
+		// verify trailer in commit message; branch name comes from current branch
 		out := runGit(t, svc.Root(), "log", "-1", "--format=%B")
 		assert.Contains(t, out, "add plan: trailer-test")
 		assert.Contains(t, out, "Co-authored-by: ralphex <noreply@ralphex.com>")
@@ -1451,6 +1452,7 @@ func TestService_CommitWithTrailer(t *testing.T) {
 		require.NoError(t, os.MkdirAll(plansDir, 0o750))
 		planFile := filepath.Join(plansDir, "no-trailer.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+		require.NoError(t, svc.CreateBranch("no-trailer"))
 
 		err = svc.CommitPlanFile(planFile, svc.Root())
 		require.NoError(t, err)

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -196,7 +196,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		log := &mockLogger{}
 		svc.log = log
 
-		err = svc.CreateBranchForPlan(filepath.Join(dir, "docs", "plans", "feature.md"), "master")
+		err = svc.CreateBranchForPlan(filepath.Join(dir, "docs", "plans", "feature.md"), "master", "")
 		require.NoError(t, err)
 
 		// should not have logged anything (no branch created)
@@ -220,7 +220,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "add-feature.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.NoError(t, err)
 
 		// should have created branch
@@ -252,7 +252,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "existing-feature.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.NoError(t, err)
 
 		// should have switched to existing branch
@@ -279,7 +279,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		otherFile := filepath.Join(dir, "other.txt")
 		require.NoError(t, os.WriteFile(otherFile, []byte("other content"), 0o600))
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "worktree has uncommitted changes")
 		assert.Contains(t, err.Error(), "other.txt")
@@ -297,7 +297,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "new-feature.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# New Feature Plan"), 0o600))
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.NoError(t, err)
 
 		// should have created branch and committed plan
@@ -326,7 +326,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		log := &mockLogger{}
 		svc.log = log
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.NoError(t, err)
 
 		// should only have one log (creating branch, no committing)
@@ -345,7 +345,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "2024-01-15-add-auth.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.NoError(t, err)
 
 		// branch name should not have date prefix
@@ -370,7 +370,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		log := &mockLogger{}
 		svc.log = log
 
-		err = svc.CreateBranchForPlan(planFile, "develop")
+		err = svc.CreateBranchForPlan(planFile, "develop", "")
 		require.NoError(t, err)
 
 		branch, err := svc.CurrentBranch()
@@ -391,7 +391,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 		svc.log = log
 
 		// default branch is "origin/master" but we're on feature-x, should skip
-		err = svc.CreateBranchForPlan(filepath.Join(dir, "docs", "plans", "feature.md"), "origin/master")
+		err = svc.CreateBranchForPlan(filepath.Join(dir, "docs", "plans", "feature.md"), "origin/master", "")
 		require.NoError(t, err)
 		assert.Empty(t, log.logs) // no branch created
 	})
@@ -410,7 +410,7 @@ func TestService_CreateBranchForPlan(t *testing.T) {
 
 		// call CreateBranchForPlan with lowercase path (different case)
 		lowercasePlan := filepath.Join(plansDir, "branch-case.md")
-		err = svc.CreateBranchForPlan(lowercasePlan, "master")
+		err = svc.CreateBranchForPlan(lowercasePlan, "master", "")
 		require.NoError(t, err, "should succeed despite case mismatch in plan file path")
 
 		// verify branch created (name derived from resolved on-disk case)
@@ -855,7 +855,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "add-worktree.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit, "untracked plan file should need commit")
 		assert.Contains(t, wtPath, filepath.Join(".ralphex", "worktrees", "add-worktree"))
@@ -891,7 +891,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		log := &mockLogger{}
 		svc.log = log
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.False(t, planNeedsCommit, "already-committed plan file should not need commit")
 
@@ -917,7 +917,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		require.NoError(t, svc.CreateBranch("feature"))
 
 		planFile := filepath.Join(dir, "docs", "plans", "feature.md")
-		_, _, err = svc.CreateWorktreeForPlan(planFile, "master")
+		_, _, err = svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires master branch")
 	})
@@ -931,7 +931,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		require.NoError(t, svc.CreateBranch("feature"))
 
 		planFile := filepath.Join(dir, "docs", "plans", "feature.md")
-		_, _, err = svc.CreateWorktreeForPlan(planFile, "")
+		_, _, err = svc.CreateWorktreeForPlan(planFile, "", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires main/master branch")
 	})
@@ -945,7 +945,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		require.NoError(t, svc.CreateBranch("feature"))
 
 		planFile := filepath.Join(dir, "docs", "plans", "feature.md")
-		_, _, err = svc.CreateWorktreeForPlan(planFile, "develop")
+		_, _, err = svc.CreateWorktreeForPlan(planFile, "develop", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires develop branch")
 	})
@@ -963,7 +963,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "develop-feature.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "develop")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "develop", "")
 		require.NoError(t, err)
 		assert.Contains(t, wtPath, "develop-feature")
 		assert.True(t, planNeedsCommit, "untracked plan file should need commit")
@@ -986,7 +986,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		// create another uncommitted file
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "other.txt"), []byte("other"), 0o600))
 
-		_, _, err = svc.CreateWorktreeForPlan(planFile, "master")
+		_, _, err = svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot create worktree")
 		assert.Contains(t, err.Error(), "uncommitted changes")
@@ -1005,7 +1005,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
 		// create first worktree
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit, "untracked plan file should need commit")
 
@@ -1013,7 +1013,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		require.NoError(t, svc.repo.checkoutBranch("master"))
 
 		// second attempt should fail
-		_, _, err = svc.CreateWorktreeForPlan(planFile, "master")
+		_, _, err = svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "worktree already exists")
 
@@ -1033,7 +1033,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "new-feature.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# New Feature"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit, "untracked plan file should need commit")
 
@@ -1061,7 +1061,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "no-commit-on-main.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Regression Test"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit)
 
@@ -1085,7 +1085,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "branch-conflict.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit, "untracked plan file should need commit")
 		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // cleanup
@@ -1108,7 +1108,7 @@ func TestService_CreateWorktreeForPlan(t *testing.T) {
 		planFile := filepath.Join(plansDir, "2024-01-15-add-auth.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit, "untracked plan file should need commit")
 		assert.Contains(t, wtPath, "add-auth")
@@ -1139,7 +1139,7 @@ func TestService_CommitPlanFile(t *testing.T) {
 		require.NoError(t, os.WriteFile(planFile, []byte("# Commit Test Plan"), 0o600))
 
 		// create worktree (plan is copied in)
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit)
 
@@ -1176,7 +1176,7 @@ func TestService_CommitPlanFile(t *testing.T) {
 		require.NoError(t, os.WriteFile(planFile, []byte("# Case Test Plan"), 0o600))
 
 		// create worktree from master (plan is copied in with original case)
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit)
 
@@ -1210,7 +1210,7 @@ func TestService_RemoveWorktree(t *testing.T) {
 		planFile := filepath.Join(plansDir, "rm-test.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit)
 
@@ -1246,7 +1246,7 @@ func TestService_RemoveWorktree(t *testing.T) {
 		planFile := filepath.Join(plansDir, "preserve-branch.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master")
+		wtPath, planNeedsCommit, err := svc.CreateWorktreeForPlan(planFile, "master", "")
 		require.NoError(t, err)
 		assert.True(t, planNeedsCommit)
 
@@ -1256,6 +1256,44 @@ func TestService_RemoveWorktree(t *testing.T) {
 
 		// branch should still exist
 		assert.True(t, svc.repo.branchExists("preserve-branch"))
+	})
+
+	t.Run("branch override used instead of plan filename", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, &mockLogger{})
+		require.NoError(t, err)
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "2026-04-30-some-long-generated-name.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "my-custom-branch")
+		require.NoError(t, err)
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck
+
+		// worktree path should use the override, not the plan filename
+		assert.Contains(t, wtPath, "my-custom-branch")
+		assert.True(t, svc.repo.branchExists("my-custom-branch"))
+		assert.False(t, svc.repo.branchExists("some-long-generated-name"))
+	})
+
+	t.Run("branch override used in CreateBranchForPlan", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, &mockLogger{})
+		require.NoError(t, err)
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "2026-04-30-some-long-generated-name.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		err = svc.CreateBranchForPlan(planFile, "master", "my-custom-branch")
+		require.NoError(t, err)
+
+		branch, err := svc.CurrentBranch()
+		require.NoError(t, err)
+		assert.Equal(t, "my-custom-branch", branch)
 	})
 }
 
@@ -1434,7 +1472,7 @@ func TestService_CommitWithTrailer(t *testing.T) {
 		planFile := filepath.Join(plansDir, "branch-trailer.md")
 		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
 
-		err = svc.CreateBranchForPlan(planFile, "master")
+		err = svc.CreateBranchForPlan(planFile, "master", "")
 		require.NoError(t, err)
 
 		out := runGit(t, dir, "log", "-1", "--format=%B")


### PR DESCRIPTION
## Summary

Related to #306. Replaces #310.

The `--branch=NAME` flag lets users explicitly set the branch/worktree name instead of relying on auto-derivation from the plan filename.

## Motivation

PR #310 attempted to fix branch name derivation with a heuristic (generic filename detection + parent directory fallback). As @umputun pointed out in the review, this approach is too fragile for such a simple case:

- The heuristic only helps when the filename is in a hardcoded set (`tasks`, `plan`, `plans`, `index`, `readme`) — listing all possible generic names is impossible, and users with `spec.md`, `description.md`, etc. get nothing
- The `--worktree` mode was the only path where the heuristic actually changed anything; regular mode already works because `preparePlanBranch` returns early if already on a feature branch
- A flag is strictly more general: works for any layout, custom namespacing (`feat/foo`), capitalized variants, arbitrary filenames
- ~5 lines, no regex, no edge cases, self-documenting in `--help`

## Changes

- Add `--branch=NAME` CLI flag (overrides branch name derived from plan filename)
- Thread `BranchOverride` through `executePlanRequest`, `preparePlanBranch`, `CreateBranchForPlan`, `CreateWorktreeForPlan`
- Both the worktree path (`.ralphex/worktrees/<name>`) and the progress logger use the override when set
- Works for worktree mode, normal mode, and plan-continuation mode
- Added tests for `CreateWorktreeForPlan` and `CreateBranchForPlan` with override

## Usage

```bash
# OpenSpec layout: tasks.md → would derive "tasks" without --branch
ralphex --worktree --branch=add-dark-mode openspec/changes/add-dark-mode/tasks.md

# Custom namespacing
ralphex --branch=feat/user-auth docs/plans/auth.md

# Generic plan filenames
ralphex --branch=my-feature docs/plans/plan.md
```

## Test plan

- [x] `go test ./pkg/git/...` — new override test cases pass
- [x] `make test` — full suite green
- [ ] Manual: `ralphex --worktree --branch=my-branch docs/plans/tasks.md` creates worktree at `.ralphex/worktrees/my-branch` on branch `my-branch`
- [ ] Manual: without `--branch`, existing behavior unchanged