### PR TITLE
feat(config): configurable base directory for engine-created worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- Configurable base directory for engine-created worktrees via the `worktree_path`
+  config option. Defaults to `.ralphex/worktrees` (relative to the repo root) so
+  the change is non-breaking. Absolute paths are supported for placing worktrees
+  outside the repo (e.g., `/var/lib/ralphex-worktrees` or a sibling directory
+  next to the main checkout).
+
 ## v1.3.1 - 2026-05-22
 
 ### New Features

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -304,6 +304,7 @@ func run(ctx context.Context, o opts) error {
 		return fmt.Errorf("open git repo: %w", err)
 	}
 	gitSvc.SetCommitTrailer(cfg.CommitTrailer)
+	gitSvc.SetWorktreePath(cfg.WorktreePath)
 
 	// ensure repository has commits (prompts to create initial commit if empty)
 	if ensureErr := ensureRepoHasCommits(ctx, gitSvc, os.Stdin, os.Stdout); ensureErr != nil {
@@ -754,6 +755,7 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 		return fmt.Errorf("open worktree git service: %w", err)
 	}
 	wtGitSvc.SetCommitTrailer(req.Config.CommitTrailer)
+	wtGitSvc.SetWorktreePath(req.Config.WorktreePath)
 
 	// resolve plan file path inside the worktree so Claude operates on the local copy,
 	// not the original in the main repo. the plan was copied by CreateWorktreeForPlan.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,8 +94,9 @@ type Config struct {
 
 	MovePlanOnCompletion bool `json:"move_plan_on_completion"`
 
-	WorktreeEnabled    bool `json:"worktree_enabled"`
-	WorktreeEnabledSet bool `json:"-"` // tracks if use_worktree was explicitly set in config
+	WorktreeEnabled    bool   `json:"worktree_enabled"`
+	WorktreeEnabledSet bool   `json:"-"`             // tracks if use_worktree was explicitly set in config
+	WorktreePath       string `json:"worktree_path"` // base directory for engine-created worktrees (relative to repo root, or absolute); default ".ralphex/worktrees"
 
 	PlansDir      string   `json:"plans_dir"`
 	WatchDirs     []string `json:"watch_dirs"`     // directories to watch for progress files
