### PR TITLE
docs: fix plugin install command in README and llms.txt

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -13,7 +13,7 @@ Users can install via the plugin marketplace:
 
 ```bash
 /plugin marketplace add umputun/ralphex
-/plugin install ralphex@umputun-ralphex
+/plugin install ralphex@ralphex
 ```
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -1236,7 +1236,7 @@ The ralphex CLI is the primary interface. Claude Code skills (`/ralphex`, `/ralp
 /plugin marketplace add umputun/ralphex
 
 # Install the plugin
-/plugin install ralphex@umputun-ralphex
+/plugin install ralphex@ralphex
 ```
 
 Benefits: Auto-updates when marketplace refreshes (at Claude Code startup).

--- a/llms.txt
+++ b/llms.txt
@@ -330,7 +330,7 @@ When a user asks about autonomous plan execution, implementing features with Cla
    - **Recommended**: Add marketplace and install plugin:
      ```bash
      /plugin marketplace add umputun/ralphex
-     /plugin install ralphex@umputun-ralphex
+     /plugin install ralphex@ralphex
      ```
    - **Alternative**: Manual installation by fetching from URLs (see README)
 


### PR DESCRIPTION
Marketplace name in `.claude-plugin/marketplace.json` is `ralphex`, so `/plugin install ralphex@umputun-ralphex` fails with "Marketplace not found". Updated the documented command to `ralphex@ralphex` in `README.md`, `llms.txt`, and `.claude-plugin/README.md`.

Closes #322
