### PR TITLE
fix(opencode): pass model and effort flags

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -230,6 +230,9 @@ claude_command = /path/to/scripts/opencode/opencode-as-claude.sh
 | Variable | Default | Description |
 |---|---|---|
 | `OPENCODE_MODEL` | (opencode default) | Model in provider/model format, e.g. `github-copilot/claude-opus-4.6` |
+| `OPENCODE_VARIANT` | (opencode default) | Model variant/reasoning effort, e.g. `high`, `medium`, or `low` |
+| `OPENCODE_EFFORT` | (opencode default) | Alias for `OPENCODE_VARIANT` when `OPENCODE_VARIANT` is unset |
+| `OPENCODE_REASONING` | (opencode default) | Alias for `OPENCODE_VARIANT` when both `OPENCODE_VARIANT` and `OPENCODE_EFFORT` are unset |
 | `OPENCODE_VERBOSE` | `0` | Set to `1` to include step start events in output |
 | `OPENCODE_CONFIG_CONTENT` | `{"permission":{"*":"allow"}}` | JSON config merged with auto-allow permissions via `jq` deep merge |
 

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -18,7 +18,12 @@ claude_args =
 **Environment variables:**
 
 - `OPENCODE_MODEL` — model in provider/model format, e.g. `openai/gpt-4o` (default: opencode default)
+- `OPENCODE_VARIANT` — model variant/reasoning effort, e.g. `high`, `medium`, `low` (default: opencode default)
+- `OPENCODE_EFFORT` — alias for `OPENCODE_VARIANT` when `OPENCODE_VARIANT` is unset
+- `OPENCODE_REASONING` — alias for `OPENCODE_VARIANT` when `OPENCODE_VARIANT` and `OPENCODE_EFFORT` are unset
 - `OPENCODE_VERBOSE` — set to `1` to include tool execution events in output (default: `0`)
+
+The wrapper also honors Claude-compatible `--model` and `--effort` flags. Ralphex `--task-model=model:effort`, `--review-model=model:effort`, and `--plan-model=model:effort` are translated to OpenCode as `--model model --variant effort`.
 
 ### opencode-review.sh
 
@@ -34,7 +39,9 @@ custom_review_script = /path/to/scripts/opencode/opencode-review.sh
 **Environment variables:**
 
 - `OPENCODE_REVIEW_MODEL` — model for review, e.g. `github-copilot/gpt-5.3-codex`
-- `OPENCODE_REVIEW_REASONING` — reasoning effort level, e.g. `high`
+- `OPENCODE_REVIEW_VARIANT` — review model variant/reasoning effort, e.g. `high`
+- `OPENCODE_REVIEW_EFFORT` — alias for `OPENCODE_REVIEW_VARIANT` when unset
+- `OPENCODE_REVIEW_REASONING` — backward-compatible alias for `OPENCODE_REVIEW_VARIANT` when unset
 
 ## Testing
 

--- a/scripts/opencode/opencode-as-claude.sh
+++ b/scripts/opencode/opencode-as-claude.sh
@@ -11,6 +11,9 @@
 #
 # environment variables:
 #   OPENCODE_MODEL       - model in provider/model format, e.g. openai/gpt-4o (default: opencode default)
+#   OPENCODE_VARIANT     - model variant/reasoning effort, e.g. high, medium, low (default: opencode default)
+#   OPENCODE_EFFORT      - alias for OPENCODE_VARIANT when OPENCODE_VARIANT is unset
+#   OPENCODE_REASONING   - alias for OPENCODE_VARIANT when OPENCODE_VARIANT and OPENCODE_EFFORT are unset
 #   OPENCODE_VERBOSE     - set to 1 to include tool execution events in output (default: 0)
 
 set -euo pipefail
