### PR TITLE
docs(plans): standardize date format on YYYYMMDD- in prompts and skill

### DIFF
--- a/assets/claude/skills/ralphex-plan/SKILL.md
+++ b/assets/claude/skills/ralphex-plan/SKILL.md
@@ -4,7 +4,7 @@ description: Create structured implementation plan in docs/plans/
 
 # Implementation Plan Creation
 
-Create an implementation plan in `docs/plans/YYYY-MM-DD-<task-name>.md` with interactive context gathering.
+Create an implementation plan in `docs/plans/YYYYMMDD-<task-name>.md` with interactive context gathering.
 
 ## Prerequisites: Verify CLI Installation
 
@@ -124,7 +124,7 @@ Use AskUserQuestion tool to let user select preferred approach before creating t
 
 ## Step 2: Create Plan File
 
-Check `docs/plans/` for existing files, then create `docs/plans/YYYY-MM-DD-<task-name>.md`:
+Check `docs/plans/` for existing files, then create `docs/plans/YYYYMMDD-<task-name>.md`:
 
 ### Plan Structure
 
@@ -255,7 +255,7 @@ Example (NOTICE: tests are separate checklist items):
 
 After creating the file, tell user:
 
-"Created plan: `docs/plans/YYYY-MM-DD-<task-name>.md`
+"Created plan: `docs/plans/YYYYMMDD-<task-name>.md`
 
 Ready to start implementation?"
 

--- a/pkg/config/defaults/prompts/make_plan.txt
+++ b/pkg/config/defaults/prompts/make_plan.txt
@@ -104,7 +104,7 @@ This step executes ONLY after the user accepts your draft (progress file contain
 
 Write the accepted plan to disk:
 
-1. Create a plan file at {{PLANS_DIR}}/YYYY-MM-DD-<slug>.md where <slug> is derived from the description
+1. Create a plan file at {{PLANS_DIR}}/YYYYMMDD-<slug>.md where <slug> is derived from the description
 2. Use this structure:
 
 ---


### PR DESCRIPTION
fixes the date-format inconsistency reported in #370.

switches `make_plan.txt` and `ralphex-plan/SKILL.md` from `YYYY-MM-DD-<slug>.md` to `YYYYMMDD-<slug>.md`, matching what `ralphex-adopt` and `llms.txt` already specify. Plan-rename tolerance in `pkg/plan/altdate.go` keeps existing files in either format working.

Related to #370
