### PR TITLE
fix: progress log filename ignores --branch override

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -417,10 +417,11 @@ func setupProgressLogger(o opts, req executePlanRequest, branch string) (progres
 	} else {
 		var err error
 		baseLog, err = progress.NewLogger(progress.Config{
-			PlanFile: req.PlanFile,
-			Mode:     string(req.Mode),
-			Branch:   branch,
-			NoColor:  o.NoColor,
+			PlanFile:       req.PlanFile,
+			Mode:           string(req.Mode),
+			Branch:         branch,
+			BranchOverride: req.BranchOverride,
+			NoColor:        o.NoColor,
 		}, req.Colors, holder)
 		if err != nil {
 			return progressLogResult{}, fmt.Errorf("create progress logger: %w", err)
@@ -663,10 +664,11 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 	holder := &status.PhaseHolder{}
 	branch := req.GitSvc.EffectiveBranchName(req.PlanFile, req.BranchOverride)
 	baseLog, err := progress.NewLogger(progress.Config{
-		PlanFile: req.PlanFile,
-		Mode:     string(req.Mode),
-		Branch:   branch,
-		NoColor:  o.NoColor,
+		PlanFile:       req.PlanFile,
+		Mode:           string(req.Mode),
+		Branch:         branch,
+		BranchOverride: req.BranchOverride,
+		NoColor:        o.NoColor,
 	}, req.Colors, holder)
 	if err != nil {
 		return fmt.Errorf("create progress logger: %w", err)

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -135,6 +135,7 @@ type Config struct {
 	PlanDescription string // plan description for plan mode (used for filename)
 	Mode            string // execution mode: full, review, codex-only, plan
 	Branch          string // current git branch
+	BranchOverride  string // explicit branch name override (--branch flag); when set, used as filename stem instead of plan file
 	NoColor         bool   // disable color output (sets color.NoColor globally)
 }
 
@@ -151,7 +152,7 @@ func NewLogger(cfg Config, colors *Colors, holder *status.PhaseHolder) (*Logger,
 		color.NoColor = true
 	}
 
-	progressPath := progressFilename(cfg.PlanFile, cfg.PlanDescription, cfg.Mode)
+	progressPath := progressFilename(cfg.PlanFile, cfg.PlanDescription, cfg.Mode, cfg.BranchOverride)
 
 	// resolve to absolute path so Logger.Path() works from any CWD (e.g. after worktree chdir)
 	if absPath, absErr := filepath.Abs(progressPath); absErr == nil {
@@ -652,24 +653,33 @@ func isProgressCompleted(f *os.File, size int64) bool {
 // progressDir is the directory for progress files within the project.
 const progressDir = ".ralphex/progress"
 
+// filenameWithStem returns the progress file path for a known stem and mode.
+func filenameWithStem(stem, mode string) string {
+	switch mode {
+	case "codex-only":
+		return filepath.Join(progressDir, fmt.Sprintf("progress-%s-codex.txt", stem))
+	case "review":
+		return filepath.Join(progressDir, fmt.Sprintf("progress-%s-review.txt", stem))
+	default:
+		return filepath.Join(progressDir, fmt.Sprintf("progress-%s.txt", stem))
+	}
+}
+
 // progressFilename returns progress file path based on plan and mode.
-func progressFilename(planFile, planDescription, mode string) string {
+func progressFilename(planFile, planDescription, mode, branchOverride string) string {
 	// plan mode uses sanitized plan description
 	if mode == "plan" && planDescription != "" {
 		sanitized := sanitizePlanName(planDescription)
 		return filepath.Join(progressDir, fmt.Sprintf("progress-plan-%s.txt", sanitized))
 	}
 
+	// explicit branch override takes precedence over plan filename as stem
+	if branchOverride != "" {
+		return filenameWithStem(sanitizePlanName(branchOverride), mode)
+	}
+
 	if planFile != "" {
-		stem := strings.TrimSuffix(filepath.Base(planFile), ".md")
-		switch mode {
-		case "codex-only":
-			return filepath.Join(progressDir, fmt.Sprintf("progress-%s-codex.txt", stem))
-		case "review":
-			return filepath.Join(progressDir, fmt.Sprintf("progress-%s-review.txt", stem))
-		default:
-			return filepath.Join(progressDir, fmt.Sprintf("progress-%s.txt", stem))
-		}
+		return filenameWithStem(strings.TrimSuffix(filepath.Base(planFile), ".md"), mode)
 	}
 
 	switch mode {

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -788,24 +788,29 @@ func TestGetProgressFilename(t *testing.T) {
 		planFile        string
 		planDescription string
 		mode            string
+		branchOverride  string
 		want            string
 	}{
-		{"full mode with plan", "docs/plans/feature.md", "", "full", filepath.Join(progressDir, "progress-feature.txt")},
-		{"review mode with plan", "docs/plans/feature.md", "", "review", filepath.Join(progressDir, "progress-feature-review.txt")},
-		{"codex-only mode with plan", "docs/plans/feature.md", "", "codex-only", filepath.Join(progressDir, "progress-feature-codex.txt")},
-		{"full mode no plan", "", "", "full", filepath.Join(progressDir, "progress.txt")},
-		{"review mode no plan", "", "", "review", filepath.Join(progressDir, "progress-review.txt")},
-		{"codex-only mode no plan", "", "", "codex-only", filepath.Join(progressDir, "progress-codex.txt")},
-		{"full with date prefix", "plans/2024-01-15-refactor.md", "", "full", filepath.Join(progressDir, "progress-2024-01-15-refactor.txt")},
-		{"plan mode with description", "", "implement caching", "plan", filepath.Join(progressDir, "progress-plan-implement-caching.txt")},
-		{"plan mode with complex description", "", "Add User Authentication!", "plan", filepath.Join(progressDir, "progress-plan-add-user-authentication.txt")},
-		{"plan mode no description", "", "", "plan", filepath.Join(progressDir, "progress-plan.txt")},
-		{"plan mode with special chars", "", "fix: bug #123", "plan", filepath.Join(progressDir, "progress-plan-fix-bug-123.txt")},
+		{"full mode with plan", "docs/plans/feature.md", "", "full", "", filepath.Join(progressDir, "progress-feature.txt")},
+		{"review mode with plan", "docs/plans/feature.md", "", "review", "", filepath.Join(progressDir, "progress-feature-review.txt")},
+		{"codex-only mode with plan", "docs/plans/feature.md", "", "codex-only", "", filepath.Join(progressDir, "progress-feature-codex.txt")},
+		{"full mode no plan", "", "", "full", "", filepath.Join(progressDir, "progress.txt")},
+		{"review mode no plan", "", "", "review", "", filepath.Join(progressDir, "progress-review.txt")},
+		{"codex-only mode no plan", "", "", "codex-only", "", filepath.Join(progressDir, "progress-codex.txt")},
+		{"full with date prefix", "plans/2024-01-15-refactor.md", "", "full", "", filepath.Join(progressDir, "progress-2024-01-15-refactor.txt")},
+		{"plan mode with description", "", "implement caching", "plan", "", filepath.Join(progressDir, "progress-plan-implement-caching.txt")},
+		{"plan mode with complex description", "", "Add User Authentication!", "plan", "", filepath.Join(progressDir, "progress-plan-add-user-authentication.txt")},
+		{"plan mode no description", "", "", "plan", "", filepath.Join(progressDir, "progress-plan.txt")},
+		{"plan mode with special chars", "", "fix: bug #123", "plan", "", filepath.Join(progressDir, "progress-plan-fix-bug-123.txt")},
+		{"branch override full mode", "docs/plans/tasks.md", "", "full", "my-feature", filepath.Join(progressDir, "progress-my-feature.txt")},
+		{"branch override review mode", "docs/plans/tasks.md", "", "review", "my-feature", filepath.Join(progressDir, "progress-my-feature-review.txt")},
+		{"branch override codex-only mode", "docs/plans/tasks.md", "", "codex-only", "my-feature", filepath.Join(progressDir, "progress-my-feature-codex.txt")},
+		{"branch override no plan", "", "", "full", "my-feature", filepath.Join(progressDir, "progress-my-feature.txt")},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := progressFilename(tc.planFile, tc.planDescription, tc.mode)
+			got := progressFilename(tc.planFile, tc.planDescription, tc.mode, tc.branchOverride)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

- Discovered during manual testing of #315: when `--branch` is used with a generic plan file (e.g. `tasks.md`), the progress log was still named after the plan file instead of the branch override
- Added `BranchOverride` field to `progress.Config` so `progressFilename` uses the explicit branch name as the filename stem when set
- Extracted `filenameWithStem` helper to eliminate duplication between the two switch blocks
- Added test cases covering `--branch` override for full, review, and codex-only modes

## Test plan

- [x] `make test` passes
- [x] `ralphex --worktree --branch=my-feature docs/plans/tasks.md` creates `.ralphex/progress/progress-my-feature.txt` instead of `progress-tasks.txt`