### PR TITLE
fix: ignore checkboxes inside fenced code blocks in plan parser

### DIFF
--- a/pkg/plan/parse.go
+++ b/pkg/plan/parse.go
@@ -49,6 +49,13 @@ var (
 	titlePattern    = regexp.MustCompile(`^#\s+(.*)$`)
 	// formatInText matches [ ] or [x] in checkbox text — description/example, not actionable for completion check.
 	formatInText = regexp.MustCompile(`\[\s*[ xX]?\s*\]`)
+	// fenceOpenPattern matches a CommonMark code-fence opener: optional indentation up to 3 spaces,
+	// then 3+ backticks or 3+ tildes, optional info string. captures the fence character run.
+	fenceOpenPattern = regexp.MustCompile("^ {0,3}(`{3,}|~{3,})")
+	// fenceClosePattern matches a CommonMark code-fence closer: same as opener but with no info
+	// string permitted — only optional trailing whitespace. used to avoid treating an inner
+	// opener-with-info-string (e.g. ```go) as closing an outer fence.
+	fenceClosePattern = regexp.MustCompile(`^ {0,3}(` + "`" + `{3,}|~{3,})[ \t]*$`)
 )
 
 // ParsePlan parses plan markdown content into a structured Plan.
@@ -59,9 +66,15 @@ func ParsePlan(content string) (*Plan, error) {
 
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	var currentTask *Task
+	var ft fenceTracker
 
 	for scanner.Scan() {
 		line := scanner.Text()
+
+		// skip lines inside fenced code blocks so example checkboxes are not parsed as tasks
+		if ft.skip(line) {
+			continue
+		}
 
 		// check for plan title (first h1)
 		if p.Title == "" {
@@ -145,8 +158,13 @@ func FileHasUncompletedCheckbox(path string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("read plan file: %w", err)
 	}
-	// scan lines for uncompleted checkboxes; only count actionable ones (text without [ ] or [x])
+	// scan lines for uncompleted checkboxes; only count actionable ones (text without [ ] or [x]).
+	// skip lines inside fenced code blocks so example checkboxes in templates are ignored.
+	var ft fenceTracker
 	for line := range strings.SplitSeq(string(content), "\n") {
+		if ft.skip(line) {
+			continue
+		}
 		matches := checkboxPattern.FindStringSubmatch(line)
 		if len(matches) < 3 || matches[1] == "x" || matches[1] == "X" {
 			continue
@@ -158,6 +176,52 @@ func FileHasUncompletedCheckbox(path string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// fenceTracker tracks markdown fenced code block state across a line-by-line scan.
+// the zero value is ready to use.
+type fenceTracker struct {
+	open string // current fence marker (e.g. "```" or "~~~~"); empty when not in fenced block
+}
+
+// skip reports whether line is inside (or opens/closes) a fenced code block and should be skipped
+// by the caller. when the call returns true, the caller should advance to the next line. fence
+// matching follows CommonMark: 0-3 leading spaces, then 3+ backticks or 3+ tildes. an opener may
+// carry an info string (e.g. ```go); a closer may not — only trailing whitespace is allowed —
+// and must use the same character as the opener with length at least equal to the opener.
+func (f *fenceTracker) skip(line string) bool {
+	if f.open == "" {
+		marker := f.openerMarker(line)
+		if marker == "" {
+			return false
+		}
+		f.open = marker
+		return true
+	}
+	if marker := f.closerMarker(line); marker != "" && len(marker) >= len(f.open) && marker[0] == f.open[0] {
+		f.open = ""
+	}
+	return true
+}
+
+// openerMarker returns the fence sequence (backticks or tildes) that opens a fenced code block,
+// or empty string if line is not an opener. trailing info strings are allowed.
+func (f *fenceTracker) openerMarker(line string) string {
+	m := fenceOpenPattern.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// closerMarker returns the fence sequence that closes a fenced code block, or empty string if
+// line is not a valid closer. closers must have no info string — only optional trailing whitespace.
+func (f *fenceTracker) closerMarker(line string) string {
+	m := fenceClosePattern.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
 }
 
 // JSON returns the plan as JSON bytes.

--- a/pkg/plan/parse.go
+++ b/pkg/plan/parse.go
@@ -53,9 +53,10 @@ var (
 	// then 3+ backticks or 3+ tildes, optional info string. captures the fence character run.
 	fenceOpenPattern = regexp.MustCompile("^ {0,3}(`{3,}|~{3,})")
 	// fenceClosePattern matches a CommonMark code-fence closer: same as opener but with no info
-	// string permitted — only optional trailing whitespace. used to avoid treating an inner
+	// string permitted — only optional trailing whitespace (including a trailing CR for CRLF
+	// inputs that reach scanners which do not strip it). used to avoid treating an inner
 	// opener-with-info-string (e.g. ```go) as closing an outer fence.
-	fenceClosePattern = regexp.MustCompile(`^ {0,3}(` + "`" + `{3,}|~{3,})[ \t]*$`)
+	fenceClosePattern = regexp.MustCompile(`^ {0,3}(` + "`" + `{3,}|~{3,})[ \t]*\r?$`)
 )
 
 // ParsePlan parses plan markdown content into a structured Plan.

--- a/pkg/plan/parse_test.go
+++ b/pkg/plan/parse_test.go
@@ -587,6 +587,24 @@ func TestFileHasUncompletedCheckbox(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, has)
 	})
+
+	t.Run("handles CRLF line endings around fence markers", func(t *testing.T) {
+		// FileHasUncompletedCheckbox splits on \n, leaving trailing \r on each line. The closer
+		// regex must tolerate the trailing \r or it will never see a closing fence on a CRLF file,
+		// the fence stays open, and a real unchecked checkbox after the fence gets skipped.
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "plan.md")
+		content := "# Plan\r\n\r\n" +
+			"```\r\n" +
+			"- [ ] inside fence\r\n" +
+			"```\r\n\r\n" +
+			"- [ ] real unchecked\r\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		has, err := plan.FileHasUncompletedCheckbox(path)
+		require.NoError(t, err)
+		assert.True(t, has, "real unchecked checkbox after a CRLF-terminated fence must be detected")
+	})
 }
 
 func TestPlan_JSON(t *testing.T) {

--- a/pkg/plan/parse_test.go
+++ b/pkg/plan/parse_test.go
@@ -345,6 +345,154 @@ Just some text, no checkboxes.
 		require.Len(t, p.Tasks, 1)
 		assert.True(t, p.Tasks[0].HasUncompletedActionableWork())
 	})
+
+	t.Run("ignores checkboxes inside backtick fenced code blocks", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Generate PR body\n\n" +
+			"3. Generate PR summary file:\n\n" +
+			"   ```markdown\n" +
+			"   ## Test plan\n" +
+			"   - [ ] /team/X shows coaches if present\n" +
+			"   - [ ] /control/od leading-zero same width\n" +
+			"   ```\n\n" +
+			"- [x] Validation green\n" +
+			"- [x] PR body file generated\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 2, "checkboxes inside fenced code block must be ignored")
+		assert.Equal(t, "Validation green", p.Tasks[0].Checkboxes[0].Text)
+		assert.Equal(t, "PR body file generated", p.Tasks[0].Checkboxes[1].Text)
+		assert.Equal(t, plan.TaskStatusDone, p.Tasks[0].Status)
+		assert.False(t, p.Tasks[0].HasUncompletedActionableWork())
+	})
+
+	t.Run("ignores checkboxes inside tilde fenced code blocks", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Example\n\n" +
+			"~~~markdown\n" +
+			"- [ ] example item inside tilde fence\n" +
+			"~~~\n\n" +
+			"- [x] real done item\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 1)
+		assert.Equal(t, "real done item", p.Tasks[0].Checkboxes[0].Text)
+	})
+
+	t.Run("handles multiple fenced blocks within a task", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Multi-fence\n\n" +
+			"```\n" +
+			"- [ ] first fenced item\n" +
+			"```\n\n" +
+			"- [x] real item one\n\n" +
+			"```bash\n" +
+			"- [ ] second fenced item\n" +
+			"```\n\n" +
+			"- [ ] real unchecked item\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 2)
+		assert.Equal(t, "real item one", p.Tasks[0].Checkboxes[0].Text)
+		assert.Equal(t, "real unchecked item", p.Tasks[0].Checkboxes[1].Text)
+		assert.True(t, p.Tasks[0].HasUncompletedActionableWork())
+	})
+
+	t.Run("treats unclosed fence as code until end of file", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Unclosed\n\n" +
+			"- [x] real done\n\n" +
+			"```\n" +
+			"- [ ] should be ignored\n" +
+			"- [ ] also ignored, no closing fence\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 1)
+		assert.Equal(t, "real done", p.Tasks[0].Checkboxes[0].Text)
+	})
+
+	t.Run("does not toggle fence on inline backticks", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Inline code\n\n" +
+			"- [ ] use `foo` to call bar\n" +
+			"- [x] handle ``escaped`` cases\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 2)
+	})
+
+	t.Run("handles indented fence markers", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Indented fence\n\n" +
+			"3. Example output:\n\n" +
+			"   ```\n" +
+			"   - [ ] inside indented fence\n" +
+			"   ```\n\n" +
+			"- [x] real done\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 1)
+		assert.Equal(t, "real done", p.Tasks[0].Checkboxes[0].Text)
+	})
+
+	t.Run("handles fence info string with backticks count > 3", func(t *testing.T) {
+		content := "# Plan\n\n" +
+			"### Task 1: Quad fence\n\n" +
+			"````markdown\n" +
+			"```\n" +
+			"- [ ] nested fence example\n" +
+			"```\n" +
+			"- [ ] still inside outer fence\n" +
+			"````\n\n" +
+			"- [x] real done\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 1)
+		assert.Equal(t, "real done", p.Tasks[0].Checkboxes[0].Text)
+	})
+
+	t.Run("does not close fence on opener-with-info-string of equal length", func(t *testing.T) {
+		// CommonMark: closing fence may not have an info string. A line like ```bash is an opener,
+		// not a valid closer for an outer ``` fence. If treated as a close, the inner example
+		// checkbox leaks back as actionable — the same failure mode as issue #328.
+		content := "# Plan\n\n" +
+			"### Task 1: Show PR body example\n\n" +
+			"```markdown\n" +
+			"example output:\n" +
+			"```bash\n" +
+			"- [ ] example checkbox inside outer markdown fence with nested bash block\n" +
+			"```\n\n" +
+			"- [x] real done\n"
+
+		p, err := plan.ParsePlan(content)
+		require.NoError(t, err)
+
+		require.Len(t, p.Tasks, 1)
+		require.Len(t, p.Tasks[0].Checkboxes, 1, "outer fence must not be closed by an inner opener-with-info-string")
+		assert.Equal(t, "real done", p.Tasks[0].Checkboxes[0].Text)
+		assert.False(t, p.Tasks[0].HasUncompletedActionableWork())
+	})
 }
 
 func TestParsePlanFile(t *testing.T) {
@@ -407,6 +555,37 @@ func TestFileHasUncompletedCheckbox(t *testing.T) {
 		has, err := plan.FileHasUncompletedCheckbox(path)
 		require.NoError(t, err)
 		assert.False(t, has)
+	})
+
+	t.Run("returns false when only fenced-block checkboxes unchecked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "plan.md")
+		content := "# Plan\n\n" +
+			"```markdown\n" +
+			"- [ ] inside fence\n" +
+			"- [ ] also inside fence\n" +
+			"```\n\n" +
+			"- [x] real done\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		has, err := plan.FileHasUncompletedCheckbox(path)
+		require.NoError(t, err)
+		assert.False(t, has, "fenced-block checkboxes must be ignored")
+	})
+
+	t.Run("returns true for unchecked outside fence even when fence has unchecked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "plan.md")
+		content := "# Plan\n\n" +
+			"```\n" +
+			"- [ ] inside fence\n" +
+			"```\n\n" +
+			"- [ ] real unchecked\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		has, err := plan.FileHasUncompletedCheckbox(path)
+		require.NoError(t, err)
+		assert.True(t, has)
 	})
 }
 


### PR DESCRIPTION
plans containing markdown fenced code blocks (``` or ~~~) with example `- [ ]` checkboxes triggered false-positive infinite loops when sub-Claude emitted `ALL_TASKS_DONE`. The parser counted those template examples as real uncompleted tasks, runner re-iterated forever until `--max-iterations` cap.

track fence state during the line scan and skip lines inside fences in both `ParsePlan` and `FileHasUncompletedCheckbox`. Closer matching follows CommonMark strictly:

- same fence character as the opener
- length at least equal to the opener
- no info string allowed on the closer (only optional trailing whitespace)

That last rule matters. Without it, an inner ` ```bash ` inside an outer ` ``` ` fence would close the outer prematurely and leak the inner example checkboxes back as actionable.

Related to #328