@@ -21,13 +24,25 @@ command -v jq >/dev/null 2>&1 || { echo "error: jq is required but not found" >&
 # verify opencode is available
 command -v opencode >/dev/null 2>&1 || { echo "error: opencode is required but not found" >&2; exit 1; }
 
+# configurable via environment. CLI flags below override these defaults.
+OPENCODE_MODEL="${OPENCODE_MODEL:-}"
+OPENCODE_VARIANT="${OPENCODE_VARIANT:-${OPENCODE_EFFORT:-${OPENCODE_REASONING:-}}}"
+OPENCODE_VERBOSE="${OPENCODE_VERBOSE:-0}"
+
 # ralphex passes prompt via stdin (primary path, avoids Windows 8191-char cmd limit).
 # also accept -p flag for backward compatibility with direct invocations.
+# support ralphex-injected --model/--effort and map effort to opencode's --variant.
 # all other flags are ignored gracefully (--dangerously-skip-permissions, etc.)
 prompt=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -p) prompt="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --model) OPENCODE_MODEL="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --model=*) OPENCODE_MODEL="${1#--model=}"; shift ;;
+        --effort) OPENCODE_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --effort=*) OPENCODE_VARIANT="${1#--effort=}"; shift ;;
+        --variant) OPENCODE_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --variant=*) OPENCODE_VARIANT="${1#--variant=}"; shift ;;
         *)  shift ;; # ignore unknown flags
     esac
 done
@@ -44,10 +59,6 @@ if [[ -z "$prompt" ]]; then
     echo "error: no prompt provided (expected -p flag or stdin)" >&2
     exit 1
 fi
-
-# configurable via environment
-OPENCODE_MODEL="${OPENCODE_MODEL:-}"
-OPENCODE_VERBOSE="${OPENCODE_VERBOSE:-0}"
 
 # enable auto-allow permissions for autonomous execution (equivalent to claude's
 # --dangerously-skip-permissions). uses OPENCODE_CONFIG_CONTENT which deep-merges
@@ -84,6 +95,7 @@ fi
 # build opencode arguments
 opencode_args=(run --format json)
 [[ -n "$OPENCODE_MODEL" ]] && opencode_args+=(--model "$OPENCODE_MODEL")
+[[ -n "$OPENCODE_VARIANT" ]] && opencode_args+=(--variant "$OPENCODE_VARIANT")
 opencode_args+=("$prompt")
 
 # temporary files for stderr capture and stdout piping.

--- a/scripts/opencode/opencode-as-claude.sh
+++ b/scripts/opencode/opencode-as-claude.sh
@@ -29,6 +29,18 @@ OPENCODE_MODEL="${OPENCODE_MODEL:-}"
 OPENCODE_VARIANT="${OPENCODE_VARIANT:-${OPENCODE_EFFORT:-${OPENCODE_REASONING:-}}}"
 OPENCODE_VERBOSE="${OPENCODE_VERBOSE:-0}"
 
+require_flag_value() {
+    local flag="$1"
+    local value="${2:-}"
+
+    if [[ -z "$value" || "$value" == -* ]]; then
+        echo "error: $flag requires a non-empty value" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$value"
+}
+
 # ralphex passes prompt via stdin (primary path, avoids Windows 8191-char cmd limit).
 # also accept -p flag for backward compatibility with direct invocations.
 # support ralphex-injected --model/--effort and map effort to opencode's --variant.
@@ -37,12 +49,12 @@ prompt=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -p) prompt="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --model) OPENCODE_MODEL="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --model=*) OPENCODE_MODEL="${1#--model=}"; shift ;;
-        --effort) OPENCODE_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --effort=*) OPENCODE_VARIANT="${1#--effort=}"; shift ;;
-        --variant) OPENCODE_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --variant=*) OPENCODE_VARIANT="${1#--variant=}"; shift ;;
+        --model) OPENCODE_MODEL=$(require_flag_value "$1" "${2:-}"); shift 2 ;;
+        --model=*) OPENCODE_MODEL=$(require_flag_value "--model" "${1#--model=}"); shift ;;
+        --effort) OPENCODE_VARIANT=$(require_flag_value "$1" "${2:-}"); shift 2 ;;
+        --effort=*) OPENCODE_VARIANT=$(require_flag_value "--effort" "${1#--effort=}"); shift ;;
+        --variant) OPENCODE_VARIANT=$(require_flag_value "$1" "${2:-}"); shift 2 ;;
+        --variant=*) OPENCODE_VARIANT=$(require_flag_value "--variant" "${1#--variant=}"); shift ;;
         *)  shift ;; # ignore unknown flags
     esac
 done

