### PR TITLE
feat(config): require_worktree opt-in for worktree-first workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- Added a `require_worktree` config option. When enabled, ralphex refuses to run
+  from the main checkout's default branch without `--worktree` and surfaces the
+  missing worktree as a clear error before any agent is invoked. Operators who
+  manage worktrees externally (e.g. `git worktree add ../task-X -b task-X`) get
+  fail-fast feedback instead of an unintended feature-branch commit in the main
+  checkout. Default is `false`; the in-place flow on feature branches is
+  untouched.
+
 ## v1.3.1 - 2026-05-22
 
 ### New Features

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -370,6 +370,17 @@ func selectAndExecutePlan(ctx context.Context, o opts, req executePlanRequest, s
 		return runWithWorktree(ctx, o, req)
 	}
 
+	// require_worktree safety: when the operator opts into a worktree-first workflow,
+	// refuse to create a feature branch in the main checkout. fires only when a branch
+	// would otherwise be created (mode requires it AND we are on the default branch).
+	// runs before EnsureLocalGitignore so the .ralphex/.gitignore is not written into
+	// the main checkout as a side effect of an aborted run.
+	if req.Config.RequireWorktree && planFile != "" && modeRequiresBranch(req.Mode) {
+		if rwErr := enforceRequireWorktree(req); rwErr != nil {
+			return rwErr
+		}
+	}
+
 	if err := req.GitSvc.EnsureLocalGitignore(); err != nil {
 		return fmt.Errorf("ensure gitignore: %w", err)
 	}
@@ -380,6 +391,29 @@ func selectAndExecutePlan(ctx context.Context, o opts, req executePlanRequest, s
 	}
 
 	return executePlan(ctx, o, req)
+}
+
+// enforceRequireWorktree returns an error when the operator launched ralphex from
+// the main checkout's default branch without --worktree. The check fires only when
+// require_worktree is set (caller's responsibility). When the operator is already
+// on a feature branch (presumably inside a pre-existing worktree, or a branch in
+// the main checkout), the check is satisfied and returns nil.
+func enforceRequireWorktree(req executePlanRequest) error {
+	isDefault, err := req.GitSvc.IsDefaultBranch(req.DefaultBranch)
+	if err != nil {
+		return fmt.Errorf("require_worktree: check default branch: %w", err)
+	}
+	if !isDefault {
+		return nil
+	}
+	branch, _ := req.GitSvc.CurrentBranch() // best-effort, only used for the error message
+	return fmt.Errorf("require_worktree is enabled but ralphex was launched on the default branch %q without --worktree\n\n"+
+		"ralphex would create a feature branch in this checkout. require_worktree forbids that.\n\n"+
+		"options:\n"+
+		"  git worktree add ../<branch> -b <branch>   # create a worktree, then cd into it and rerun\n"+
+		"  ralphex --worktree <plan>                  # let ralphex create the worktree (see worktree_path config)\n"+
+		"  unset require_worktree in your config       # accept in-place branch creation",
+		branch)
 }
 
 // getCurrentBranch returns the current git branch name or "unknown" if unavailable.

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -913,6 +913,124 @@ func TestGetCurrentBranch(t *testing.T) {
 	})
 }
 