@@ -330,6 +331,7 @@ func loadConfigFromDirs(globalDir, localDir string) (*Config, error) {
 		MovePlanOnCompletion:    values.MovePlanOnCompletion,
 		WorktreeEnabled:         values.WorktreeEnabled,
 		WorktreeEnabledSet:      values.WorktreeEnabledSet,
+		WorktreePath:            values.WorktreePath,
 		PlansDir:                values.PlansDir,
 		DefaultBranch:           values.DefaultBranch,
 		VcsCommand:              values.VcsCommand,

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -146,9 +146,17 @@ move_plan_on_completion = true
 # ------------------------------------------------------------------------------
 
 # use_worktree: run each plan in an isolated git worktree
-# creates .ralphex/worktrees/<plan-name> for parallel execution
+# creates <worktree_path>/<plan-name> for parallel execution
 # default: false
 # use_worktree = false
+
+# worktree_path: base directory for engine-created worktrees (use_worktree = true)
+# relative paths are resolved against the repo root; absolute paths are used as-is.
+# the per-plan directory is appended as <worktree_path>/<branch>.
+# does not apply when ralphex is launched from a pre-existing worktree (no engine
+# worktree is created in that case).
+# default: .ralphex/worktrees
+# worktree_path = .ralphex/worktrees
 
 # ------------------------------------------------------------------------------
 # timing

--- a/pkg/config/values.go
+++ b/pkg/config/values.go
@@ -63,6 +63,7 @@ type Values struct {
 	MovePlanOnCompletionSet    bool // tracks if move_plan_on_completion was explicitly set
 	WorktreeEnabled            bool
 	WorktreeEnabledSet         bool   // tracks if use_worktree was explicitly set
+	WorktreePath               string // base directory for engine-created worktrees (relative to repo root); default ".ralphex/worktrees"
 	VcsCommand                 string // custom VCS command (default: "git")
 	CommitTrailer              string // trailer line to append to all commits (e.g., "Co-authored-by: ...")
 	PlansDir                   string
@@ -368,6 +369,9 @@ func (vl *valuesLoader) parseValuesFromBytes(data []byte) (Values, error) {
 		values.WorktreeEnabled = val
 		values.WorktreeEnabledSet = true
 	}
+	if key, err := section.GetKey("worktree_path"); err == nil {
+		values.WorktreePath = strings.TrimSpace(key.String())
+	}
 
 	// paths
 	if key, err := section.GetKey("plans_dir"); err == nil {
@@ -586,6 +590,9 @@ func (dst *Values) mergeExtraFrom(src *Values) {
 	if src.WorktreeEnabledSet {
 		dst.WorktreeEnabled = src.WorktreeEnabled
 		dst.WorktreeEnabledSet = true
+	}
+	if src.WorktreePath != "" {
+		dst.WorktreePath = src.WorktreePath
 	}
 	if src.PlansDir != "" {
 		dst.PlansDir = src.PlansDir

--- a/pkg/config/values_test.go
+++ b/pkg/config/values_test.go
@@ -380,6 +380,50 @@ func TestValuesLoader_Load_WorktreeEnabled(t *testing.T) {
 	})
 }
 
+func TestValuesLoader_Load_WorktreePath(t *testing.T) {
+	t.Run("parse relative worktree_path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`worktree_path = tmp/wt`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load("", cfgPath)
+		require.NoError(t, err)
+		assert.Equal(t, "tmp/wt", values.WorktreePath)
+	})
+
+	t.Run("parse absolute worktree_path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`worktree_path = /var/lib/ralphex-worktrees`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load("", cfgPath)
+		require.NoError(t, err)
+		assert.Equal(t, "/var/lib/ralphex-worktrees", values.WorktreePath)
+	})
+
+	t.Run("not set leaves empty (caller uses default)", func(t *testing.T) {
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load("", "")
+		require.NoError(t, err)
+		assert.Empty(t, values.WorktreePath)
+	})
+
+	t.Run("local overrides global", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		globalCfg := filepath.Join(tmpDir, "global")
+		localCfg := filepath.Join(tmpDir, "local")
+		require.NoError(t, os.WriteFile(globalCfg, []byte(`worktree_path = /global/path`), 0o600))
+		require.NoError(t, os.WriteFile(localCfg, []byte(`worktree_path = /local/path`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load(localCfg, globalCfg)
+		require.NoError(t, err)
+		assert.Equal(t, "/local/path", values.WorktreePath)
+	})
+}
+
 func TestValues_mergeFrom_WorktreeEnabled(t *testing.T) {
 	t.Run("set flag merges", func(t *testing.T) {
 		dst := Values{WorktreeEnabled: false, WorktreeEnabledSet: false}

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -52,12 +52,17 @@ type DiffStats struct {
 	Deletions int // lines deleted
 }
 
+// defaultWorktreeBase is the default base directory (relative to the repo
+// root) for engine-created worktrees. Overridable via SetWorktreePath.
+const defaultWorktreeBase = ".ralphex/worktrees"
+
 // Service provides git operations for ralphex workflows.
 // It is the single public API for the git package.
 type Service struct {
-	repo    backend
-	log     Logger
-	trailer string // optional trailer line appended to all commits
+	repo         backend
+	log          Logger
+	trailer      string // optional trailer line appended to all commits
+	worktreeBase string // base directory for engine-created worktrees; empty means use defaultWorktreeBase
 }
 
 // NewService opens a git repository and returns a Service.
@@ -80,6 +85,28 @@ func NewService(path string, log Logger, vcsCmd ...string) (*Service, error) {
 // when set, a blank line and the trailer are appended after the commit message.
 func (s *Service) SetCommitTrailer(trailer string) {
 	s.trailer = trailer
+}
+
+// SetWorktreePath overrides the base directory used for engine-created worktrees.
+// An empty path resets to the default (".ralphex/worktrees").
+// Relative paths are resolved against the repo root; absolute paths are used as-is.
+// The per-plan worktree directory is appended as <base>/<branch>.
+func (s *Service) SetWorktreePath(path string) {
+	s.worktreeBase = path
+}
+
+// worktreePath returns the absolute base directory for engine-created worktrees,
+// resolving relative paths against the repo root and falling back to the default
+// when no override has been configured.
+func (s *Service) worktreePath() string {
+	base := s.worktreeBase
+	if base == "" {
+		base = defaultWorktreeBase
+	}
+	if filepath.IsAbs(base) {
+		return base
+	}
+	return filepath.Join(s.repo.root(), base)
 }
 
 // appendTrailer appends the configured trailer to a commit message.
@@ -269,7 +296,9 @@ func (s *Service) CreateBranchForPlan(planFile, defaultBranch, branchOverride st
 
 // CreateWorktreeForPlan creates an isolated git worktree for plan execution.
 // must be called from the default branch (same guard as CreateBranchForPlan).
-// derives branch name from plan file, creates worktree at .ralphex/worktrees/<branch>.
+// derives branch name from plan file, creates worktree at <worktree-base>/<branch>.
+// the base directory defaults to ".ralphex/worktrees" and can be overridden via
+// SetWorktreePath (typically wired to the worktree_path config option).
 // returns (worktree path, planNeedsCommit, error). when planNeedsCommit is true the caller
 // must commit the plan file in the worktree context (via CommitPlanFile on the worktree's
 // git service) so the commit lands on the feature branch rather than the default branch.
@@ -281,7 +310,7 @@ func (s *Service) CreateWorktreeForPlan(planFile, defaultBranch, branchOverride 
 	// check worktree existence early, before preparePlanBranch runs hasChangesOtherThan
 	// (an existing worktree dir would show up as untracked and fail the dirty check)
 	earlyBranch := s.EffectiveBranchName(planFile, branchOverride)
-	wtPath := filepath.Join(s.repo.root(), ".ralphex", "worktrees", earlyBranch)
+	wtPath := filepath.Join(s.worktreePath(), earlyBranch)
 
 	// prune stale worktree entries first
 	if pruneErr := s.repo.pruneWorktrees(); pruneErr != nil {

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -1452,6 +1452,95 @@ func TestService_CommitPlanFile(t *testing.T) {
 	})
 }
 
+func TestService_SetWorktreePath(t *testing.T) {
+	t.Run("default base when unset", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, noopServiceLogger())
+		require.NoError(t, err)
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "default-path.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "")
+		require.NoError(t, err)
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup
+
+		assert.Contains(t, wtPath, filepath.Join(".ralphex", "worktrees", "default-path"))
+	})
+
+	t.Run("relative path resolves under repo root", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, noopServiceLogger())
+		require.NoError(t, err)
+		svc.SetWorktreePath(filepath.Join("tmp", "wt"))
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "rel-path.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "")
+		require.NoError(t, err)
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup
+
+		// resolve symlinks for stable comparison (macOS /var → /private/var)
+		expectedRoot, err := filepath.EvalSymlinks(dir)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(expectedRoot, "tmp", "wt", "rel-path"), wtPath)
+	})
+
+	t.Run("absolute path used as-is", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, noopServiceLogger())
+		require.NoError(t, err)
+
+		// place the worktree base in a sibling temp dir so it lives outside the repo root
+		absBase := filepath.Join(t.TempDir(), "external-wt-base")
+		svc.SetWorktreePath(absBase)
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "abs-path.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "")
+		require.NoError(t, err)
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup
+
+		// the actual on-disk path may have symlinks resolved (macOS /var → /private/var);
+		// resolve both sides for comparison so the test passes regardless of the temp
+		// directory's symlink layout.
+		expected, err := filepath.EvalSymlinks(filepath.Join(absBase, "abs-path"))
+		require.NoError(t, err)
+		actual, err := filepath.EvalSymlinks(wtPath)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("empty path resets to default", func(t *testing.T) {
+		dir := setupExternalTestRepo(t)
+		svc, err := NewService(dir, noopServiceLogger())
+		require.NoError(t, err)
+
+		// override then reset
+		svc.SetWorktreePath("custom/base")
+		svc.SetWorktreePath("")
+
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "reset-path.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan"), 0o600))
+
+		wtPath, _, err := svc.CreateWorktreeForPlan(planFile, "master", "")
+		require.NoError(t, err)
+		defer svc.RemoveWorktree(wtPath) //nolint:errcheck // test cleanup
+
+		assert.Contains(t, wtPath, filepath.Join(".ralphex", "worktrees", "reset-path"))
+	})
+}
+
 func TestService_RemoveWorktree(t *testing.T) {
 	t.Run("removes existing worktree", func(t *testing.T) {
 		dir := setupExternalTestRepo(t)


### PR DESCRIPTION
## Motivation

`CreateWorktreeForPlan` hardcodes the worktree base directory to
`.ralphex/worktrees/<branch>` under the repo root. Operators who run ralphex
under `use_worktree = true` cannot redirect those worktrees elsewhere — for
example to a sibling directory next to the main checkout (which keeps the
worktrees visible to `git worktree list` from the main repo but out of `git
status`), or to a faster filesystem.

This PR adds a `worktree_path` config option to override that base directory.

## Behavior

- Default value: `.ralphex/worktrees` (matches the previous hardcoded path —
  the change is non-breaking).
- Relative paths are resolved against the repo root.
- Absolute paths are used as-is, so operators can place engine-created
  worktrees outside the repo entirely (e.g. `/var/lib/ralphex-worktrees` or
  `../ralphex-worktrees`).
- The per-plan directory is always `<worktree_path>/<branch>`.
- The config is wired into `git.Service` via a new `SetWorktreePath` method,
  mirroring the existing `SetCommitTrailer` pattern.

## Note on `.ralphex/.gitignore`

`EnsureLocalGitignore` still writes `progress/` and `worktrees/` so the
default path is covered. When operators set `worktree_path` to a location
inside the repo but outside `.ralphex/`, they are responsible for adding it
to their own `.gitignore` (typical for absolute or sibling paths, which is
the main use case). Documented inline in `defaults/config`.

## Tests

- `pkg/git/service_test.go` — `TestService_SetWorktreePath` covers default,
  relative, absolute, and reset-to-default paths.
- `pkg/config/values_test.go` — `TestValuesLoader_Load_WorktreePath` covers
  parsing and local-overrides-global precedence.

`go test ./...` passes the new tests; one pre-existing failure
(`TestService_CreateWorktreeForPlan/fails_when_branch_is_checked_out_in_another_worktree`)
exists on `master` too — it depends on the local git binary emitting "already
used by worktree" rather than "already checked out". Not touched by this PR.

`golangci-lint run ./...` reports 0 issues.

## Open to discussion

Happy to adjust naming (`worktree_path` vs `worktree_base_dir`), default
behavior, or the `Service` API shape (`SetWorktreePath` vs constructor
parameter) before merging. The current shape was chosen to keep the change
non-breaking and mirror existing patterns in the codebase.