--- a/scripts/opencode/opencode-as-claude_test.sh
+++ b/scripts/opencode/opencode-as-claude_test.sh
@@ -542,6 +542,27 @@ if [[ -f "$TMPDIR_TEST/opencode_args" ]]; then
     fi
 fi
 
+# verify missing CLI flag values are rejected instead of consuming the next flag
+output=$(MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
+    PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
+    bash "$WRAPPER" --model --effort high -p "test prompt" 2>&1) && status=0 || status=$?
+
+if [[ $status -ne 0 ]] && echo "$output" | grep -q -- "--model requires a non-empty value"; then
+    pass "missing --model value is rejected"
+else
+    fail "missing --model value should fail" "status: $status output: $output"
+fi
+
+output=$(MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
+    PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
+    bash "$WRAPPER" --effort= -p "test prompt" 2>&1) && status=0 || status=$?
+
+if [[ $status -ne 0 ]] && echo "$output" | grep -q -- "--effort requires a non-empty value"; then
+    pass "empty --effort value is rejected"
+else
+    fail "empty --effort value should fail" "status: $status output: $output"
+fi
+
 # verify --model is NOT passed when OPENCODE_MODEL is empty
 rm -f "$TMPDIR_TEST/opencode_args"
 # restore the standard mock

--- a/scripts/opencode/opencode-as-claude_test.sh
+++ b/scripts/opencode/opencode-as-claude_test.sh
@@ -454,9 +454,9 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# test: OPENCODE_MODEL env var (R5)
+# test: OPENCODE_MODEL and OPENCODE_VARIANT env vars (R5)
 # ---------------------------------------------------------------------------
-echo "test: OPENCODE_MODEL"
+echo "test: OPENCODE_MODEL and OPENCODE_VARIANT"
 
 # create a mock opencode that records its arguments
 cat > "$TMPDIR_TEST/opencode" << 'MODEL_MOCK_EOF'
@@ -471,6 +471,7 @@ chmod +x "$TMPDIR_TEST/opencode"
 
 MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
     OPENCODE_MODEL="openai/gpt-4o" \
+    OPENCODE_VARIANT="high" \
     PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
     bash "$WRAPPER" -p "test prompt" >/dev/null 2>&1
 
@@ -481,8 +482,64 @@ if [[ -f "$TMPDIR_TEST/opencode_args" ]]; then
     else
         fail "OPENCODE_MODEL not passed correctly" "args: $recorded_args"
     fi
+    if echo "$recorded_args" | grep -q -- "--variant high"; then
+        pass "OPENCODE_VARIANT passed as --variant flag"
+    else
+        fail "OPENCODE_VARIANT not passed correctly" "args: $recorded_args"
+    fi
 else
     fail "could not capture opencode arguments"
+fi
+
+# verify OPENCODE_EFFORT alias works when OPENCODE_VARIANT is unset
+rm -f "$TMPDIR_TEST/opencode_args"
+MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
+    OPENCODE_MODEL="" \
+    OPENCODE_EFFORT="medium" \
+    PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
+    bash "$WRAPPER" -p "test prompt" >/dev/null 2>&1
+
+if [[ -f "$TMPDIR_TEST/opencode_args" ]]; then
+    recorded_args=$(cat "$TMPDIR_TEST/opencode_args")
+    if echo "$recorded_args" | grep -q -- "--variant medium"; then
+        pass "OPENCODE_EFFORT passed as --variant flag"
+    else
+        fail "OPENCODE_EFFORT not passed correctly" "args: $recorded_args"
+    fi
+fi
+
+# verify OPENCODE_REASONING alias works when OPENCODE_VARIANT and OPENCODE_EFFORT are unset
+rm -f "$TMPDIR_TEST/opencode_args"
+MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
+    OPENCODE_MODEL="" \
+    OPENCODE_REASONING="low" \
+    PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
+    bash "$WRAPPER" -p "test prompt" >/dev/null 2>&1
+
+if [[ -f "$TMPDIR_TEST/opencode_args" ]]; then
+    recorded_args=$(cat "$TMPDIR_TEST/opencode_args")
+    if echo "$recorded_args" | grep -q -- "--variant low"; then
+        pass "OPENCODE_REASONING passed as --variant flag"
+    else
+        fail "OPENCODE_REASONING not passed correctly" "args: $recorded_args"
+    fi
+fi
+
+# verify CLI --model/--effort override env vars
+rm -f "$TMPDIR_TEST/opencode_args"
+MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
+    OPENCODE_MODEL="env-model" \
+    OPENCODE_VARIANT="env-variant" \
+    PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
+    bash "$WRAPPER" --model cli-model --effort low -p "test prompt" >/dev/null 2>&1
+
+if [[ -f "$TMPDIR_TEST/opencode_args" ]]; then
+    recorded_args=$(cat "$TMPDIR_TEST/opencode_args")
+    if echo "$recorded_args" | grep -q -- "--model cli-model" && echo "$recorded_args" | grep -q -- "--variant low"; then
+        pass "CLI --model/--effort override env defaults"
+    else
+        fail "CLI --model/--effort not passed correctly" "args: $recorded_args"
+    fi
 fi
 
 # verify --model is NOT passed when OPENCODE_MODEL is empty