+func TestEnforceRequireWorktree(t *testing.T) {
+	t.Run("returns nil on a feature branch (typical worktree case)", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		runGit(t, dir, "checkout", "-b", "feat/some-work")
+
+		gitSvc, err := git.NewService(dir, testColors().Info())
+		require.NoError(t, err)
+
+		err = enforceRequireWorktree(executePlanRequest{
+			GitSvc:        gitSvc,
+			DefaultBranch: "master",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("errors on the default branch", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		gitSvc, err := git.NewService(dir, testColors().Info())
+		require.NoError(t, err)
+
+		err = enforceRequireWorktree(executePlanRequest{
+			GitSvc:        gitSvc,
+			DefaultBranch: "master",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require_worktree is enabled")
+		assert.Contains(t, err.Error(), "master")
+		// the message should also tell the operator what to do
+		assert.Contains(t, err.Error(), "git worktree add")
+		assert.Contains(t, err.Error(), "--worktree")
+	})
+
+	t.Run("treats empty default branch as main/master fallback", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		gitSvc, err := git.NewService(dir, testColors().Info())
+		require.NoError(t, err)
+
+		// no explicit default: IsDefaultBranch falls back to checking main/master
+		err = enforceRequireWorktree(executePlanRequest{
+			GitSvc:        gitSvc,
+			DefaultBranch: "",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require_worktree is enabled")
+	})
+}
+
+func TestSelectAndExecutePlan_RequireWorktree(t *testing.T) {
+	t.Run("blocks default-branch launch when require_worktree is set", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		gitSvc, err := git.NewService(dir, testColors().Info())
+		require.NoError(t, err)
+
+		// fzf-less plan selection: pass the plan file via PlanFile and let the selector resolve it
+		plansDir := filepath.Join(dir, "docs", "plans")
+		require.NoError(t, os.MkdirAll(plansDir, 0o750))
+		planFile := filepath.Join(plansDir, "feat-branch-name.md")
+		require.NoError(t, os.WriteFile(planFile, []byte("# Plan\n\n### Task 1: do thing\n- [ ] do it\n"), 0o600))
+
+		// cd into the repo so plan.Selector resolves the plan path correctly
+		origDir, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(dir))
+		t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+		cfg := &config.Config{RequireWorktree: true, RequireWorktreeSet: true}
+		req := executePlanRequest{
+			PlanFile:      planFile,
+			Mode:          processor.ModeFull,
+			GitSvc:        gitSvc,
+			Config:        cfg,
+			Colors:        testColors(),
+			DefaultBranch: "master",
+			BaseRef:       "master",
+		}
+		selector := plan.NewSelector("", testColors())
+		err = selectAndExecutePlan(context.Background(), opts{PlanFile: planFile}, req, selector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require_worktree is enabled")
+
+		// verify ralphex did NOT proceed: no .ralphex/.gitignore should have been written
+		// (the EnsureLocalGitignore call sits after the safety check)
+		_, statErr := os.Stat(filepath.Join(dir, ".ralphex", ".gitignore"))
+		assert.True(t, os.IsNotExist(statErr), "ralphex must abort before EnsureLocalGitignore writes")
+
+		// and no feature branch should have been created
+		assert.False(t, gitHasBranch(t, dir, "feat-branch-name"))
+	})
+
+	t.Run("permits feature-branch launch when require_worktree is set", func(t *testing.T) {
+		dir := setupTestRepo(t)
+		runGit(t, dir, "checkout", "-b", "feat/some-work")
+
+		gitSvc, err := git.NewService(dir, testColors().Info())
+		require.NoError(t, err)
+
+		cfg := &config.Config{RequireWorktree: true, RequireWorktreeSet: true}
+		req := executePlanRequest{
+			GitSvc:        gitSvc,
+			Config:        cfg,
+			DefaultBranch: "master",
+		}
+
+		// directly verify the guard returns nil for a feature branch; selectAndExecutePlan
+		// would proceed to execute the plan which requires claude on PATH (covered separately).
+		err = enforceRequireWorktree(req)
+		require.NoError(t, err)
+	})
+}
+
+// gitHasBranch returns true if the given branch exists in the repo.
+func gitHasBranch(t *testing.T, dir, name string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+name)
+	cmd.Dir = dir
+	return cmd.Run() == nil
+}
+
 func TestValidateFlags(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,13 @@ type Config struct {
 	WorktreeEnabled    bool `json:"worktree_enabled"`
 	WorktreeEnabledSet bool `json:"-"` // tracks if use_worktree was explicitly set in config
 
+	// RequireWorktree, when true, refuses to run from the main repo's working tree on
+	// the default branch without --worktree. Operators who want a worktree-first
+	// workflow set this to surface the missing worktree before any agent invocation
+	// rather than letting the engine create a feature branch in the main checkout.
+	RequireWorktree    bool `json:"require_worktree"`
+	RequireWorktreeSet bool `json:"-"` // tracks if require_worktree was explicitly set in config
+
 	PlansDir      string   `json:"plans_dir"`
 	WatchDirs     []string `json:"watch_dirs"`     // directories to watch for progress files
 	DefaultBranch string   `json:"default_branch"` // override auto-detected default branch
@@ -330,6 +337,8 @@ func loadConfigFromDirs(globalDir, localDir string) (*Config, error) {
 		MovePlanOnCompletion:    values.MovePlanOnCompletion,
 		WorktreeEnabled:         values.WorktreeEnabled,
 		WorktreeEnabledSet:      values.WorktreeEnabledSet,
+		RequireWorktree:         values.RequireWorktree,
+		RequireWorktreeSet:      values.RequireWorktreeSet,
 		PlansDir:                values.PlansDir,
 		DefaultBranch:           values.DefaultBranch,
 		VcsCommand:              values.VcsCommand,

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -150,6 +150,14 @@ move_plan_on_completion = true
 # default: false
 # use_worktree = false
 
+# require_worktree: refuse to run from the main checkout's default branch without
+# --worktree. for operators who manage worktrees externally and want the engine to
+# fail fast when launched from the wrong place, before any agent invocation.
+# leaves the in-place flow untouched on feature branches (the typical "launch from
+# a pre-existing worktree" case).
+# default: false
+# require_worktree = false
+
 # ------------------------------------------------------------------------------
 # timing
 # ------------------------------------------------------------------------------

--- a/pkg/config/values.go
+++ b/pkg/config/values.go
@@ -63,6 +63,8 @@ type Values struct {
 	MovePlanOnCompletionSet    bool // tracks if move_plan_on_completion was explicitly set
 	WorktreeEnabled            bool
 	WorktreeEnabledSet         bool   // tracks if use_worktree was explicitly set
+	RequireWorktree            bool   // when true, refuse to run from the main repo on the default branch without --worktree
+	RequireWorktreeSet         bool   // tracks if require_worktree was explicitly set
 	VcsCommand                 string // custom VCS command (default: "git")
 	CommitTrailer              string // trailer line to append to all commits (e.g., "Co-authored-by: ...")
 	PlansDir                   string
@@ -368,6 +370,14 @@ func (vl *valuesLoader) parseValuesFromBytes(data []byte) (Values, error) {
 		values.WorktreeEnabled = val
 		values.WorktreeEnabledSet = true
 	}
+	if key, err := section.GetKey("require_worktree"); err == nil {
+		val, boolErr := key.Bool()
+		if boolErr != nil {
+			return Values{}, fmt.Errorf("invalid require_worktree: %w", boolErr)
+		}
+		values.RequireWorktree = val
+		values.RequireWorktreeSet = true
+	}
 
 	// paths
 	if key, err := section.GetKey("plans_dir"); err == nil {
@@ -586,6 +596,10 @@ func (dst *Values) mergeExtraFrom(src *Values) {
 	if src.WorktreeEnabledSet {
 		dst.WorktreeEnabled = src.WorktreeEnabled
 		dst.WorktreeEnabledSet = true
+	}
+	if src.RequireWorktreeSet {
+		dst.RequireWorktree = src.RequireWorktree
+		dst.RequireWorktreeSet = true
 	}
 	if src.PlansDir != "" {
 		dst.PlansDir = src.PlansDir

--- a/pkg/config/values_test.go
+++ b/pkg/config/values_test.go
@@ -380,6 +380,91 @@ func TestValuesLoader_Load_WorktreeEnabled(t *testing.T) {
 	})
 }
 
+func TestValuesLoader_Load_RequireWorktree(t *testing.T) {
+	t.Run("parse require_worktree true", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`require_worktree = true`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load("", cfgPath)
+		require.NoError(t, err)
+		assert.True(t, values.RequireWorktree)
+		assert.True(t, values.RequireWorktreeSet)
+	})
+
+	t.Run("parse require_worktree false", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`require_worktree = false`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load("", cfgPath)
+		require.NoError(t, err)
+		assert.False(t, values.RequireWorktree)
+		assert.True(t, values.RequireWorktreeSet)
+	})
+
+	t.Run("not set leaves default false", func(t *testing.T) {
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load("", "")
+		require.NoError(t, err)
+		assert.False(t, values.RequireWorktree)
+		assert.False(t, values.RequireWorktreeSet)
+	})
+
+	t.Run("local overrides global", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		globalCfg := filepath.Join(tmpDir, "global")
+		localCfg := filepath.Join(tmpDir, "local")
+		require.NoError(t, os.WriteFile(globalCfg, []byte(`require_worktree = false`), 0o600))
+		require.NoError(t, os.WriteFile(localCfg, []byte(`require_worktree = true`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		values, err := loader.Load(localCfg, globalCfg)
+		require.NoError(t, err)
+		assert.True(t, values.RequireWorktree)
+		assert.True(t, values.RequireWorktreeSet)
+	})
+
+	t.Run("invalid value returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`require_worktree = notabool`), 0o600))
+
+		loader := newValuesLoader(defaultsFS)
+		_, err := loader.Load("", cfgPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid require_worktree")
+	})
+}
+
+func TestValues_mergeFrom_RequireWorktree(t *testing.T) {
+	t.Run("set flag merges", func(t *testing.T) {
+		dst := Values{RequireWorktree: false, RequireWorktreeSet: false}
+		src := Values{RequireWorktree: true, RequireWorktreeSet: true}
+		dst.mergeFrom(&src)
+		assert.True(t, dst.RequireWorktree)
+		assert.True(t, dst.RequireWorktreeSet)
+	})
+
+	t.Run("unset flag does not merge", func(t *testing.T) {
+		dst := Values{RequireWorktree: true, RequireWorktreeSet: true}
+		src := Values{RequireWorktree: false, RequireWorktreeSet: false}
+		dst.mergeFrom(&src)
+		assert.True(t, dst.RequireWorktree)
+		assert.True(t, dst.RequireWorktreeSet)
+	})
+
+	t.Run("set flag can disable", func(t *testing.T) {
+		dst := Values{RequireWorktree: true, RequireWorktreeSet: true}
+		src := Values{RequireWorktree: false, RequireWorktreeSet: true}
+		dst.mergeFrom(&src)
+		assert.False(t, dst.RequireWorktree)
+		assert.True(t, dst.RequireWorktreeSet)
+	})
+}
+
 func TestValues_mergeFrom_WorktreeEnabled(t *testing.T) {
 	t.Run("set flag merges", func(t *testing.T) {
 		dst := Values{WorktreeEnabled: false, WorktreeEnabledSet: false}


### PR DESCRIPTION
## Motivation

Operators who manage worktrees externally (e.g. via a separate worktree
command that creates `../task-X` on a feature branch) currently get no
warning if they launch ralphex from the wrong place. The engine happily
creates a feature branch in the main checkout and starts committing there.

If the operator's review/ship workflow depends on the work landing in a
specific external worktree, the wrong-place launch corrupts both the main
checkout state and the operator's mental model of where the work lives.

## Behavior

This PR adds a `require_worktree` config option (default `false`). When
enabled, ralphex refuses to run from the main checkout's default branch
without `--worktree` and surfaces the missing worktree as a clear error
before any agent is invoked.

The error message points the operator at the two ways to satisfy the
requirement (create an external worktree and rerun, or pass `--worktree`
to let ralphex create one) and at the `worktree_path` config option as a
related knob (when the operator wants ralphex to create the worktree but
not at the default location).

## Non-breaking

- Default is `false`; existing behavior is preserved when the option is
  unset.
- On feature branches (the typical "launch from a pre-existing worktree"
  case) the check is satisfied and ralphex proceeds normally.
- The check fires before `EnsureLocalGitignore`, so an aborted run does not
  leave `.ralphex/.gitignore` in the main checkout as a side effect.

## Tests

- `cmd/ralphex/main_test.go` — `TestEnforceRequireWorktree` covers the
  branch-position logic (feature branch passes, default branch fails,
  empty-default fallback fails on `main`/`master`).
- `cmd/ralphex/main_test.go` — `TestSelectAndExecutePlan_RequireWorktree`
  verifies the abort happens before any state is written
  (`.ralphex/.gitignore` does not appear, no feature branch is created).
- `pkg/config/values_test.go` — `TestValuesLoader_Load_RequireWorktree`
  and `TestValues_mergeFrom_RequireWorktree` cover parsing, the
  `*Set` tracker, local-overrides-global precedence, and invalid-value
  rejection.

`go test ./pkg/config/... ./cmd/ralphex/...` passes the new tests;
pre-existing failures unrelated to this PR (`TestAutoPlanModeDetection`
subtests that require `codex` on `PATH`) are present on `master` as well.

`golangci-lint run ./...` reports 0 issues.

## Open to discussion

Naming, error-message wording, and the placement of the check
(`selectAndExecutePlan` vs earlier in `run`) are all up for review. The
current shape keeps the check close to the decision point (right before
the in-place `CreateBranchForPlan` call) so the guard's intent reads
clearly from the code path.

The check is intentionally limited to "default branch without `--worktree`"
because vanilla ralphex on a feature branch is a no-op for branch creation
— there's nothing for `require_worktree` to gate. Happy to expand the
guard to other cases if there's a real failure mode I missed.