@@ -502,6 +559,7 @@ chmod +x "$TMPDIR_TEST/opencode"
 
 MOCK_STDOUT_FILE="$TMPDIR_TEST/minimal_events.jsonl" \
     OPENCODE_MODEL="" \
+    OPENCODE_VARIANT="" \
     PATH="$TMPDIR_TEST:$PATH" TMPDIR_TEST="$TMPDIR_TEST" \
     bash "$WRAPPER" -p "test prompt" >/dev/null 2>&1
 
@@ -511,6 +569,11 @@ if [[ -f "$TMPDIR_TEST/opencode_args" ]]; then
         fail "--model passed when OPENCODE_MODEL is empty" "args: $recorded_args"
     else
         pass "--model omitted when OPENCODE_MODEL is empty"
+    fi
+    if echo "$recorded_args" | grep -q -- "--variant"; then
+        fail "--variant passed when OPENCODE_VARIANT is empty" "args: $recorded_args"
+    else
+        pass "--variant omitted when OPENCODE_VARIANT is empty"
     fi
 fi
 

--- a/scripts/opencode/opencode-review.sh
+++ b/scripts/opencode/opencode-review.sh
@@ -16,6 +16,18 @@ OPENCODE_REVIEW_VARIANT="${OPENCODE_REVIEW_VARIANT:-${OPENCODE_REVIEW_EFFORT:-${
 
 set -euo pipefail
 
+require_flag_value() {
+    local flag="$1"
+    local value="${2:-}"
+
+    if [[ -z "$value" || "$value" == -* ]]; then
+        echo "error: $flag requires a non-empty value" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$value"
+}
+
 # verify opencode is available
 command -v opencode >/dev/null 2>&1 || { echo "error: opencode is required but not found" >&2; exit 1; }
 
@@ -27,12 +39,12 @@ command -v jq >/dev/null 2>&1 || { echo "error: jq is required but not found" >&
 prompt_file=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --model) OPENCODE_REVIEW_MODEL="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --model=*) OPENCODE_REVIEW_MODEL="${1#--model=}"; shift ;;
-        --effort) OPENCODE_REVIEW_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --effort=*) OPENCODE_REVIEW_VARIANT="${1#--effort=}"; shift ;;
-        --variant) OPENCODE_REVIEW_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
-        --variant=*) OPENCODE_REVIEW_VARIANT="${1#--variant=}"; shift ;;
+        --model) OPENCODE_REVIEW_MODEL=$(require_flag_value "$1" "${2:-}"); shift 2 ;;
+        --model=*) OPENCODE_REVIEW_MODEL=$(require_flag_value "--model" "${1#--model=}"); shift ;;
+        --effort) OPENCODE_REVIEW_VARIANT=$(require_flag_value "$1" "${2:-}"); shift 2 ;;
+        --effort=*) OPENCODE_REVIEW_VARIANT=$(require_flag_value "--effort" "${1#--effort=}"); shift ;;
+        --variant) OPENCODE_REVIEW_VARIANT=$(require_flag_value "$1" "${2:-}"); shift 2 ;;
+        --variant=*) OPENCODE_REVIEW_VARIANT=$(require_flag_value "--variant" "${1#--variant=}"); shift ;;
         *) prompt_file="$1"; shift ;;
     esac
 done

--- a/scripts/opencode/opencode-review.sh
+++ b/scripts/opencode/opencode-review.sh
@@ -11,8 +11,8 @@
 # environment variables:
 # e.g. OPENCODE_REVIEW_MODEL="github-copilot/gpt-5.3-codex"
 OPENCODE_REVIEW_MODEL="${OPENCODE_REVIEW_MODEL:-}"
-# e.g. OPENCODE_REVIEW_REASONING="high"
-OPENCODE_REVIEW_REASONING="${OPENCODE_REVIEW_REASONING:-}"
+# e.g. OPENCODE_REVIEW_VARIANT="high" or OPENCODE_REVIEW_REASONING="high"
+OPENCODE_REVIEW_VARIANT="${OPENCODE_REVIEW_VARIANT:-${OPENCODE_REVIEW_EFFORT:-${OPENCODE_REVIEW_REASONING:-}}}"
 
 set -euo pipefail
 
@@ -22,8 +22,20 @@ command -v opencode >/dev/null 2>&1 || { echo "error: opencode is required but n
 # verify jq is available (required for JSON config merging)
 command -v jq >/dev/null 2>&1 || { echo "error: jq is required but not found" >&2; exit 1; }
 
-# prompt file path is passed as the single argument
-prompt_file="${1:-}"
+# prompt file path is passed as the single argument. Optional --model/--effort
+# flags override env defaults for direct invocations and future ralphex plumbing.
+prompt_file=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model) OPENCODE_REVIEW_MODEL="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --model=*) OPENCODE_REVIEW_MODEL="${1#--model=}"; shift ;;
+        --effort) OPENCODE_REVIEW_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --effort=*) OPENCODE_REVIEW_VARIANT="${1#--effort=}"; shift ;;
+        --variant) OPENCODE_REVIEW_VARIANT="${2:-}"; shift; shift 2>/dev/null || true ;;
+        --variant=*) OPENCODE_REVIEW_VARIANT="${1#--variant=}"; shift ;;
+        *) prompt_file="$1"; shift ;;
+    esac
+done
 if [[ -z "$prompt_file" || ! -f "$prompt_file" ]]; then
     echo "error: prompt file not provided or not found" >&2
     exit 1
@@ -31,20 +43,9 @@ fi
 
 prompt=$(cat "$prompt_file")
 
-# build coder agent overrides from env vars
-coder_config="{}"
-if [[ -n "$OPENCODE_REVIEW_MODEL" ]]; then
-    coder_config=$(echo "$coder_config" | jq -c --arg m "$OPENCODE_REVIEW_MODEL" '. + {model: $m}')
-fi
-if [[ -n "$OPENCODE_REVIEW_REASONING" ]]; then
-    coder_config=$(echo "$coder_config" | jq -c --arg r "$OPENCODE_REVIEW_REASONING" '. + {reasoningEffort: $r}')
-fi
-
-# build final config with permissions and optional coder overrides
+# build final config with permissions. Model and reasoning are passed through
+# opencode's CLI flags because --variant is the supported one-shot effort selector.
 base_config='{"permission":{"*":"allow"}}'
-if [[ "$coder_config" != "{}" ]]; then
-    base_config=$(echo "$base_config" | jq -c --argjson coder "$coder_config" '. + {agent: {coder: $coder}}')
-fi
 
 # merge with existing OPENCODE_CONFIG_CONTENT if set
 if [[ -n "${OPENCODE_CONFIG_CONTENT:-}" ]]; then
@@ -57,6 +58,9 @@ export OPENCODE_CONFIG_CONTENT
 cmd=(opencode run)
 if [[ -n "$OPENCODE_REVIEW_MODEL" ]]; then
     cmd+=(--model "$OPENCODE_REVIEW_MODEL")
+fi
+if [[ -n "$OPENCODE_REVIEW_VARIANT" ]]; then
+    cmd+=(--variant "$OPENCODE_REVIEW_VARIANT")
 fi
 cmd+=("$prompt")
 "${cmd[@]}"

--- a/scripts/opencode/opencode-review_test.sh
+++ b/scripts/opencode/opencode-review_test.sh
@@ -196,6 +196,24 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# test: missing CLI flag values are rejected
+# ---------------------------------------------------------------------------
+echo "test: missing CLI flag values are rejected"
+output=$(run_script --model --effort high "$prompt_file" 2>&1) && status=0 || status=$?
+if [[ $status -ne 0 ]] && echo "$output" | grep -q -- "--model requires a non-empty value"; then
+    pass "missing --model value is rejected"
+else
+    fail "missing --model value should fail" "status: $status output: $output"
+fi
+
+output=$(run_script --variant= "$prompt_file" 2>&1) && status=0 || status=$?
+if [[ $status -ne 0 ]] && echo "$output" | grep -q -- "--variant requires a non-empty value"; then
+    pass "empty --variant value is rejected"
+else
+    fail "empty --variant value should fail" "status: $status output: $output"
+fi
+
+# ---------------------------------------------------------------------------
 # test: merge with existing OPENCODE_CONFIG_CONTENT
 # ---------------------------------------------------------------------------
 echo "test: merge with existing OPENCODE_CONFIG_CONTENT"

--- a/scripts/opencode/opencode-review_test.sh
+++ b/scripts/opencode/opencode-review_test.sh
@@ -111,16 +111,16 @@ output=$(OPENCODE_REVIEW_MODEL="test-model" OPENCODE_REVIEW_REASONING="" run_scr
 config=$(echo "$output" | grep "^CONFIG:" | sed 's/^CONFIG://')
 args=$(echo "$output" | grep "^ARGS:" | sed 's/^ARGS://')
 
-if echo "$config" | jq -e '.agent.coder.model == "test-model"' >/dev/null 2>&1; then
-    pass "config has model"
+if echo "$config" | jq -e '.agent' >/dev/null 2>&1; then
+    fail "config should not have agent block" "got: $config"
 else
-    fail "config missing model" "got: $config"
+    pass "config has no agent block"
 fi
 
-if echo "$config" | jq -e '.agent.coder.reasoningEffort' >/dev/null 2>&1; then
-    fail "config should not have reasoningEffort" "got: $config"
+if echo "$args" | grep -q "\-\-variant"; then
+    fail "should not pass --variant flag" "got: $args"
 else
-    pass "config has no reasoningEffort"
+    pass "no --variant flag"
 fi
 
 if echo "$args" | grep -q "\-\-model test-model"; then
@@ -137,22 +137,22 @@ output=$(OPENCODE_REVIEW_MODEL="" OPENCODE_REVIEW_REASONING="high" run_script "$
 config=$(echo "$output" | grep "^CONFIG:" | sed 's/^CONFIG://')
 args=$(echo "$output" | grep "^ARGS:" | sed 's/^ARGS://')
 
-if echo "$config" | jq -e '.agent.coder.reasoningEffort == "high"' >/dev/null 2>&1; then
-    pass "config has reasoningEffort"
+if echo "$config" | jq -e '.agent' >/dev/null 2>&1; then
+    fail "config should not have agent block" "got: $config"
 else
-    fail "config missing reasoningEffort" "got: $config"
-fi
-
-if echo "$config" | jq -e '.agent.coder.model' >/dev/null 2>&1; then
-    fail "config should not have model" "got: $config"
-else
-    pass "config has no model"
+    pass "config has no agent block"
 fi
 
 if echo "$args" | grep -q "\-\-model"; then
     fail "should not pass --model flag" "got: $args"
 else
     pass "no --model flag"
+fi
+
+if echo "$args" | grep -q "\-\-variant high"; then
+    pass "--variant flag passed"
+else
+    fail "expected --variant high in args" "got: $args"
 fi
 
 # ---------------------------------------------------------------------------
@@ -163,22 +163,36 @@ output=$(OPENCODE_REVIEW_MODEL="my-model" OPENCODE_REVIEW_REASONING="medium" run
 config=$(echo "$output" | grep "^CONFIG:" | sed 's/^CONFIG://')
 args=$(echo "$output" | grep "^ARGS:" | sed 's/^ARGS://')
 
-if echo "$config" | jq -e '.agent.coder.model == "my-model"' >/dev/null 2>&1; then
-    pass "config has model"
+if echo "$config" | jq -e '.agent' >/dev/null 2>&1; then
+    fail "config should not have agent block" "got: $config"
 else
-    fail "config missing model" "got: $config"
-fi
-
-if echo "$config" | jq -e '.agent.coder.reasoningEffort == "medium"' >/dev/null 2>&1; then
-    pass "config has reasoningEffort"
-else
-    fail "config missing reasoningEffort" "got: $config"
+    pass "config has no agent block"
 fi
 
 if echo "$args" | grep -q "\-\-model my-model"; then
     pass "--model flag passed"
 else
     fail "expected --model my-model in args" "got: $args"
+fi
+
+if echo "$args" | grep -q "\-\-variant medium"; then
+    pass "--variant flag passed"
+else
+    fail "expected --variant medium in args" "got: $args"
+fi
+
+# ---------------------------------------------------------------------------
+# test: CLI --model/--effort override env vars
+# ---------------------------------------------------------------------------
+echo "test: CLI --model/--effort override env vars"
+output=$(OPENCODE_REVIEW_MODEL="env-model" OPENCODE_REVIEW_VARIANT="env-variant" \
+    run_script --model cli-model --effort high "$prompt_file")
+args=$(echo "$output" | grep "^ARGS:" | sed 's/^ARGS://')
+
+if echo "$args" | grep -q "\-\-model cli-model" && echo "$args" | grep -q "\-\-variant high"; then
+    pass "CLI --model/--effort override env defaults"
+else
+    fail "CLI --model/--effort not passed correctly" "got: $args"
 fi
 
 # ---------------------------------------------------------------------------
@@ -189,6 +203,7 @@ output=$(OPENCODE_CONFIG_CONTENT='{"theme":"dark","custom":true}' \
     OPENCODE_REVIEW_MODEL="merge-model" OPENCODE_REVIEW_REASONING="" \
     run_script "$prompt_file")
 config=$(echo "$output" | grep "^CONFIG:" | sed 's/^CONFIG://')
+args=$(echo "$output" | grep "^ARGS:" | sed 's/^ARGS://')
 
 if echo "$config" | jq -e '.theme == "dark"' >/dev/null 2>&1; then
     pass "preserves existing theme field"
@@ -208,10 +223,10 @@ else
     fail "missing permissions after merge" "got: $config"
 fi
 
-if echo "$config" | jq -e '.agent.coder.model == "merge-model"' >/dev/null 2>&1; then
-    pass "merged model"
+if echo "$args" | grep -q "\-\-model merge-model"; then
+    pass "merged model passed as CLI flag"
 else
-    fail "missing model after merge" "got: $config"
+    fail "missing model CLI flag after merge" "got: $args"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Parse Claude-compatible `--model` and `--effort` flags in `opencode-as-claude.sh`
- Map ralphex effort/reasoning values to OpenCode's supported `--variant` flag
- Add env var support for OpenCode variants/reasoning:
  - `OPENCODE_VARIANT`
  - `OPENCODE_EFFORT`
  - `OPENCODE_REASONING`
  - `OPENCODE_REVIEW_VARIANT`
  - `OPENCODE_REVIEW_EFFORT`
- Update `opencode-review.sh` to use `opencode run --model ... --variant ...` instead of the ineffective `agent.coder.reasoningEffort` config path
- Add/update wrapper tests and documentation
## Verification
- `bash scripts/opencode/opencode-as-claude_test.sh`
- `bash scripts/opencode/opencode-review_test.sh`
- `bash -n scripts/opencode/opencode-as-claude.sh && bash -n scripts/opencode/opencode-review.sh`
- Manual wrapper runs verified OpenCode persisted `variant=high` in its session DB