### PR TITLE
refactor: cut code smells and duplication across packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ GOOS=windows GOARCH=amd64 go build ./...
 - Precedence: CLI flags > local config > global config > embedded defaults
 - Custom prompts: `~/.config/ralphex/prompts/*.txt` or `.ralphex/prompts/*.txt`
 - Custom agents: `~/.config/ralphex/agents/*.txt` or `.ralphex/agents/*.txt`
-- `plan_model` / `task_model` / `review_model` config options: `model[:effort]` for plan creation / task / review phases; `plan_model` and `review_model` fall back to `task_model`. CLI flags `--plan-model`/`--task-model`/`--review-model` take precedence. Parsed by `ParseModelEffort` (pkg/processor/executor_factory.go). See the Key Patterns bullet for claude- vs codex-executor behavior. Disabled by default (empty = Claude CLI defaults)
+- `plan_model` / `task_model` / `review_model` config options: `model[:effort]` for plan creation / task / review phases; `plan_model` and `review_model` fall back to `task_model`. CLI flags `--plan-model`/`--task-model`/`--review-model` take precedence. Parsed by executor setup (pkg/processor/executor_factory.go). See the Key Patterns bullet for claude- vs codex-executor behavior. Disabled by default (empty = Claude CLI defaults)
 - `default_branch` config option: override auto-detected default branch for review diffs
 - `max_iterations` config option: override CLI default (50) for maximum task iterations per plan (CLI flag `--max-iterations` takes precedence)
 - `vcs_command` config option: override the VCS binary used by the git backend (default: `"git"`). Set to a translation script path (e.g., `scripts/hg2git/hg2git.sh`) to use ralphex with Mercurial repos. See `docs/hg-support.md`
@@ -236,7 +236,7 @@ GOOS=windows GOARCH=amd64 go build ./...
 - Notification config: `notify_channels`, `notify_on_error`, `notify_on_complete`, `notify_timeout_ms`, plus channel-specific `notify_*` fields (see `docs/notifications.md`)
 - `review_patience` config option: terminate external review after N consecutive unchanged rounds (0 = disabled). CLI flag `--review-patience` takes precedence
 - `wait_on_limit` config option: duration to wait before retrying on rate limit (e.g., "1h", "30m"). CLI flag `--wait` takes precedence. Disabled by default
-- `session_timeout` config option: per-session timeout (e.g., "30m"). Applies to claude in default mode and to every executor call under `--codex` (task/review/finalize/eval); external codex/custom review in Claude mode is not affected. Kills hanging sessions, continues to next iteration. Applied in `executionPolicy.runWithSessionTimeout` via `context.WithTimeout`, gated on `Executor==ExecutorCodex || toolName=="claude"`. CLI flag `--session-timeout` takes precedence. Disabled by default
+- `session_timeout` config option: per-session timeout (e.g., "30m"). Applies to claude in default mode and to every executor call under `--codex` (task/review/finalize/eval); external codex/custom review in Claude mode is not affected. Kills hanging sessions, continues to next iteration. Applied in `retryPolicy.runWithSessionTimeout` via `context.WithTimeout`, gated on `Executor==ExecutorCodex || toolName=="claude"`. CLI flag `--session-timeout` takes precedence. Disabled by default
 - `idle_timeout` config option: kills claude/codex executor sessions when no output for a given duration (e.g., "5m"). Resets on each output line; only fires when the session goes silent. Implemented in `ClaudeExecutor.Run()`/`CodexExecutor.Run()` via `time.AfterFunc`. Wired by `buildCodexExecutor` for first-class `--codex`; NOT by `buildExternalCodexExecutor`, so external codex review in default-claude mode has no idle timeout. Custom external review unaffected. CLI flag `--idle-timeout` takes precedence. Disabled by default
 - `move_plan_on_completion` config option: controls whether completed plans move to `docs/plans/completed/` on success. Default `true`. Disable for workflows that manage plan lifecycle externally (spec-driven tooling with separate archive steps)
 - `preserve_anthropic_api_key` config option / `--preserve-anthropic-api-key` CLI flag: when true, `ANTHROPIC_API_KEY` is passed through to the child claude process (needed for API-key auth rather than OAuth/keychain). Default `false` strips the key. The merge sentinel `PreserveAnthropicAPIKeySet` lives only on `Values` (load-bearing for local-overrides-global merge); `Config` carries the resolved bool. Plumbed: `Config.PreserveAnthropicAPIKey` → `pkg/processor/executor_factory.go` → `ClaudeExecutor.PreserveAPIKey` → `execClaudeRunner.preserveAPIKey` → `claudeChildEnv()` (`pkg/executor/executor.go`). When enabled, the startup banner emits `auth: ANTHROPIC_API_KEY passthrough enabled`. `CLAUDECODE` is always stripped regardless (prevents nested-session errors)
@@ -293,7 +293,7 @@ Implementation:
 - `LimitPatternError` type in `pkg/executor/executor.go` with `Pattern` and `HelpCmd` fields
 - `matchPattern()` helper for case-insensitive matching (used by both error and limit pattern checks)
 - Patterns passed via `ClaudeExecutor.ErrorPatterns`/`LimitPatterns` and `CodexExecutor.ErrorPatterns`/`LimitPatterns`
-- `executionPolicy.Run()` in `pkg/processor/execution_policy.go` wraps executor calls with retry logic
+- `retryPolicy.Run()` in `pkg/processor/execution_policy.go` wraps executor calls with retry logic
 
 ### Agent System
 

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -953,18 +953,6 @@ func createRunner(req executePlanRequest, o opts, log processor.Logger, holder *
 		reviewPatience = o.ReviewPatience
 	}
 
-	// resolve task model: CLI flag > config file > empty (use CLI default)
-	taskModel := req.Config.TaskModel
-	if o.TaskModel != "" {
-		taskModel = o.TaskModel
-	}
-
-	// resolve review model: CLI flag > config file > empty (falls back to task_model in processor)
-	reviewModel := req.Config.ReviewModel
-	if o.ReviewModel != "" {
-		reviewModel = o.ReviewModel
-	}
-
 	r := processor.New(processor.Config{
 		PlanFile:              req.PlanFile,
 		ProgressPath:          log.Path(),
@@ -980,8 +968,8 @@ func createRunner(req executePlanRequest, o opts, log processor.Logger, holder *
 		ExternalReviewToolSet: o.externalReviewToolSet,
 		FinalizeEnabled:       req.Config.FinalizeEnabled,
 		DefaultBranch:         req.BaseRef,
-		TaskModel:             taskModel,
-		ReviewModel:           reviewModel,
+		TaskModel:             resolveSpec(o.TaskModel, req.Config.TaskModel),
+		ReviewModel:           resolveReviewSpec(o, req.Config),
 		AppConfig:             req.Config,
 	}, log, holder)
 	if req.GitSvc != nil {
@@ -1068,6 +1056,36 @@ type codexBannerInfo struct {
 	maxDropped                bool // a claude-only "max" effort was requested and dropped
 }
 
+func resolveSpec(cliVal, cfgVal string) string {
+	if cliVal != "" {
+		return cliVal
+	}
+	return cfgVal
+}
+
+func resolvePlanSpec(o opts, cfg *config.Config) string {
+	if planSpec := resolveSpec(o.PlanModel, cfg.PlanModel); planSpec != "" {
+		return planSpec
+	}
+	return resolveSpec(o.TaskModel, cfg.TaskModel)
+}
+
+func resolveReviewSpec(o opts, cfg *config.Config) string {
+	if reviewSpec := resolveSpec(o.ReviewModel, cfg.ReviewModel); reviewSpec != "" {
+		return reviewSpec
+	}
+	return resolveSpec(o.TaskModel, cfg.TaskModel)
+}
+
+func codexBannerForSpec(spec string, cfg *config.Config) codexBannerInfo {
+	model, effort, maxDropped := processor.ResolveCodexModelEffort(spec, cfg.CodexModel, cfg.CodexReasoningEffort)
+	return codexBannerInfo{
+		taskModel: model, taskEffort: effort,
+		reviewModel: model, reviewEffort: effort,
+		maxDropped: maxDropped,
+	}
+}
+
 // codexModelBanner resolves the codex task and review model/effort for the startup
 // banner from the task/review model specs (--task-model / --review-model CLI flag >
 // task_model / review_model config) against codex_model / codex_reasoning_effort. it
@@ -1075,24 +1093,13 @@ type codexBannerInfo struct {
 // codex executors will actually receive. review fields equal the task fields unless a
 // distinct review spec is given.
 func codexModelBanner(o opts, cfg *config.Config) codexBannerInfo {
-	taskSpec := cfg.TaskModel
-	if o.TaskModel != "" {
-		taskSpec = o.TaskModel
-	}
-	reviewSpec := cfg.ReviewModel
-	if o.ReviewModel != "" {
-		reviewSpec = o.ReviewModel
-	}
-	taskModel, taskEffort, taskMax := processor.ResolveCodexModelEffort(taskSpec, cfg.CodexModel, cfg.CodexReasoningEffort)
-	info := codexBannerInfo{
-		taskModel: taskModel, taskEffort: taskEffort,
-		reviewModel: taskModel, reviewEffort: taskEffort,
-		maxDropped: taskMax,
-	}
+	taskSpec := resolveSpec(o.TaskModel, cfg.TaskModel)
+	info := codexBannerForSpec(taskSpec, cfg)
+	reviewSpec := resolveSpec(o.ReviewModel, cfg.ReviewModel)
 	if reviewSpec != "" {
-		reviewModel, reviewEffort, reviewMax := processor.ResolveCodexModelEffort(reviewSpec, cfg.CodexModel, cfg.CodexReasoningEffort)
-		info.reviewModel, info.reviewEffort = reviewModel, reviewEffort
-		info.maxDropped = info.maxDropped || reviewMax
+		reviewInfo := codexBannerForSpec(reviewSpec, cfg)
+		info.reviewModel, info.reviewEffort = reviewInfo.taskModel, reviewInfo.taskEffort
+		info.maxDropped = info.maxDropped || reviewInfo.maxDropped
 	}
 	return info
 }
@@ -1100,23 +1107,7 @@ func codexModelBanner(o opts, cfg *config.Config) codexBannerInfo {
 // codexPlanBanner resolves the codex model/effort for plan creation. plan_model
 // falls back to task_model, then to codex_model/codex_reasoning_effort defaults.
 func codexPlanBanner(o opts, cfg *config.Config) codexBannerInfo {
-	taskSpec := cfg.TaskModel
-	if o.TaskModel != "" {
-		taskSpec = o.TaskModel
-	}
-	planSpec := cfg.PlanModel
-	if o.PlanModel != "" {
-		planSpec = o.PlanModel
-	}
-	if planSpec == "" {
-		planSpec = taskSpec
-	}
-	planModel, planEffort, maxDropped := processor.ResolveCodexModelEffort(planSpec, cfg.CodexModel, cfg.CodexReasoningEffort)
-	return codexBannerInfo{
-		taskModel: planModel, taskEffort: planEffort,
-		reviewModel: planModel, reviewEffort: planEffort,
-		maxDropped: maxDropped,
-	}
+	return codexBannerForSpec(resolvePlanSpec(o, cfg), cfg)
 }
 
 // runPlanMode executes interactive plan creation mode.
@@ -1192,18 +1183,6 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 	// record start time for finding the created plan
 	startTime := time.Now()
 
-	// create and configure runner
-	taskModel := req.Config.TaskModel
-	if o.TaskModel != "" {
-		taskModel = o.TaskModel
-	}
-	if req.Config.PlanModel != "" {
-		taskModel = req.Config.PlanModel
-	}
-	if o.PlanModel != "" {
-		taskModel = o.PlanModel
-	}
-
 	r := processor.New(processor.Config{
 		PlanDescription:  o.PlanDescription,
 		ProgressPath:     baseLog.Path(),
@@ -1213,7 +1192,7 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 		NoColor:          o.NoColor,
 		IterationDelayMs: req.Config.IterationDelayMs,
 		DefaultBranch:    req.BaseRef,
-		TaskModel:        taskModel,
+		TaskModel:        resolvePlanSpec(o, req.Config),
 		AppConfig:        req.Config,
 	}, baseLog, holder)
 	r.SetInputCollector(collector)

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -1165,6 +1165,31 @@ func TestCodexFlag_ApplyCLIOverrides(t *testing.T) {
 	})
 }
 
+func TestResolveModelSpecs(t *testing.T) {
+	t.Run("resolve_spec_prefers_cli", func(t *testing.T) {
+		assert.Equal(t, "cli-model:high", resolveSpec("cli-model:high", "cfg-model:low"))
+		assert.Equal(t, "cfg-model:low", resolveSpec("", "cfg-model:low"))
+	})
+
+	t.Run("plan_spec_precedence", func(t *testing.T) {
+		cfg := &config.Config{PlanModel: "cfg-plan:medium", TaskModel: "cfg-task:low"}
+
+		assert.Equal(t, "cli-plan:high", resolvePlanSpec(opts{PlanModel: "cli-plan:high", TaskModel: "cli-task:xhigh"}, cfg))
+		assert.Equal(t, "cfg-plan:medium", resolvePlanSpec(opts{TaskModel: "cli-task:xhigh"}, cfg))
+		assert.Equal(t, "cli-task:xhigh", resolvePlanSpec(opts{TaskModel: "cli-task:xhigh"}, &config.Config{TaskModel: "cfg-task:low"}))
+		assert.Equal(t, "cfg-task:low", resolvePlanSpec(opts{}, &config.Config{TaskModel: "cfg-task:low"}))
+	})
+
+	t.Run("review_spec_precedence", func(t *testing.T) {
+		cfg := &config.Config{ReviewModel: "cfg-review:medium", TaskModel: "cfg-task:low"}
+
+		assert.Equal(t, "cli-review:high", resolveReviewSpec(opts{ReviewModel: "cli-review:high", TaskModel: "cli-task:xhigh"}, cfg))
+		assert.Equal(t, "cfg-review:medium", resolveReviewSpec(opts{TaskModel: "cli-task:xhigh"}, cfg))
+		assert.Equal(t, "cli-task:xhigh", resolveReviewSpec(opts{TaskModel: "cli-task:xhigh"}, &config.Config{TaskModel: "cfg-task:low"}))
+		assert.Equal(t, "cfg-task:low", resolveReviewSpec(opts{}, &config.Config{TaskModel: "cfg-task:low"}))
+	})
+}
+
 func TestCodexModelBanner(t *testing.T) {
 	t.Run("task_model_sets_task_and_review", func(t *testing.T) {
 		cfg := &config.Config{CodexModel: "gpt-5.5", CodexReasoningEffort: "xhigh"}

--- a/docs/plans/completed/20260529-refactor-smells-and-duplication.md
+++ b/docs/plans/completed/20260529-refactor-smells-and-duplication.md
@@ -1,0 +1,224 @@
+# Behavior-Preserving Refactor: Code Smells and Duplication
+
+## Overview
+- Address the code smells and architectural duplication surfaced by the refactor-analysis workflow (12 agents, 10 package units + cross-cutting architecture pass).
+- The codebase is structurally healthy: no god objects remain, interfaces are consumer-side, error wrapping is consistent. The leverage is in **one config-structure problem** plus **recurring behavior-preserving duplication** of small domain logic that drifts silently across parallel copies.
+- **Every change in this plan must preserve behavior exactly.** No functional changes, no new features, no altered runtime behavior. INI keys, error strings, signal vocabulary, merge precedence, and concurrency contracts all stay identical.
+
+## Context (from discovery)
+- Source of findings: refactor-analysis workflow report (run `wugyu0vk8`). 44 package findings, 1 high-severity, 0 cross-cutting (all duplication is package-local or cmd-local).
+- Files/components involved (by package):
+  - `pkg/config`: `config.go`, `values.go` (four-way field mirror; three identical duration parsers; drifted godoc).
+  - `pkg/processor/phase`: `task.go`, `review.go`, `finalize.go`, `plan_creation.go`, `external_review.go`, `phase.go` (`executorName()` duplicated on 4 types — confirmed via grep). Executor-error wrap shapes are **not** uniform: 4 sites use the simple pattern-handling→`"%s execution: %w"` shape (`task.go:95`, `review.go:75`, `review.go:128`, `plan_creation.go:110`); `external_review.go`'s `handleExecutorError` adds a manual-break check and a per-call `tool` arg; `finalize.go` is **best-effort** (returns `nil` via `//nolint:nilerr`, never wraps). Only the 4 simple sites share a shape — `handleExecutorError` and `finalize.go` must stay distinct.
+  - `pkg/progress`: `progress.go` (timestamped write block in ~8 methods; mode→suffix switch duplicated).
+  - `pkg/web`: `tail.go`, `session_progress.go`, `server.go`, `broadcast_logger.go` (tailer/loader Event construction; dead `SetTailer`; deprecated `Event.JSON` shim; duplicated plan encode-and-write).
+  - `cmd/ralphex`: `main.go` (model[:effort] resolution in 4 sites; two near-identical codex banner funcs).
+  - `pkg/processor`: `executor_factory.go`, `execution_policy.go` (`ParseModelEffort` exported with no out-of-package caller; `executionPolicy`/`executor_factory` naming collision).
+  - `pkg/plan`: `parse.go`, `plan.go` (`FileHasUncompletedCheckbox` re-implements `Checkbox.IsActionable`; misleading "excluding completed/" comments).
+- Related patterns found: the codebase already uses embedded sub-structs (`NotifyParams`, `Colors`), but config grouping is constrained by Go keyed composite literal compatibility. `external_review.go` already has a `handleExecutorError` helper — the phase refactor generalizes it.
+- Dependencies identified: tasks are mostly independent per package; `pkg/config` is the highest-leverage and should land first. No cross-package API changes are required by any task.
+
+## Development Approach
+- **testing approach**: Rely on existing tests as the behavior-preservation safety net (these are refactors, not new behavior). For each task: run the affected package's existing tests and keep them green. Add tests **only** where a newly extracted helper/method has no existing coverage of its own. Do not rewrite passing tests to match new internal structure unless a signature genuinely changed.
+- complete each task fully before moving to the next.
+- make small, focused changes; one package per task.
+- **CRITICAL: all tests must pass before starting the next task** — no exceptions.
+- **CRITICAL: `make lint` must be clean before starting the next task.**
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- run `make test` and `make lint` after each task.
+- maintain backward compatibility (config files, CLI flags, error wording, signals all unchanged).
+
+## Code-Quality Rules (HARD — verify against every task before marking complete)
+
+These rules supplement project CLAUDE.md and are NOT optional. They are the gate for marking any task complete. If a rule is violated, the task is not done — refactor, re-test, then mark complete.
+
+**Signatures (hard limits):**
+- No function or method has 4+ parameters. `ctx context.Context` does not count toward the budget. If you need 4+, use an option struct (e.g., `type fooOpts struct { ... }`).
+- No function or method has 4+ return values. Split the function into two single-purpose ones, or return a struct.
+- Multiple adjacent same-type parameters (`oldLine, newLine int`) are a swap hazard — review whether they belong on a struct.
+
+**Methods vs standalone helpers (project rule, hard):**
+- If a function is called only from methods of a single struct, it MUST be a method on that struct. Calling pattern decides, not field access.
+- Standalone helpers are reserved for: (a) constructors and entry points (`Parse...`, `New...`, `Decorate...`), (b) utilities shared by multiple unrelated types or by both standalone functions AND methods, (c) tiny cross-cutting helpers.
+- Before adding any standalone helper, mentally walk its callers. If every caller is a method of one type, make the helper a method on that type.
+
+**Visibility (private by default, hard):**
+- Lowercase identifiers by default. Only export when an out-of-package caller exists.
+- Exception (per CLAUDE.md): methods called by other structs in the same package CAN be exported for inter-component API clarity. This is the only exception. It does not extend to types, functions, constants, or variables.
+- Before exporting any new identifier, grep for cross-package callers. If none, lowercase it.
+
+**Comments (default: none, hard):**
+- Default to writing no comments. Add one only when the WHY is non-obvious (a hidden invariant, a workaround, behavior that would surprise a reader).
+- Exported items get godoc comments starting with the name. Unexported items get lowercase non-godoc comments — or no comment at all.
+- Never describe WHAT the code does when the code itself is self-evident. Never write multi-paragraph comments on routine helpers.
+
+**Per-task gate (before marking ANY checkbox complete):**
+1. Formatter runs clean (`~/.claude/format.sh` or `gofmt -s -w` + `goimports -w`).
+2. `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` reports zero issues.
+3. `go test ./... -race` passes.
+4. Scan the new code for the four rule classes above. Specifically:
+   - Grep new function signatures: `grep -nE '^func.*\(.*,.*,.*,.*\)' app/<path>/*.go` — any hit with 4+ comma-separated params (excluding `ctx`) is a violation. Same for the return-value side.
+   - For every new standalone helper, `grep -rn 'helperName(' --include='*.go'` and confirm at least one caller is NOT a method of a single type. If all callers are methods of one type, convert.
+   - For every new exported identifier, grep cross-package. If no out-of-package hit, lowercase it.
+5. Only after 1–4 pass: mark the task complete.
+
+If a previous task shipped a violation (spotted later by user, reviewer, or yourself): fix it in the next commit BEFORE starting the next task. Do not let violations accumulate.
+
+**Project-specific note:** this is a refactor — every extracted helper inherits the receiver of the methods it replaces. The three config duration parsers are methods on `valuesLoader`, so the shared parser is a method on `valuesLoader`. The phase `executorName()` and `wrapExecutorError` decisions depend only on `Config`/`Policy`, so they belong on those types (the plan already specifies `(c Config) executorName()`). Do not introduce standalone helpers where a method fits the calling pattern.
+
+## Testing Strategy
+- **unit tests**: existing package tests are the primary guard. New tests required only for net-new exported-within-package helpers that lack equivalent coverage.
+- **behavior-preservation checks** per task:
+  - `pkg/config`: round-trip a representative config (all INI keys set) through load+merge and assert the resulting `Config` is field-for-field identical to pre-refactor (existing config tests already cover this — keep them green).
+  - `pkg/processor/phase`: error-wrapping tests must still observe the exact `"%s execution: %w"` strings and the same `HandlePatternMatchError` invocation order.
+  - `pkg/progress`: concurrency tests (race detector) must pass — the single-lock-around-the-write-sequence contract is preserved.
+  - `pkg/web`: tailer/loader tests must produce identical `Event` streams from the same progress-file input.
+- **e2e tests**: `e2e/` (Playwright, `-tags=e2e`) covers the web dashboard. The `pkg/web` task (tailer/loader Event construction, dead-code removal) must keep e2e green — run `go test -tags=e2e -timeout=10m -count=1 ./e2e/...` after that task. Other tasks do not touch UI behavior and do not require an e2e run.
+- run with the race detector for the `pkg/progress` and `pkg/web` tasks: `go test -race ./pkg/progress/... ./pkg/web/...`.
+
+## Progress Tracking
+- mark completed items with `[x]` immediately when done.
+- add newly discovered tasks with ➕ prefix.
+- document issues/blockers with ⚠️ prefix.
+- update plan if implementation deviates from original scope.
+
+## Solution Overview
+- Preserve the flat public `Values` and `Config` field shape while reducing safe internal duplication; Go keyed composite literals make embedded config grouping a public API change.
+- Replace each cluster of byte-identical duplicated logic with a single private helper/method, leaving only the genuinely-differing bits at each call site.
+- Remove dead code and unexport identifiers with no out-of-package callers.
+- All extractions are mechanical and local; no package boundaries or public APIs change.
+
+## Technical Details
+- Sub-struct grouping mirrors the existing `NotifyParams`/`Colors` precedent; `loadConfigFromDirs` assigns whole groups, merge operates per group. `*Set` sentinel semantics and precedence (CLI > local > global > embedded) are preserved exactly.
+- Helper extractions keep identical inputs/outputs: error strings, lock scope, timestamp format, signal output constants, and JSON encoding are unchanged.
+- Line numbers in the discovery report are approximate guidance; the implementer locates the current code by symbol name (the output-rendering layer was flaky during planning, so re-confirm exact ranges at edit time).
+
+## What Goes Where
+- **Implementation Steps** (`[ ]` checkboxes): all refactors and quick wins live in this repo.
+- **Post-Completion** (no checkboxes): none — this is a self-contained internal refactor with no external-system impact.
+
+## Implementation Steps
+
+### Task 1: Reduce config duplication while preserving public field shape
+
+**Files:**
+- Modify: `pkg/config/config.go`
+- Modify: `pkg/config/values.go`
+- Modify: `pkg/config/config_test.go` (only if a struct-shape change requires test field-path updates)
+
+- [x] ⚠️ premise correction: `Values` and `Config` are **not** a clean four-way mirror — `Values` carries merge-sentinel `*Set` fields (e.g. `CodexModelSet`, `ExecutorSet`, `PassClaudeMdSet`, `MovePlanOnCompletionSet`, the `Notify*Set` group) that `Config` does not; `Config` carries `json:"..."` tags that `Values` does not. The grouping must **preserve this asymmetry**, not unify it. Only group fields that genuinely exist on both with the same meaning; do not add `*Set` fields to `Config` or drop them from `Values`
+- [x] identify cohesive option clusters and define embedded sub-structs (candidates: claude, codex, execution/timeouts, error/limit patterns, worktree/plan/paths; notify already grouped) shared by `Values` and `Config` only where field sets match, following the existing `NotifyParams`/`Colors` precedent
+  - ⚠️ second-review correction: even the four pattern fields must remain flat exported fields on `Values` and `Config`. Although no in-repo out-of-package composite literal used them, external Go callers can legally write `config.Config{ClaudeErrorPatterns: ...}` and `config.Values{ClaudeErrorPatterns: ...}`. Embedding would break that source-compatible public API shape.
+- [x] preserve every INI key name, every `*Set` sentinel field, and **every `json:` tag** exactly; keep pattern fields flat to avoid a public API change
+- [x] update `parseValuesFromBytes` to populate the grouped fields (no key renames) — promoted assignments unchanged
+- [x] update `loadConfigFromDirs` where safe; pattern fields remain per-field assignments to preserve the flat public struct shape
+- [x] update the `mergeFrom` family to merge per group, preserving precedence and `*Set`-gated overrides exactly — pattern merges keep promoted-name access (`len(src.X) > 0`), byte-identical precedence
+- [x] delete the drifted hand-listed `*Set` enumeration from the `Config` godoc; keep the one-sentence explanation (inline field comments remain source of truth)
+- [x] extract one shared duration parser **as a method on `valuesLoader`** (e.g. `(vl *valuesLoader) parseDurationKey(section *ini.Section, key string) (time.Duration, bool, error)`) to replace the three byte-identical `parseWaitOnLimit`/`parseSessionTimeout`/`parseIdleTimeout` methods; preserve each error string exactly (`invalid <key>: ...`) and the non-negative check; signature stays under the 4-param limit (`ctx` not in play here)
+- [x] run existing config tests (load + merge round-trip) — must stay green and assert resulting `Config` is field-for-field identical to before
+- [x] **add a JSON round-trip assertion**: marshal a fully-populated `Config` to JSON before and after the refactor and assert byte-identical output (the Go field-equality test does NOT catch `json:` tag drift, which is a real dashboard/API behavior surface consumed by `pkg/web`) — `TestConfig_JSONShape` asserts the exact 37-key set, flattened pattern keys, and absence of `json:"-"` fields
+- [x] add a test asserting a field added to a shared sub-struct is visible in both `Values` and `Config` (guards against future drift) only if not already implied by existing round-trip coverage — not applicable after preserving flat public pattern fields for Go API compatibility
+- [x] run `make test` and `make lint` — must pass before Task 2
+
+### Task 2: De-duplicate executor-error wrap and executorName in the phase package
+
+**Files:**
+- Modify: `pkg/processor/phase/phase.go`
+- Modify: `pkg/processor/phase/task.go`
+- Modify: `pkg/processor/phase/review.go`
+- Modify: `pkg/processor/phase/finalize.go`
+- Modify: `pkg/processor/phase/plan_creation.go`
+- Modify: `pkg/processor/phase/external_review.go`
+
+- [x] add `func (c Config) executorName() string` next to `isCodexExecutor()` in `phase.go`; remove the four byte-identical per-type `executorName()` methods (task/review/finalize/plan_creation) and route callers through `p.cfg.executorName()`
+- [x] add a **new, simpler** `wrapExecutorError(policy Policy, err error, execName string) error` (3 params, 1 return) covering ONLY the 4 simple sites: returns `nil` for nil err, else runs `HandlePatternMatchError` returning `"%s pattern handling: %w"` on match, else wraps with `"%s execution: %w"`. **This is a new helper, NOT a generalization of `handleExecutorError`** — do not fold in the manual-break check or the `tool` arg
+- [x] replace the verbatim error-wrap sequence in `task.go`, `review.go` (both sites), and `plan_creation.go` with calls to `wrapExecutorError`; keep error strings and `HandlePatternMatchError` ordering byte-identical. Note `plan_creation.go` returns `planIterationOutcome{}, err` — the caller keeps its own zero-value first return; the helper returns only the `error`
+- [x] **do NOT touch `finalize.go`'s error handling** — it is best-effort (`return nil`); only its `executorName()` method is removed (first checkbox). **Do NOT route `external_review.go`'s `handleExecutorError` through the new helper** — its manual-break path is external-review-only; leave it as-is (optionally have it call `wrapExecutorError` *after* its break check, only if byte-identical output is preserved)
+- [x] add a one-line comment at the `external_review.go` post-handled-error fall-through (currently unreachable, reads as a latent bug) clarifying it is intentional; add a one-line comment to the empty `continue`-case switch documenting the sleep path
+- [x] run existing phase tests — error-wrapping assertions must still observe the exact strings and call order
+- [x] add a focused test for `wrapExecutorError` (nil err → nil; non-nil → pattern-match invoked + correct wrap) only if existing tests do not already cover it directly — added `TestWrapExecutorError` to `review_test.go` (existing pattern/nil tests assert only substrings, not the wrap-string contract)
+- [x] run `make test` and `make lint` — must pass before Task 3
+
+### Task 3: De-duplicate the timestamped write block in pkg/progress
+
+**Files:**
+- Modify: `pkg/progress/progress.go`
+- Modify: `pkg/progress/progress_test.go` (only if a new private helper warrants direct coverage)
+
+- [x] add **two private methods on `*Logger`** (callers are all `*Logger` methods, so per the methods-vs-standalone rule these must be methods, not standalone helpers): one producing the timestamp + colored `[%s]` prefix, one performing the mutex-held file+stdout write pair given a format/args and colored payload
+- [x] collapse the ~8 single-line write methods to one helper call each; have multi-line methods reuse the timestamp helper
+- [x] **preserve the single-lock-around-the-whole-sequence contract exactly** — do not narrow or widen the `writeMu` scope
+- [x] resolve the mode→suffix switch duplicated between `filenameWithStem` and `progressFilename`; ⚠️ confirm whether `filenameWithStem` missing the `plan` case is intentional before unifying — **"leave both as-is" is a valid completion** if unifying would force the `plan` case onto `filenameWithStem` and change behavior. Do not silently "fix" the asymmetry
+- [x] run `go test -race ./pkg/progress/...` — concurrency tests must pass, output framing unchanged
+- [x] run `make test` and `make lint` — must pass before Task 4
+
+### Task 4: Share tailer/loader Event construction and remove dead code in pkg/web
+
+**Files:**
+- Modify: `pkg/web/tail.go`
+- Modify: `pkg/web/session_progress.go`
+- Modify: `pkg/web/server.go`
+- Modify: `pkg/web/broadcast_logger.go`
+- Modify: corresponding `_test.go` files only where signatures change
+
+- [x] extract `buildPendingSectionEvents(name, phase, ts) []Event` consumed by both the loader (`session_progress.go`) and live tailer (`tail.go`)
+- [x] extract `eventFromParsed(parsed, phase) Event` for the timestamp/plain cases, called from both `parseLine` and `parseLineDeferred`; leave only the section-deferral difference in `parseLineDeferred`
+- [x] remove dead `Session.SetTailer` (confirmed: only callers are `session_test.go`) — drop the method and its two test usages
+- [x] remove the deprecated `Event.JSON` shim (confirmed: production code uses `json.Marshal`/`plan.Plan.JSON`; the only `Event.JSON` callers are `event_test.go`) — delete the method and switch those test assertions to `json.Marshal(event)`; keep test-only `GetTailer`/`getLastPhase` only if other tests still need them
+- [x] extract `writePlanJSON` **as a method on `*Server`** (both callers `handlePlan`/`handleSessionPlan` are `*Server` methods) to collapse the identical encode-and-write tail; share the signal-normalization output constants between `broadcast_logger.go` and `tail.go`
+- [x] run existing web tests — tailer/loader must produce identical `Event` streams from the same input; run `go test -race ./pkg/web/...`
+- [x] run web e2e: `go test -tags=e2e -timeout=10m -count=1 ./e2e/...` — must stay green
+- [x] run `make test` and `make lint` — must pass before Task 5
+
+### Task 5: Consolidate model/effort resolution and codex banners in cmd/ralphex
+
+**Files:**
+- Modify: `cmd/ralphex/main.go`
+- Modify: `cmd/ralphex/main_test.go` (only if a new helper warrants direct coverage)
+
+- [x] add `resolveSpec(cliVal, cfgVal string) string` plus `resolvePlanSpec`/`resolveReviewSpec` (applying the task-spec fallback) and route `createRunner`, `runPlanMode`, `codexModelBanner`, and `codexPlanBanner` through them so banner and runner derive specs from identical code
+- [x] extract one helper that resolves a single spec into `codexBannerInfo`; have `codexModelBanner` add the review override and `codexPlanBanner` pass the plan-with-task-fallback spec (collapse the two near-identical banner functions)
+- [x] run existing cmd tests — resolved specs and banner output must be identical to before
+- [x] add a focused test for `resolveSpec`/`resolvePlanSpec`/`resolveReviewSpec` fallback precedence only if not already covered
+- [x] run `make test` and `make lint` — must pass before Task 6
+
+### Task 6: Naming and visibility cleanups in pkg/processor and pkg/plan
+
+**Files:**
+- Modify: `pkg/processor/executor_factory.go`
+- Modify: `pkg/processor/execution_policy.go` (and rename references)
+- Modify: `pkg/plan/parse.go`
+- Modify: `pkg/plan/plan.go`
+- Modify: corresponding `_test.go` files where identifiers are referenced
+
+- [x] confirm via grep `ParseModelEffort` has no out-of-package caller, then unexport it to `parseModelEffort` (keep `ResolveCodexModelEffort` exported); update in-package and test references
+- [x] rename `executionPolicy` → `retryPolicy` (the concrete type, its constructor/opts, and in-package references only). **Do NOT rename the `Run`/`HandlePatternMatchError`/`Sleep` methods** — they satisfy the consumer-side `phase.Policy` interface; renaming them would break that contract. Update the two CLAUDE.md references and the `runner_test.go` comments. (Lowest-value item in the plan — if the rename churn is not worth it, skipping it is acceptable; flag for Eugene's call)
+- [x] reuse `Checkbox.IsActionable` / `Task.HasUncompletedActionableWork` inside `FileHasUncompletedCheckbox` instead of re-implementing the actionable rule
+- [x] reword the misleading "excluding completed/" comments in `pkg/plan/plan.go` to describe the non-recursive glob mechanism
+- [x] run existing processor and plan tests — must stay green (behavior unchanged)
+- [x] add a test case asserting `FileHasUncompletedCheckbox` agrees with `Checkbox.IsActionable` on edge cases only if not already covered
+- [x] run `make test` and `make lint` — must pass before Task 7
+
+### Task 7: Verify acceptance criteria
+- [x] verify all seven refactors and the quick wins from the Overview are implemented
+- [x] confirm no INI key, CLI flag, error string, or signal constant changed (grep/diff review)
+- [x] run full test suite: `make test`
+- [x] run with race detector across touched packages: `go test -race ./pkg/config/... ./pkg/processor/... ./pkg/progress/... ./pkg/web/...`
+- [x] run web e2e: `go test -tags=e2e -timeout=10m -count=1 ./e2e/...`
+- [x] run `make lint` — zero issues
+- [x] cross-compile Windows to verify no build-tag regressions: `GOOS=windows GOARCH=amd64 go build ./...`
+- [x] verify coverage did not regress below project standard
+
+### Task 8: [Final] Update documentation
+- [x] update `CLAUDE.md` only if a refactor changed a pattern documented there (e.g. config sub-struct grouping, `executionPolicy`→`retryPolicy` rename references in the Key Patterns section) — no new edit needed; the `retryPolicy` references were already updated and the config grouping is internal
+- [x] confirm `llms.txt` needs no change (no user-facing behavior changed)
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+*None — this is a self-contained internal refactor. No external systems, consuming projects, deployment configs, or third-party integrations are affected. No CLI/config/behavior surface changes, so no user-facing migration or verification is required.*
+
+---
+
+Smells pre-check: 2 items fixed before save — (1) the shared duration parser was pinned to a method on `valuesLoader`; (2) `writePlanJSON` was pinned to a `*Server` method. All proposed signatures verified under the hard limits (≤3 params excluding ctx, ≤1–3 returns): `(c Config) executorName() string`, `wrapExecutorError(policy, err, execName) error` (standalone justified — shared across unrelated phase types), `buildPendingSectionEvents`/`eventFromParsed` (shared across loader and tailer), `resolveSpec`/`resolvePlanSpec`/`resolveReviewSpec` (main-package free functions). No new exported identifiers; `ParseModelEffort` is being unexported.
+
+Plan-review pass (plan-review agent, verified against code): 3 behavior-preservation fixes applied — (1) Task 2 `wrapExecutorError` clarified as a NEW helper for the 4 simple sites only; `external_review.go`'s `handleExecutorError` (manual-break path) and `finalize.go` (best-effort `nil`) explicitly excluded — the earlier "5 sites" framing was misleading; (2) Task 1 gained a JSON byte-identity assertion (Go field-equality misses `json:` tag drift) and a premise correction noting `Values`/`Config` `*Set` fields are asymmetric, not a clean mirror; (3) Task 3's two progress helpers pinned to `*Logger` methods, and "leave both filename funcs as-is" allowed when unifying would change behavior. Task 6 rename scoped to the concrete type only (interface method names untouched) and flagged as optional/lowest-value. Verdict: ready after these revisions.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,22 +38,11 @@ const (
 )
 
 // Config holds all configuration settings for ralphex.
-// Fields ending in *Set track whether that field was explicitly set in config.
+// Fields ending in *Set mostly track whether that field was explicitly set in config.
 // This allows distinguishing explicit false/0 from "not set", enabling proper
 // merge behavior where local config can override global config with zero values.
-//
-// *Set fields:
-//   - ClaudeArgsSet: tracks if claude_args was explicitly overridden at runtime
-//   - CodexEnabledSet: tracks if codex_enabled was explicitly set
-//   - CodexTimeoutMsSet: tracks if codex_timeout_ms was explicitly set
-//   - CodexSandboxSet: tracks if codex_sandbox was explicitly set outside embedded defaults
-//   - IterationDelayMsSet: tracks if iteration_delay_ms was explicitly set
-//   - TaskRetryCountSet: tracks if task_retry_count was explicitly set
-//   - FinalizeEnabledSet: tracks if finalize_enabled was explicitly set
-//   - WorktreeEnabledSet: tracks if use_worktree was explicitly set
-//   - MaxIterationsSet: tracks if max_iterations was explicitly set
-//   - WaitOnLimitSet: tracks if wait_on_limit was explicitly set
-//   - SessionTimeoutSet: tracks if session_timeout was explicitly set
+// Runtime-only exceptions, such as ClaudeArgsSet, are documented inline.
+// The inline field comments are the source of truth for which *Set sentinels exist.
 type Config struct {
 	ClaudeCommand string `json:"claude_command"`
 	ClaudeArgs    string `json:"claude_args"`
@@ -104,15 +93,13 @@ type Config struct {
 	VcsCommand    string   `json:"vcs_command"`    // custom VCS command (default: "git")
 	CommitTrailer string   `json:"commit_trailer"` // trailer line to append to all commits
 
-	// error patterns to detect in executor output (e.g., rate limit messages)
-	ClaudeErrorPatterns []string `json:"claude_error_patterns"`
-	CodexErrorPatterns  []string `json:"codex_error_patterns"`
+	ClaudeErrorPatterns []string `json:"claude_error_patterns"` // patterns to detect in claude output (e.g., rate limit messages)
+	CodexErrorPatterns  []string `json:"codex_error_patterns"`  // patterns to detect in codex output (e.g., rate limit messages)
+	ClaudeLimitPatterns []string `json:"claude_limit_patterns"` // patterns to detect rate limits in claude output (for wait+retry)
+	CodexLimitPatterns  []string `json:"codex_limit_patterns"`  // patterns to detect rate limits in codex output (for wait+retry)
 
-	// limit patterns for wait+retry behavior (overlap with error patterns is intentional)
-	ClaudeLimitPatterns []string      `json:"claude_limit_patterns"`
-	CodexLimitPatterns  []string      `json:"codex_limit_patterns"`
-	WaitOnLimit         time.Duration `json:"wait_on_limit"`
-	WaitOnLimitSet      bool          `json:"-"` // tracks if wait_on_limit was explicitly set in config
+	WaitOnLimit    time.Duration `json:"wait_on_limit"`
+	WaitOnLimitSet bool          `json:"-"` // tracks if wait_on_limit was explicitly set in config
 
 	// session timeout for configured executor sessions (external review in Claude mode is excluded)
 	SessionTimeout    time.Duration `json:"session_timeout"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1449,5 +1450,84 @@ func TestConfig_CodexExecutorSandbox(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, tc.cfg.CodexExecutorSandbox())
 		})
+	}
+}
+
+func TestConfig_JSONShape(t *testing.T) {
+	// guards against json: tag drift on Config. the Go field-equality round-trip tests
+	// do not catch tag changes, but the marshaled shape is a real dashboard/API surface
+	// consumed by pkg/web.
+	c := Config{
+		ClaudeCommand:           "claude",
+		ClaudeArgs:              "--foo",
+		PlanModel:               "opus:high",
+		TaskModel:               "sonnet:medium",
+		ReviewModel:             "sonnet:low",
+		CodexEnabled:            true,
+		CodexCommand:            "codex",
+		CodexModel:              "gpt-5.5",
+		CodexReasoningEffort:    "xhigh",
+		CodexTimeoutMs:          1000,
+		CodexSandbox:            "read-only",
+		ExternalReviewTool:      "codex",
+		CustomReviewScript:      "/tmp/review.sh",
+		IterationDelayMs:        500,
+		TaskRetryCount:          2,
+		MaxIterations:           50,
+		MaxExternalIterations:   5,
+		ReviewPatience:          3,
+		FinalizeEnabled:         true,
+		PreserveAnthropicAPIKey: true,
+		Executor:                ExecutorCodex,
+		PassClaudeMd:            true,
+		MovePlanOnCompletion:    true,
+		WorktreeEnabled:         true,
+		PlansDir:                "docs/plans",
+		WatchDirs:               []string{"a", "b"},
+		DefaultBranch:           "main",
+		VcsCommand:              "git",
+		CommitTrailer:           "Co-authored-by: x <x@y>",
+		ClaudeErrorPatterns:     []string{"e1"},
+		CodexErrorPatterns:      []string{"e2"},
+		ClaudeLimitPatterns:     []string{"l1"},
+		CodexLimitPatterns:      []string{"l2"},
+		WaitOnLimit:             time.Hour,
+		SessionTimeout:          30 * time.Minute,
+		IdleTimeout:             5 * time.Minute,
+	}
+
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	wantKeys := []string{
+		"claude_command", "claude_args", "plan_model", "task_model", "review_model",
+		"codex_enabled", "codex_command", "codex_model", "codex_reasoning_effort",
+		"codex_timeout_ms", "codex_sandbox", "external_review_tool", "custom_review_script",
+		"iteration_delay_ms", "task_retry_count", "max_iterations", "max_external_iterations",
+		"review_patience", "finalize_enabled", "preserve_anthropic_api_key", "executor",
+		"pass_claude_md", "move_plan_on_completion", "worktree_enabled", "plans_dir",
+		"watch_dirs", "default_branch", "vcs_command", "commit_trailer",
+		"claude_error_patterns", "codex_error_patterns", "claude_limit_patterns",
+		"codex_limit_patterns", "wait_on_limit", "session_timeout", "idle_timeout",
+	}
+
+	gotKeys := make([]string, 0, len(got))
+	for k := range got {
+		gotKeys = append(gotKeys, k)
+	}
+	assert.ElementsMatch(t, wantKeys, gotKeys, "marshaled Config key set drifted")
+
+	assert.JSONEq(t, `["e1"]`, string(got["claude_error_patterns"]))
+	assert.JSONEq(t, `["e2"]`, string(got["codex_error_patterns"]))
+	assert.JSONEq(t, `["l1"]`, string(got["claude_limit_patterns"]))
+	assert.JSONEq(t, `["l2"]`, string(got["codex_limit_patterns"]))
+
+	// the *Set sentinels and the loaded-from-files fields carry json:"-" and must be absent
+	for _, absent := range []string{"claude_args_set", "wait_on_limit_set", "notify_params", "colors", "task_prompt"} {
+		_, present := got[absent]
+		assert.False(t, present, "unexpected json key %q present", absent)
 	}
 }

--- a/pkg/config/values.go
+++ b/pkg/config/values.go
@@ -17,10 +17,13 @@ import (
 type Values struct {
 	ClaudeCommand              string
 	ClaudeArgs                 string
-	PlanModel                  string   // model for plan creation (falls back to TaskModel if empty)
-	TaskModel                  string   // model for task execution (e.g., "opus", "sonnet", "haiku")
-	ReviewModel                string   // model for review phases (falls back to TaskModel if empty)
-	ClaudeErrorPatterns        []string // patterns to detect in claude output (e.g., rate limit messages)
+	PlanModel                  string // model for plan creation (falls back to TaskModel if empty)
+	TaskModel                  string // model for task execution (e.g., "opus", "sonnet", "haiku")
+	ReviewModel                string // model for review phases (falls back to TaskModel if empty)
+	ClaudeErrorPatterns        []string
+	CodexErrorPatterns         []string
+	ClaudeLimitPatterns        []string
+	CodexLimitPatterns         []string
 	CodexEnabled               bool
 	CodexEnabledSet            bool // tracks if codex_enabled was explicitly set
 	CodexCommand               string
@@ -31,10 +34,7 @@ type Values struct {
 	CodexTimeoutMs             int
 	CodexTimeoutMsSet          bool // tracks if codex_timeout_ms was explicitly set
 	CodexSandbox               string
-	CodexSandboxSet            bool     // tracks if codex_sandbox was explicitly set outside embedded defaults
-	CodexErrorPatterns         []string // patterns to detect in codex output (e.g., rate limit messages)
-	ClaudeLimitPatterns        []string // patterns to detect rate limits in claude output (for wait+retry)
-	CodexLimitPatterns         []string // patterns to detect rate limits in codex output (for wait+retry)
+	CodexSandboxSet            bool // tracks if codex_sandbox was explicitly set outside embedded defaults
 	WaitOnLimit                time.Duration
 	WaitOnLimitSet             bool // tracks if wait_on_limit was explicitly set
 	SessionTimeout             time.Duration
@@ -404,84 +404,51 @@ func (vl *valuesLoader) parseValuesFromBytes(data []byte) (Values, error) {
 	values.CodexLimitPatterns = vl.parseCommaSeparated(section, "codex_limit_patterns")
 
 	// wait_on_limit duration
-	if err := vl.parseWaitOnLimit(section, &values); err != nil {
+	if d, ok, err := vl.parseDurationKey(section, "wait_on_limit"); err != nil {
 		return Values{}, err
+	} else if ok {
+		values.WaitOnLimit = d
+		values.WaitOnLimitSet = true
 	}
 
 	// session_timeout duration
-	if err := vl.parseSessionTimeout(section, &values); err != nil {
+	if d, ok, err := vl.parseDurationKey(section, "session_timeout"); err != nil {
 		return Values{}, err
+	} else if ok {
+		values.SessionTimeout = d
+		values.SessionTimeoutSet = true
 	}
 
 	// idle_timeout duration
-	if err := vl.parseIdleTimeout(section, &values); err != nil {
+	if d, ok, err := vl.parseDurationKey(section, "idle_timeout"); err != nil {
 		return Values{}, err
+	} else if ok {
+		values.IdleTimeout = d
+		values.IdleTimeoutSet = true
 	}
 
 	return values, nil
 }
 
-// parseWaitOnLimit parses wait_on_limit duration from an INI section.
-func (vl *valuesLoader) parseWaitOnLimit(section *ini.Section, values *Values) error {
-	if !section.HasKey("wait_on_limit") {
-		return nil
+// parseDurationKey parses a non-negative duration from the named INI key.
+// ok is false (with nil error) when the key is absent or empty, so the caller
+// leaves both the value and its *Set sentinel untouched.
+func (vl *valuesLoader) parseDurationKey(section *ini.Section, key string) (time.Duration, bool, error) {
+	if !section.HasKey(key) {
+		return 0, false, nil
 	}
-	val := strings.TrimSpace(section.Key("wait_on_limit").String())
+	val := strings.TrimSpace(section.Key(key).String())
 	if val == "" {
-		return nil
+		return 0, false, nil
 	}
 	d, parseErr := time.ParseDuration(val)
 	if parseErr != nil {
-		return fmt.Errorf("invalid wait_on_limit: %w", parseErr)
+		return 0, false, fmt.Errorf("invalid %s: %w", key, parseErr)
 	}
 	if d < 0 {
-		return fmt.Errorf("invalid wait_on_limit: must be non-negative, got %s", val)
+		return 0, false, fmt.Errorf("invalid %s: must be non-negative, got %s", key, val)
 	}
-	values.WaitOnLimit = d
-	values.WaitOnLimitSet = true
-	return nil
-}
-
-// parseSessionTimeout parses session_timeout duration from an INI section.
-func (vl *valuesLoader) parseSessionTimeout(section *ini.Section, values *Values) error {
-	if !section.HasKey("session_timeout") {
-		return nil
-	}
-	val := strings.TrimSpace(section.Key("session_timeout").String())
-	if val == "" {
-		return nil
-	}
-	d, parseErr := time.ParseDuration(val)
-	if parseErr != nil {
-		return fmt.Errorf("invalid session_timeout: %w", parseErr)
-	}
-	if d < 0 {
-		return fmt.Errorf("invalid session_timeout: must be non-negative, got %s", val)
-	}
-	values.SessionTimeout = d
-	values.SessionTimeoutSet = true
-	return nil
-}
-
-// parseIdleTimeout parses idle_timeout duration from an INI section.
-func (vl *valuesLoader) parseIdleTimeout(section *ini.Section, values *Values) error {
-	if !section.HasKey("idle_timeout") {
-		return nil
-	}
-	val := strings.TrimSpace(section.Key("idle_timeout").String())
-	if val == "" {
-		return nil
-	}
-	d, parseErr := time.ParseDuration(val)
-	if parseErr != nil {
-		return fmt.Errorf("invalid idle_timeout: %w", parseErr)
-	}
-	if d < 0 {
-		return fmt.Errorf("invalid idle_timeout: must be non-negative, got %s", val)
-	}
-	values.IdleTimeout = d
-	values.IdleTimeoutSet = true
-	return nil
+	return d, true, nil
 }
 
 // mergeFrom merges non-empty values from src into dst.

--- a/pkg/plan/parse.go
+++ b/pkg/plan/parse.go
@@ -159,24 +159,22 @@ func FileHasUncompletedCheckbox(path string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("read plan file: %w", err)
 	}
-	// scan lines for uncompleted checkboxes; only count actionable ones (text without [ ] or [x]).
-	// skip lines inside fenced code blocks so example checkboxes in templates are ignored.
 	var ft fenceTracker
+	task := Task{}
 	for line := range strings.SplitSeq(string(content), "\n") {
 		if ft.skip(line) {
 			continue
 		}
 		matches := checkboxPattern.FindStringSubmatch(line)
-		if len(matches) < 3 || matches[1] == "x" || matches[1] == "X" {
+		if len(matches) < 3 {
 			continue
 		}
-		text := strings.TrimSpace(matches[2])
-		if formatInText.MatchString(text) {
-			continue // format description, not actionable
-		}
-		return true, nil
+		task.Checkboxes = append(task.Checkboxes, Checkbox{
+			Text:    strings.TrimSpace(matches[2]),
+			Checked: matches[1] == "x" || matches[1] == "X",
+		})
 	}
-	return false, nil
+	return task.HasUncompletedActionableWork(), nil
 }
 
 // fenceTracker tracks markdown fenced code block state across a line-by-line scan.

--- a/pkg/plan/parse.go
+++ b/pkg/plan/parse.go
@@ -160,7 +160,6 @@ func FileHasUncompletedCheckbox(path string) (bool, error) {
 		return false, fmt.Errorf("read plan file: %w", err)
 	}
 	var ft fenceTracker
-	task := Task{}
 	for line := range strings.SplitSeq(string(content), "\n") {
 		if ft.skip(line) {
 			continue
@@ -169,12 +168,15 @@ func FileHasUncompletedCheckbox(path string) (bool, error) {
 		if len(matches) < 3 {
 			continue
 		}
-		task.Checkboxes = append(task.Checkboxes, Checkbox{
+		cb := Checkbox{
 			Text:    strings.TrimSpace(matches[2]),
 			Checked: matches[1] == "x" || matches[1] == "X",
-		})
+		}
+		if !cb.Checked && cb.IsActionable() {
+			return true, nil
+		}
 	}
-	return task.HasUncompletedActionableWork(), nil
+	return false, nil
 }
 
 // fenceTracker tracks markdown fenced code block state across a line-by-line scan.

--- a/pkg/plan/parse_test.go
+++ b/pkg/plan/parse_test.go
@@ -605,6 +605,31 @@ func TestFileHasUncompletedCheckbox(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, has, "real unchecked checkbox after a CRLF-terminated fence must be detected")
 	})
+
+	t.Run("agrees with checkbox actionability on edge cases", func(t *testing.T) {
+		tests := []struct {
+			name string
+			line string
+			cb   plan.Checkbox
+		}{
+			{name: "actionable unchecked", line: "- [ ] real work", cb: plan.Checkbox{Text: "real work"}},
+			{name: "format unchecked", line: "- [ ] use [ ] in examples", cb: plan.Checkbox{Text: "use [ ] in examples"}},
+			{name: "format checked marker unchecked", line: "- [ ] use [x] in examples", cb: plan.Checkbox{Text: "use [x] in examples"}},
+			{name: "actionable checked", line: "- [x] real work", cb: plan.Checkbox{Text: "real work", Checked: true}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tmpDir := t.TempDir()
+				path := filepath.Join(tmpDir, "plan.md")
+				require.NoError(t, os.WriteFile(path, []byte("# Plan\n"+tt.line), 0o600))
+
+				has, err := plan.FileHasUncompletedCheckbox(path)
+				require.NoError(t, err)
+				assert.Equal(t, !tt.cb.Checked && tt.cb.IsActionable(), has)
+			})
+		}
+	})
 }
 
 func TestPlan_JSON(t *testing.T) {

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -88,7 +88,7 @@ func (s *Selector) selectWithFzf(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("cannot access plans directory %s: %w", s.PlansDir, err)
 	}
 
-	// find plan files (excluding completed/)
+	// glob only direct plan files; completed/ is not matched recursively.
 	plans, err := filepath.Glob(filepath.Join(s.PlansDir, "*.md"))
 	if err != nil || len(plans) == 0 {
 		return "", fmt.Errorf("%w: %s", ErrNoPlansFound, s.PlansDir)
@@ -125,7 +125,7 @@ func (s *Selector) selectWithFzf(ctx context.Context) (string, error) {
 // FindRecent finds the most recently modified plan file in the plans directory
 // that was modified after the given start time.
 func (s *Selector) FindRecent(startTime time.Time) string {
-	// find all .md files in plansDir (excluding completed/ subdirectory)
+	// glob only direct plan files; completed/ is not matched recursively.
 	pattern := filepath.Join(s.PlansDir, "*.md")
 	plans, err := filepath.Glob(pattern)
 	if err != nil || len(plans) == 0 {

--- a/pkg/processor/execution_policy.go
+++ b/pkg/processor/execution_policy.go
@@ -10,23 +10,23 @@ import (
 	"github.com/umputun/ralphex/pkg/processor/phase"
 )
 
-type executionPolicy struct {
+type retryPolicy struct {
 	cfg         Config
 	log         Logger
 	waitOnLimit time.Duration
 }
 
-type executionPolicyOpts struct {
+type retryPolicyOpts struct {
 	cfg         Config
 	log         Logger
 	waitOnLimit time.Duration
 }
 
-func newExecutionPolicy(opts executionPolicyOpts) *executionPolicy {
-	return &executionPolicy{cfg: opts.cfg, log: opts.log, waitOnLimit: opts.waitOnLimit}
+func newRetryPolicy(opts retryPolicyOpts) *retryPolicy {
+	return &retryPolicy{cfg: opts.cfg, log: opts.log, waitOnLimit: opts.waitOnLimit}
 }
 
-func (p *executionPolicy) Run(ctx context.Context, run func(context.Context, string) executor.Result,
+func (p *retryPolicy) Run(ctx context.Context, run func(context.Context, string) executor.Result,
 	prompt string, toolName string) phase.ExecutionResult {
 	for {
 		result := p.runWithSessionTimeout(ctx, run, prompt, toolName)
@@ -52,7 +52,7 @@ func (p *executionPolicy) Run(ctx context.Context, run func(context.Context, str
 	}
 }
 
-func (p *executionPolicy) HandlePatternMatchError(err error, tool string) error {
+func (p *retryPolicy) HandlePatternMatchError(err error, tool string) error {
 	var patternErr *executor.PatternMatchError
 	if errors.As(err, &patternErr) {
 		p.log.Print("error: detected %q in %s output", patternErr.Pattern, tool)
@@ -68,7 +68,7 @@ func (p *executionPolicy) HandlePatternMatchError(err error, tool string) error 
 	return nil
 }
 
-func (p *executionPolicy) Sleep(ctx context.Context, d time.Duration) error {
+func (p *retryPolicy) Sleep(ctx context.Context, d time.Duration) error {
 	t := time.NewTimer(d)
 	defer t.Stop()
 	select {
@@ -79,7 +79,7 @@ func (p *executionPolicy) Sleep(ctx context.Context, d time.Duration) error {
 	}
 }
 
-func (p *executionPolicy) runWithSessionTimeout(ctx context.Context, run func(context.Context, string) executor.Result,
+func (p *retryPolicy) runWithSessionTimeout(ctx context.Context, run func(context.Context, string) executor.Result,
 	prompt string, toolName string) phase.ExecutionResult {
 	sessionTimeout := p.sessionTimeout()
 	codexMode := p.cfg.isCodexExecutor()
@@ -106,7 +106,7 @@ func (p *executionPolicy) runWithSessionTimeout(ctx context.Context, run func(co
 	return phase.ExecutionResult{Result: result, TimedOut: p.handleIdleTimeout(result, toolName)}
 }
 
-func (p *executionPolicy) handleIdleTimeout(result executor.Result, toolName string) bool {
+func (p *retryPolicy) handleIdleTimeout(result executor.Result, toolName string) bool {
 	if result.IdleTimedOut && result.Signal == "" {
 		p.log.Print("warning: %s session idle timed out, no output activity detected", toolName)
 		return true
@@ -114,7 +114,7 @@ func (p *executionPolicy) handleIdleTimeout(result executor.Result, toolName str
 	return false
 }
 
-func (p *executionPolicy) sessionTimeout() time.Duration {
+func (p *retryPolicy) sessionTimeout() time.Duration {
 	if p.cfg.AppConfig == nil {
 		return 0
 	}

--- a/pkg/processor/execution_policy_test.go
+++ b/pkg/processor/execution_policy_test.go
@@ -19,7 +19,7 @@ func TestExecutionPolicy_RunReturnsPerCallTimeoutState(t *testing.T) {
 	appCfg := testAppConfig(t)
 	appCfg.SessionTimeout = 20 * time.Millisecond
 	appCfg.SessionTimeoutSet = true
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
 
 	blockingRun := func(ctx context.Context, _ string) executor.Result {
 		<-ctx.Done()
@@ -41,7 +41,7 @@ func TestExecutionPolicy_RunReturnsPerCallTimeoutState(t *testing.T) {
 
 func TestExecutionPolicy_RunRetriesLimitErrors(t *testing.T) {
 	log := newMockLogger()
-	policy := newExecutionPolicy(executionPolicyOpts{log: log, waitOnLimit: time.Millisecond})
+	policy := newRetryPolicy(retryPolicyOpts{log: log, waitOnLimit: time.Millisecond})
 
 	calls := 0
 	run := func(_ context.Context, _ string) executor.Result {
@@ -68,7 +68,7 @@ func TestExecutionPolicy_RunRetriesLimitErrors(t *testing.T) {
 
 func TestExecutionPolicy_RunWithLimitRetryRetryOnLimitError(t *testing.T) {
 	log := newMockLogger()
-	policy := newExecutionPolicy(executionPolicyOpts{log: log, waitOnLimit: 10 * time.Millisecond})
+	policy := newRetryPolicy(retryPolicyOpts{log: log, waitOnLimit: 10 * time.Millisecond})
 
 	callCount := 0
 	run := func(_ context.Context, _ string) executor.Result {
@@ -88,7 +88,7 @@ func TestExecutionPolicy_RunWithLimitRetryRetryOnLimitError(t *testing.T) {
 }
 
 func TestExecutionPolicy_RunWithLimitRetryNoRetryWhenWaitZero(t *testing.T) {
-	policy := newExecutionPolicy(executionPolicyOpts{log: newMockLogger()})
+	policy := newRetryPolicy(retryPolicyOpts{log: newMockLogger()})
 
 	callCount := 0
 	run := func(_ context.Context, _ string) executor.Result {
@@ -106,7 +106,7 @@ func TestExecutionPolicy_RunWithLimitRetryNoRetryWhenWaitZero(t *testing.T) {
 }
 
 func TestExecutionPolicy_RunWithLimitRetryContextCancelledDuringWait(t *testing.T) {
-	policy := newExecutionPolicy(executionPolicyOpts{log: newMockLogger(), waitOnLimit: 10 * time.Second})
+	policy := newRetryPolicy(retryPolicyOpts{log: newMockLogger(), waitOnLimit: 10 * time.Second})
 	ctx, cancel := context.WithCancel(t.Context())
 
 	callCount := 0
@@ -124,7 +124,7 @@ func TestExecutionPolicy_RunWithLimitRetryContextCancelledDuringWait(t *testing.
 }
 
 func TestExecutionPolicy_RunWithLimitRetryPatternMatchErrorNotRetried(t *testing.T) {
-	policy := newExecutionPolicy(executionPolicyOpts{log: newMockLogger(), waitOnLimit: 10 * time.Millisecond})
+	policy := newRetryPolicy(retryPolicyOpts{log: newMockLogger(), waitOnLimit: 10 * time.Millisecond})
 
 	callCount := 0
 	run := func(_ context.Context, _ string) executor.Result {
@@ -142,7 +142,7 @@ func TestExecutionPolicy_RunWithLimitRetryPatternMatchErrorNotRetried(t *testing
 }
 
 func TestExecutionPolicy_RunWithLimitRetryMultipleRetries(t *testing.T) {
-	policy := newExecutionPolicy(executionPolicyOpts{log: newMockLogger(), waitOnLimit: time.Millisecond})
+	policy := newRetryPolicy(retryPolicyOpts{log: newMockLogger(), waitOnLimit: time.Millisecond})
 
 	callCount := 0
 	run := func(_ context.Context, _ string) executor.Result {
@@ -161,7 +161,7 @@ func TestExecutionPolicy_RunWithLimitRetryMultipleRetries(t *testing.T) {
 }
 
 func TestExecutionPolicy_RunWithLimitRetryNoErrorPassesThrough(t *testing.T) {
-	policy := newExecutionPolicy(executionPolicyOpts{log: newMockLogger(), waitOnLimit: time.Hour})
+	policy := newRetryPolicy(retryPolicyOpts{log: newMockLogger(), waitOnLimit: time.Hour})
 
 	callCount := 0
 	run := func(_ context.Context, _ string) executor.Result {
@@ -182,7 +182,7 @@ func TestExecutionPolicy_SessionTimeoutBlockingExecutor(t *testing.T) {
 	appCfg := testAppConfig(t)
 	appCfg.SessionTimeout = 50 * time.Millisecond
 	appCfg.SessionTimeoutSet = true
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
 
 	run := func(ctx context.Context, _ string) executor.Result {
 		<-ctx.Done()
@@ -202,7 +202,7 @@ func TestExecutionPolicy_SessionTimeoutBlockingExecutor(t *testing.T) {
 func TestExecutionPolicy_SessionTimeoutZeroDoesNotAddDeadline(t *testing.T) {
 	log := newMockLogger()
 	appCfg := testAppConfig(t)
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
 
 	var hasDeadline bool
 	run := func(ctx context.Context, _ string) executor.Result {
@@ -225,7 +225,7 @@ func TestExecutionPolicy_SessionTimeoutParentCancelNotMisidentified(t *testing.T
 	appCfg := testAppConfig(t)
 	appCfg.SessionTimeout = 10 * time.Second
 	appCfg.SessionTimeoutSet = true
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
 	ctx, cancel := context.WithCancel(t.Context())
 
 	run := func(runCtx context.Context, _ string) executor.Result {
@@ -247,7 +247,7 @@ func TestExecutionPolicy_SessionTimeoutIntegrationWithLimitRetry(t *testing.T) {
 	appCfg := testAppConfig(t)
 	appCfg.SessionTimeout = 50 * time.Millisecond
 	appCfg.SessionTimeoutSet = true
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: newMockLogger()})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: newMockLogger()})
 
 	run := func(ctx context.Context, _ string) executor.Result {
 		<-ctx.Done()
@@ -281,7 +281,7 @@ func TestExecutionPolicy_SessionTimeoutGatedByExecutorAndToolName(t *testing.T) 
 			appCfg.SessionTimeout = 50 * time.Millisecond
 			appCfg.SessionTimeoutSet = true
 			appCfg.Executor = tt.executor
-			policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: newMockLogger()})
+			policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: newMockLogger()})
 
 			var hasDeadline bool
 			run := func(ctx context.Context, _ string) executor.Result {
@@ -314,7 +314,7 @@ func TestExecutionPolicy_ExternalReviewBypassPreservesIdleTimeoutDiagnostic(t *t
 			appCfg.SessionTimeout = 50 * time.Millisecond
 			appCfg.SessionTimeoutSet = true
 			appCfg.Executor = config.ExecutorClaude
-			policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
+			policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: log})
 
 			var hadDeadline bool
 			run := func(ctx context.Context, _ string) executor.Result {
@@ -335,7 +335,7 @@ func TestExecutionPolicy_SessionTimeoutClearsSignalOnTimeout(t *testing.T) {
 	appCfg := testAppConfig(t)
 	appCfg.SessionTimeout = 50 * time.Millisecond
 	appCfg.SessionTimeoutSet = true
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: Config{AppConfig: appCfg}, log: newMockLogger()})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: Config{AppConfig: appCfg}, log: newMockLogger()})
 
 	run := func(ctx context.Context, _ string) executor.Result {
 		<-ctx.Done()

--- a/pkg/processor/executor_factory.go
+++ b/pkg/processor/executor_factory.go
@@ -53,14 +53,14 @@ func (cfg Config) buildClaudeExecutors(log Logger) (*executor.ClaudeExecutor, Ex
 	}
 	cfg.applyClaudeAppConfig(claudeExec)
 
-	taskModel, taskEffort := ParseModelEffort(cfg.TaskModel)
+	taskModel, taskEffort := parseModelEffort(cfg.TaskModel)
 	claudeExec.Model, claudeExec.Effort = taskModel, taskEffort
 
 	reviewSpec := cfg.ReviewModel
 	if reviewSpec == "" {
 		reviewSpec = cfg.TaskModel
 	}
-	reviewModel, reviewEffort := ParseModelEffort(reviewSpec)
+	reviewModel, reviewEffort := parseModelEffort(reviewSpec)
 	if reviewModel == taskModel && reviewEffort == taskEffort {
 		return claudeExec, nil
 	}
@@ -232,13 +232,11 @@ func (*executorFactory) needsCodexBinary(appConfig *config.Config) bool {
 	}
 }
 
-// ParseModelEffort splits a "model[:effort]" spec into separate parts.
-// Used by New to parse phase model config values into the ClaudeExecutor.Model
-// and ClaudeExecutor.Effort fields.
-// Empty input returns ("", ""). Missing colon returns (s, "").
-// A leading colon (":high") returns ("", "high"); a trailing colon ("opus:") returns ("opus", "").
-// Only the first colon is treated as the separator; anything after is passed through as effort.
-func ParseModelEffort(s string) (model, effort string) {
+// parseModelEffort splits a "model[:effort]" spec into separate parts.
+// empty input returns ("", ""). missing colon returns (s, "").
+// a leading colon (":high") returns ("", "high"); a trailing colon ("opus:") returns ("opus", "").
+// only the first colon is treated as the separator; anything after is passed through as effort.
+func parseModelEffort(s string) (model, effort string) {
 	model, effort, _ = strings.Cut(s, ":")
 	return model, effort
 }
@@ -253,7 +251,7 @@ func ResolveCodexModelEffort(spec, defModel, defEffort string) (model, effort st
 	if spec == "" {
 		return model, effort, false
 	}
-	m, e := ParseModelEffort(spec)
+	m, e := parseModelEffort(spec)
 	if m != "" {
 		model = m
 	}

--- a/pkg/processor/executor_factory_test.go
+++ b/pkg/processor/executor_factory_test.go
@@ -149,7 +149,7 @@ func TestRunner_New_CodexNotInstalled_NoneReviewStillWorks(t *testing.T) {
 	assert.NotNil(t, r, "runner should be created")
 }
 
-func TestParseModelEffort(t *testing.T) {
+func TestParseModelSpec(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  string
@@ -167,7 +167,7 @@ func TestParseModelEffort(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			model, effort := ParseModelEffort(tc.input)
+			model, effort := parseModelEffort(tc.input)
 			assert.Equal(t, tc.model, model)
 			assert.Equal(t, tc.effort, effort)
 		})

--- a/pkg/processor/phase/external_review.go
+++ b/pkg/processor/phase/external_review.go
@@ -157,6 +157,7 @@ loop:
 
 		switch result.action {
 		case externalReviewContinue:
+			// fall through to the sleep before the next iteration below
 		case externalReviewStop:
 			return outcome, nil
 		case externalReviewBreakLoop:
@@ -215,6 +216,8 @@ func (p *ExternalReviewPhase) runIteration(ctx context.Context, opts externalRev
 		if err := p.handleExecutorError(ctx, opts.parent, opts.tool, reviewResult.Error); err != nil {
 			return externalReviewIterationResult{}, err
 		}
+		// handleExecutorError always returns non-nil for a non-nil error, so this
+		// fall-through is intentionally unreachable; kept defensive against future changes.
 	}
 
 	if reviewExecResult.TimedOut {

--- a/pkg/processor/phase/finalize.go
+++ b/pkg/processor/phase/finalize.go
@@ -47,7 +47,7 @@ func (p *FinalizePhase) Run(ctx context.Context) error {
 	}
 	p.log.PrintSection(status.NewGenericSection("finalize step"))
 
-	execName := p.executorName()
+	execName := p.cfg.executorName()
 	execResult := p.policy.Run(ctx, p.exec.Run, p.prompts.FinalizePrompt(), execName)
 	result := execResult.Result
 
@@ -69,11 +69,4 @@ func (p *FinalizePhase) Run(ctx context.Context) error {
 
 	p.log.Print("finalize step completed")
 	return nil
-}
-
-func (p *FinalizePhase) executorName() string {
-	if p.cfg.isCodexExecutor() {
-		return "codex"
-	}
-	return "claude"
 }

--- a/pkg/processor/phase/phase.go
+++ b/pkg/processor/phase/phase.go
@@ -3,6 +3,7 @@ package phase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/umputun/ralphex/pkg/config"
@@ -34,6 +35,25 @@ type Config struct {
 
 func (c Config) isCodexExecutor() bool {
 	return c.AppConfig != nil && c.AppConfig.Executor == config.ExecutorCodex
+}
+
+func (c Config) executorName() string {
+	if c.isCodexExecutor() {
+		return "codex"
+	}
+	return "claude"
+}
+
+// wrapExecutorError wraps a phase executor error, routing through pattern-match handling first.
+// shared by task, review, and plan-creation phases (distinct from external_review's break-aware variant).
+func wrapExecutorError(policy Policy, err error, execName string) error {
+	if err == nil {
+		return nil
+	}
+	if patternErr := policy.HandlePatternMatchError(err, execName); patternErr != nil {
+		return fmt.Errorf("%s pattern handling: %w", execName, patternErr)
+	}
+	return fmt.Errorf("%s execution: %w", execName, err)
 }
 
 // Executor runs a phase prompt and returns the executor result.

--- a/pkg/processor/phase/plan_creation.go
+++ b/pkg/processor/phase/plan_creation.go
@@ -103,14 +103,11 @@ func (p *PlanCreationPhase) runIteration(ctx context.Context, lastRevisionFeedba
 		prompt = fmt.Sprintf("%s\n\n---\nPREVIOUS DRAFT FEEDBACK:\nUser requested revisions with this feedback:\n%s\n\nPlease revise the plan accordingly and present a new PLAN_DRAFT.", prompt, lastRevisionFeedback)
 	}
 
-	execName := p.executorName()
+	execName := p.cfg.executorName()
 	execResult := p.policy.Run(ctx, p.exec.Run, prompt, execName)
 	result := execResult.Result
-	if result.Error != nil {
-		if err := p.policy.HandlePatternMatchError(result.Error, execName); err != nil {
-			return planIterationOutcome{}, fmt.Errorf("%s pattern handling: %w", execName, err)
-		}
-		return planIterationOutcome{}, fmt.Errorf("%s execution: %w", execName, result.Error)
+	if err := wrapExecutorError(p.policy, result.Error, execName); err != nil {
+		return planIterationOutcome{}, err
 	}
 
 	if result.Signal == SignalFailed {
@@ -197,11 +194,4 @@ func (p *PlanCreationPhase) handleQuestion(ctx context.Context, output string) (
 
 	p.log.LogAnswer(answer)
 	return true, nil
-}
-
-func (p *PlanCreationPhase) executorName() string {
-	if p.cfg.isCodexExecutor() {
-		return "codex"
-	}
-	return "claude"
 }

--- a/pkg/processor/phase/review.go
+++ b/pkg/processor/phase/review.go
@@ -58,7 +58,7 @@ func (p *ReviewPhase) Loop(ctx context.Context, prefix string) error {
 	}
 	maxReviewIterations := max(minReviewIterations, p.cfg.MaxIterations/reviewIterationDivisor)
 
-	execName := p.executorName()
+	execName := p.cfg.executorName()
 	for i := 1; i <= maxReviewIterations; i++ {
 		select {
 		case <-ctx.Done():
@@ -71,11 +71,8 @@ func (p *ReviewPhase) Loop(ctx context.Context, prefix string) error {
 
 		execResult := p.policy.Run(ctx, p.exec.Run, p.prompts.SecondReviewPrompt(prefix), execName)
 		result := execResult.Result
-		if result.Error != nil {
-			if err := p.policy.HandlePatternMatchError(result.Error, execName); err != nil {
-				return fmt.Errorf("%s pattern handling: %w", execName, err)
-			}
-			return fmt.Errorf("%s execution: %w", execName, result.Error)
+		if err := wrapExecutorError(p.policy, result.Error, execName); err != nil {
+			return err
 		}
 
 		if result.Signal == SignalFailed {
@@ -121,14 +118,11 @@ func (p *ReviewPhase) section(iteration int, suffix string) status.Section {
 }
 
 func (p *ReviewPhase) run(ctx context.Context, prompt, phaseLabel string) error {
-	execName := p.executorName()
+	execName := p.cfg.executorName()
 	execResult := p.policy.Run(ctx, p.exec.Run, prompt, execName)
 	result := execResult.Result
-	if result.Error != nil {
-		if err := p.policy.HandlePatternMatchError(result.Error, execName); err != nil {
-			return fmt.Errorf("%s pattern handling: %w", execName, err)
-		}
-		return fmt.Errorf("%s execution: %w", execName, result.Error)
+	if err := wrapExecutorError(p.policy, result.Error, execName); err != nil {
+		return err
 	}
 
 	if result.Signal == SignalFailed {
@@ -148,11 +142,4 @@ func (p *ReviewPhase) run(ctx context.Context, prompt, phaseLabel string) error 
 	}
 
 	return nil
-}
-
-func (p *ReviewPhase) executorName() string {
-	if p.cfg.isCodexExecutor() {
-		return "codex"
-	}
-	return "claude"
 }

--- a/pkg/processor/phase/review_test.go
+++ b/pkg/processor/phase/review_test.go
@@ -68,6 +68,28 @@ func TestReviewPhase_Loop_PatternMatchError(t *testing.T) {
 	assertLogContains(t, log, "detected")
 }
 
+func TestWrapExecutorError(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.NoError(t, wrapExecutorError(newScriptedTestPolicy(newMockLogger("")), nil, "claude"))
+	})
+
+	t.Run("pattern match wraps as pattern handling", func(t *testing.T) {
+		policy := newScriptedTestPolicy(newMockLogger(""))
+		patternErr := &executor.PatternMatchError{Pattern: "rate limit", HelpCmd: "usage"}
+		err := wrapExecutorError(policy, patternErr, "codex")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "codex pattern handling:")
+		assert.Contains(t, err.Error(), "rate limit")
+	})
+
+	t.Run("plain error wraps as execution", func(t *testing.T) {
+		err := wrapExecutorError(newScriptedTestPolicy(newMockLogger("")), errors.New("boom"), "claude")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "claude execution:")
+		assert.Contains(t, err.Error(), "boom")
+	})
+}
+
 func TestReviewPhase_Loop_NoCommitExit(t *testing.T) {
 	exec := newTaskPhaseMockExecutor([]executor.Result{{Output: "looked at code, nothing to fix"}})
 	phase, log := reviewPhaseFromRunner(t, reviewPhaseTestOpts{cfg: Config{MaxIterations: 50}, exec: exec})

--- a/pkg/processor/phase/task.go
+++ b/pkg/processor/phase/task.go
@@ -72,7 +72,7 @@ func (p *TaskPhase) Run(ctx context.Context) error {
 
 		loopCtx, loopCancel := p.breaks.context(ctx)
 
-		execName := p.executorName()
+		execName := p.cfg.executorName()
 		execResult := p.policy.Run(loopCtx, p.exec.Run, prompt, execName)
 		result := execResult.Result
 
@@ -91,11 +91,8 @@ func (p *TaskPhase) Run(ctx context.Context) error {
 			continue
 		}
 
-		if result.Error != nil {
-			if err := p.policy.HandlePatternMatchError(result.Error, execName); err != nil {
-				return fmt.Errorf("%s pattern handling: %w", execName, err)
-			}
-			return fmt.Errorf("%s execution: %w", execName, result.Error)
+		if err := wrapExecutorError(p.policy, result.Error, execName); err != nil {
+			return err
 		}
 
 		if execResult.TimedOut {
@@ -190,11 +187,4 @@ func (p *TaskPhase) NextPlanTaskPosition() int {
 		}
 	}
 	return 0
-}
-
-func (p *TaskPhase) executorName() string {
-	if p.cfg.isCodexExecutor() {
-		return "codex"
-	}
-	return "claude"
 }

--- a/pkg/processor/runner.go
+++ b/pkg/processor/runner.go
@@ -40,7 +40,7 @@ type Config struct {
 	NoColor               bool           // disable color output
 	IterationDelayMs      int            // delay between iterations in milliseconds
 	TaskRetryCount        int            // number of times to retry failed tasks
-	TaskModel             string         // model[:effort] spec for task execution; parsed via ParseModelEffort (empty = CLI defaults)
+	TaskModel             string         // model[:effort] spec for task execution; parsed by executor setup (empty = CLI defaults)
 	ReviewModel           string         // model[:effort] spec for review phases; empty falls back to TaskModel
 	CodexEnabled          bool           // whether codex review is enabled
 	ExternalReviewToolSet bool           // when true, AppConfig.ExternalReviewTool is an explicit choice that overrides codex_enabled=false back-compat
@@ -200,7 +200,7 @@ func NewWithExecutors(cfg Config, log Logger, execs Executors, holder *status.Ph
 	}
 
 	locator := newPlanLocator(cfg)
-	policy := newExecutionPolicy(executionPolicyOpts{cfg: cfg, log: log, waitOnLimit: waitOnLimit})
+	policy := newRetryPolicy(retryPolicyOpts{cfg: cfg, log: log, waitOnLimit: waitOnLimit})
 	prompts := newPromptBuilder(promptBuilderOpts{cfg: cfg, log: log, locator: locator})
 	phaseCfg := toPhaseConfig(cfg)
 	deps := &phase.Deps{}

--- a/pkg/processor/runner_test.go
+++ b/pkg/processor/runner_test.go
@@ -598,7 +598,7 @@ func TestRunner_ErrorPatternMatch_ClaudeInTaskPhase(t *testing.T) {
 }
 
 func TestRunner_LimitPatternMatch_ClaudeInTaskPhase_NoWait(t *testing.T) {
-	// verifies that LimitPatternError is handled gracefully by executionPolicy
+	// verifies that LimitPatternError is handled gracefully by retryPolicy
 	// when waitOnLimit == 0, same as PatternMatchError (logs error + help, returns error)
 	tmpDir := t.TempDir()
 	planFile := filepath.Join(tmpDir, "plan.md")
@@ -620,7 +620,7 @@ func TestRunner_LimitPatternMatch_ClaudeInTaskPhase_NoWait(t *testing.T) {
 	assert.Equal(t, "You've hit your limit", limitErr.Pattern)
 	assert.Equal(t, "claude /usage", limitErr.HelpCmd)
 
-	// verify executionPolicy logging
+	// verify retryPolicy logging
 	var foundErrorLog, foundHelpLog bool
 	for _, call := range log.PrintCalls() {
 		if strings.Contains(call.Format, "error: detected") && strings.Contains(call.Format, "%s output") {

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -271,18 +271,30 @@ const timestampFormat = "06-01-02 15:04:05"
 // isProgressCompleted relies on this exact value to detect completed files.
 var separatorLine = strings.Repeat("-", 60)
 
-// writeTimestamped writes a message to both file and stdout with timestamp and optional prefix.
-// Holds l.writeMu across the file + stdout pair so concurrent producers cannot
-// split the two sinks (e.g., file gets producer A then B while stdout gets B then A).
-func (l *Logger) writeTimestamped(prefix string, clr *color.Color, msg string) {
-	timestamp := time.Now().Format(timestampFormat)
-	tsStr := l.colors.Timestamp().Sprintf("[%s]", timestamp)
-	coloredMsg := clr.Sprintf("%s%s", prefix, msg)
+type timestampPrefix struct {
+	raw     string
+	colored string
+}
 
+func (l *Logger) timestampPrefix() timestampPrefix {
+	timestamp := time.Now().Format(timestampFormat)
+	return timestampPrefix{
+		raw:     timestamp,
+		colored: l.colors.Timestamp().Sprintf("[%s]", timestamp),
+	}
+}
+
+func (l *Logger) writeOutput(fileFormat string, fileArgs []any, stdoutPayload string) {
 	l.writeMu.Lock()
 	defer l.writeMu.Unlock()
-	l.writeFileLocked("[%s] %s%s\n", timestamp, prefix, msg)
-	l.writeStdoutLocked("%s %s\n", tsStr, coloredMsg)
+	l.writeFileLocked(fileFormat, fileArgs...)
+	l.writeStdoutLocked("%s", stdoutPayload)
+}
+
+func (l *Logger) writeTimestamped(prefix string, clr *color.Color, msg string) {
+	ts := l.timestampPrefix()
+	coloredMsg := clr.Sprintf("%s%s", prefix, msg)
+	l.writeOutput("[%s] %s%s\n", []any{ts.raw, prefix, msg}, fmt.Sprintf("%s %s\n", ts.colored, coloredMsg))
 }
 
 // Print writes a timestamped message to both file and stdout.
@@ -294,10 +306,7 @@ func (l *Logger) Print(format string, args ...any) {
 // Holds l.writeMu across the file + stdout pair, see writeTimestamped.
 func (l *Logger) PrintRaw(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	l.writeMu.Lock()
-	defer l.writeMu.Unlock()
-	l.writeFileLocked("%s", msg)
-	l.writeStdoutLocked("%s", msg)
+	l.writeOutput("%s", []any{msg}, msg)
 }
 
 // PrintSection writes a section header without timestamp in yellow.
@@ -306,10 +315,7 @@ func (l *Logger) PrintRaw(format string, args ...any) {
 func (l *Logger) PrintSection(section status.Section) {
 	header := fmt.Sprintf("\n--- %s ---\n", section.Label)
 	coloredHeader := l.colors.Warn().Sprint(header)
-	l.writeMu.Lock()
-	defer l.writeMu.Unlock()
-	l.writeFileLocked("%s", header)
-	l.writeStdoutLocked("%s", coloredHeader)
+	l.writeOutput("%s", []any{header}, coloredHeader)
 }
 
 // getTerminalWidth returns terminal width, using COLUMNS env var or syscall.
@@ -435,9 +441,7 @@ func (l *Logger) PrintAligned(text string) {
 
 		displayLine := line
 
-		// timestamp each line
-		timestamp := time.Now().Format(timestampFormat)
-		tsPrefix := l.colors.Timestamp().Sprintf("[%s]", timestamp)
+		ts := l.timestampPrefix()
 
 		// use red for signal lines
 		lineColor := phaseColor
@@ -448,13 +452,7 @@ func (l *Logger) PrintAligned(text string) {
 			lineColor = l.colors.Signal()
 		}
 
-		// hold writeMu across the file + stdout pair so concurrent producers
-		// cannot split a single line's two sinks (file gets producer A while
-		// stdout shows producer B, or vice versa).
-		l.writeMu.Lock()
-		l.writeFileLocked("[%s] %s\n", timestamp, line)
-		l.writeStdoutLocked("%s %s\n", tsPrefix, lineColor.Sprint(displayLine))
-		l.writeMu.Unlock()
+		l.writeOutput("[%s] %s\n", []any{ts.raw, line}, fmt.Sprintf("%s %s\n", ts.colored, lineColor.Sprint(displayLine)))
 	}
 }
 
@@ -523,18 +521,17 @@ func (l *Logger) Warn(format string, args ...any) {
 // Holds l.writeMu across the full 4-write sequence so another producer cannot
 // split the QUESTION line from its companion OPTIONS line on either sink.
 func (l *Logger) LogQuestion(question string, options []string) {
-	timestamp := time.Now().Format(timestampFormat)
-	tsStr := l.colors.Timestamp().Sprintf("[%s]", timestamp)
+	ts := l.timestampPrefix()
 	questionStr := l.colors.Info().Sprintf("QUESTION: %s", question)
 	optionsStr := l.colors.Info().Sprintf("OPTIONS: %s", strings.Join(options, ", "))
 	optionsJoined := strings.Join(options, ", ")
 
 	l.writeMu.Lock()
 	defer l.writeMu.Unlock()
-	l.writeFileLocked("[%s] QUESTION: %s\n", timestamp, question)
-	l.writeFileLocked("[%s] OPTIONS: %s\n", timestamp, optionsJoined)
-	l.writeStdoutLocked("%s %s\n", tsStr, questionStr)
-	l.writeStdoutLocked("%s %s\n", tsStr, optionsStr)
+	l.writeFileLocked("[%s] QUESTION: %s\n", ts.raw, question)
+	l.writeFileLocked("[%s] OPTIONS: %s\n", ts.raw, optionsJoined)
+	l.writeStdoutLocked("%s %s\n", ts.colored, questionStr)
+	l.writeStdoutLocked("%s %s\n", ts.colored, optionsStr)
 }
 
 // LogAnswer logs the user's answer for plan creation mode.
@@ -549,19 +546,18 @@ func (l *Logger) LogAnswer(answer string) {
 // Holds l.writeMu across the full 2- or 4-write sequence so the DRAFT REVIEW
 // and FEEDBACK lines stay grouped on both sinks under concurrent producers.
 func (l *Logger) LogDraftReview(action, feedback string) {
-	timestamp := time.Now().Format(timestampFormat)
-	tsStr := l.colors.Timestamp().Sprintf("[%s]", timestamp)
+	ts := l.timestampPrefix()
 	actionStr := l.colors.Info().Sprintf("DRAFT REVIEW: %s", action)
 
 	l.writeMu.Lock()
 	defer l.writeMu.Unlock()
-	l.writeFileLocked("[%s] DRAFT REVIEW: %s\n", timestamp, action)
-	l.writeStdoutLocked("%s %s\n", tsStr, actionStr)
+	l.writeFileLocked("[%s] DRAFT REVIEW: %s\n", ts.raw, action)
+	l.writeStdoutLocked("%s %s\n", ts.colored, actionStr)
 
 	if feedback != "" {
 		feedbackStr := l.colors.Info().Sprintf("FEEDBACK: %s", feedback)
-		l.writeFileLocked("[%s] FEEDBACK: %s\n", timestamp, feedback)
-		l.writeStdoutLocked("%s %s\n", tsStr, feedbackStr)
+		l.writeFileLocked("[%s] FEEDBACK: %s\n", ts.raw, feedback)
+		l.writeStdoutLocked("%s %s\n", ts.colored, feedbackStr)
 	}
 }
 
@@ -574,11 +570,11 @@ func (l *Logger) LogDiffStats(files, additions, deletions int) {
 	if l.file == nil || files <= 0 {
 		return
 	}
-	timestamp := time.Now().Format(timestampFormat)
+	ts := l.timestampPrefix()
 	l.writeMu.Lock()
 	defer l.writeMu.Unlock()
 	l.writeFileLocked("[%s] DIFFSTATS: files=%d additions=%d deletions=%d\n",
-		timestamp, files, additions, deletions)
+		ts.raw, files, additions, deletions)
 }
 
 // Elapsed returns formatted elapsed time since start.
@@ -710,14 +706,7 @@ const progressDir = ".ralphex/progress"
 
 // filenameWithStem returns the progress file path for a known stem and mode.
 func filenameWithStem(stem, mode string) string {
-	switch mode {
-	case "codex-only":
-		return filepath.Join(progressDir, fmt.Sprintf("progress-%s-codex.txt", stem))
-	case "review":
-		return filepath.Join(progressDir, fmt.Sprintf("progress-%s-review.txt", stem))
-	default:
-		return filepath.Join(progressDir, fmt.Sprintf("progress-%s.txt", stem))
-	}
+	return filepath.Join(progressDir, fmt.Sprintf("progress-%s%s.txt", stem, modeSuffix(mode)))
 }
 
 // progressFilename returns progress file path based on plan and mode.
@@ -739,13 +728,24 @@ func progressFilename(planFile, planDescription, mode, branchOverride string) st
 
 	switch mode {
 	case "codex-only":
-		return filepath.Join(progressDir, "progress-codex.txt")
+		return filepath.Join(progressDir, "progress"+modeSuffix(mode)+".txt")
 	case "review":
-		return filepath.Join(progressDir, "progress-review.txt")
+		return filepath.Join(progressDir, "progress"+modeSuffix(mode)+".txt")
 	case "plan":
 		return filepath.Join(progressDir, "progress-plan.txt")
 	default:
 		return filepath.Join(progressDir, "progress.txt")
+	}
+}
+
+func modeSuffix(mode string) string {
+	switch mode {
+	case "codex-only":
+		return "-codex"
+	case "review":
+		return "-review"
+	default:
+		return ""
 	}
 }
 

--- a/pkg/web/broadcast_logger.go
+++ b/pkg/web/broadcast_logger.go
@@ -157,13 +157,13 @@ func formatText(format string, args ...any) string {
 func extractTerminalSignal(text string) string {
 	switch {
 	case strings.Contains(text, status.Completed):
-		return "COMPLETED"
+		return signalCompleted
 	case strings.Contains(text, status.Failed):
-		return "FAILED"
+		return signalFailed
 	case strings.Contains(text, status.ReviewDone):
-		return "REVIEW_DONE"
+		return signalReviewDone
 	case strings.Contains(text, status.CodexDone):
-		return "CODEX_REVIEW_DONE"
+		return signalCodexReviewDone
 	default:
 		return ""
 	}

--- a/pkg/web/event.go
+++ b/pkg/web/event.go
@@ -25,6 +25,13 @@ const (
 	EventTypeIterationStart EventType = "iteration_start" // review/codex iteration started
 )
 
+const (
+	signalCompleted       = "COMPLETED"
+	signalFailed          = "FAILED"
+	signalReviewDone      = "REVIEW_DONE"
+	signalCodexReviewDone = "CODEX_REVIEW_DONE"
+)
+
 // Event represents a single event to be streamed to web clients.
 type Event struct {
 	Type         EventType    `json:"type"`
@@ -112,13 +119,6 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("marshal event: %w", err)
 	}
 	return data, nil
-}
-
-// JSON returns the event as JSON bytes for SSE streaming.
-//
-// Deprecated: use json.Marshal(event) instead.
-func (e Event) JSON() ([]byte, error) {
-	return e.MarshalJSON()
 }
 
 // ToSSEMessage converts the event to a go-sse Message for streaming.

--- a/pkg/web/event_test.go
+++ b/pkg/web/event_test.go
@@ -47,7 +47,7 @@ func TestEvent_JSON(t *testing.T) {
 	t.Run("output event serializes correctly", func(t *testing.T) {
 		e := NewOutputEvent(status.PhaseTask, "test output")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded Event
@@ -62,7 +62,7 @@ func TestEvent_JSON(t *testing.T) {
 	t.Run("section event includes section field", func(t *testing.T) {
 		e := NewSectionEvent(status.PhaseReview, "Test Section")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded map[string]any
@@ -75,7 +75,7 @@ func TestEvent_JSON(t *testing.T) {
 	t.Run("signal event includes signal field", func(t *testing.T) {
 		e := NewSignalEvent(status.PhaseTask, "DONE")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded map[string]any
@@ -88,7 +88,7 @@ func TestEvent_JSON(t *testing.T) {
 	t.Run("omits empty fields", func(t *testing.T) {
 		e := NewOutputEvent(status.PhaseTask, "simple output")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded map[string]any
@@ -152,7 +152,7 @@ func TestEvent_JSON_TaskAndIterationFields(t *testing.T) {
 	t.Run("task event includes task_num", func(t *testing.T) {
 		e := NewTaskStartEvent(status.PhaseTask, 7, "task iteration 7")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded map[string]any
@@ -165,7 +165,7 @@ func TestEvent_JSON_TaskAndIterationFields(t *testing.T) {
 	t.Run("iteration event includes iteration_num", func(t *testing.T) {
 		e := NewIterationStartEvent(status.PhaseCodex, 3, "codex iteration 3")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded map[string]any
@@ -178,7 +178,7 @@ func TestEvent_JSON_TaskAndIterationFields(t *testing.T) {
 	t.Run("omits zero task_num and iteration_num", func(t *testing.T) {
 		e := NewOutputEvent(status.PhaseTask, "simple output")
 
-		data, err := e.JSON()
+		data, err := json.Marshal(e)
 		require.NoError(t, err)
 
 		var decoded map[string]any

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -193,15 +193,7 @@ func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := p.JSON()
-	if err != nil {
-		log.Printf("[WARN] failed to encode plan: %v", err)
-		http.Error(w, "unable to encode plan", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write(data)
+	s.writePlanJSON(w, p)
 }
 
 // handleSessionPlan handles plan requests for a specific session in multi-session mode.
@@ -234,6 +226,10 @@ func (s *Server) handleSessionPlan(w http.ResponseWriter, sessionID string) {
 		return
 	}
 
+	s.writePlanJSON(w, p)
+}
+
+func (s *Server) writePlanJSON(w http.ResponseWriter, p *plan.Plan) {
 	data, err := p.JSON()
 	if err != nil {
 		log.Printf("[WARN] failed to encode plan: %v", err)

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -209,13 +209,6 @@ func (s *Session) GetTailer() *Tailer {
 	return s.tailer
 }
 
-// SetTailer updates the session's tailer thread-safely.
-func (s *Session) SetTailer(tailer *Tailer) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.tailer = tailer
-}
-
 // SetLastModified updates the last modified time thread-safely.
 func (s *Session) SetLastModified(t time.Time) {
 	s.mu.Lock()

--- a/pkg/web/session_progress.go
+++ b/pkg/web/session_progress.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -124,7 +123,7 @@ func (m *SessionManager) loadProgressFileIntoSession(path string, session *Sessi
 	}
 
 	if pendingSection != "" {
-		m.emitPendingSection(session, pendingSection, phase, time.Now())
+		m.publishEvents(session, buildPendingSectionEvents(pendingSection, phase, time.Now()))
 	}
 
 	session.setLastOffset(bytesRead)
@@ -142,7 +141,7 @@ func (m *SessionManager) processProgressLine(session *Session, parsed ParsedLine
 		return phase, pendingSection
 	case ParsedLineSection:
 		if pendingSection != "" {
-			m.emitPendingSection(session, pendingSection, phase, time.Now())
+			m.publishEvents(session, buildPendingSectionEvents(pendingSection, phase, time.Now()))
 		}
 		phase = parsed.Phase
 		// defer emitting section until we see a timestamped event
@@ -150,63 +149,31 @@ func (m *SessionManager) processProgressLine(session *Session, parsed ParsedLine
 	case ParsedLineTimestamp:
 		// emit pending section with this event's timestamp (for accurate durations)
 		if pendingSection != "" {
-			m.emitPendingSection(session, pendingSection, phase, parsed.Timestamp)
+			m.publishEvents(session, buildPendingSectionEvents(pendingSection, phase, parsed.Timestamp))
 			pendingSection = ""
 		}
-		event := Event{
-			Type:      parsed.EventType,
-			Phase:     phase,
-			Text:      parsed.Text,
-			Timestamp: parsed.Timestamp,
-			Signal:    parsed.Signal,
-		}
+		event := eventFromParsed(parsed, phase)
 		if event.Type == EventTypeOutput {
 			if stats, ok := parseDiffStats(event.Text); ok {
 				session.SetDiffStats(stats)
 			}
 		}
-		_ = session.Publish(event)
+		m.publishEvent(session, event)
 	case ParsedLinePlain:
-		_ = session.Publish(Event{
-			Type:      EventTypeOutput,
-			Phase:     phase,
-			Text:      parsed.Text,
-			Timestamp: time.Now(),
-		})
+		m.publishEvent(session, eventFromParsed(parsed, phase))
 	}
 	return phase, pendingSection
 }
 
-// emitPendingSection publishes section and task_start events for a pending section.
-// task_start is emitted before section for task iteration sections.
-func (m *SessionManager) emitPendingSection(session *Session, sectionName string, phase status.Phase, ts time.Time) {
-	// emit task_start event for task iteration sections
-	if matches := taskIterationRegex.FindStringSubmatch(sectionName); matches != nil {
-		taskNum, err := strconv.Atoi(matches[1])
-		if err != nil {
-			// log parse error but continue - section will still be emitted
-			log.Printf("[WARN] failed to parse task number from section %q: %v", sectionName, err)
-		} else {
-			if err := session.Publish(Event{
-				Type:      EventTypeTaskStart,
-				Phase:     phase,
-				TaskNum:   taskNum,
-				Text:      sectionName,
-				Timestamp: ts,
-			}); err != nil {
-				log.Printf("[WARN] failed to publish task_start event: %v", err)
-			}
-		}
+func (m *SessionManager) publishEvents(session *Session, events []Event) {
+	for _, event := range events {
+		m.publishEvent(session, event)
 	}
+}
 
-	if err := session.Publish(Event{
-		Type:      EventTypeSection,
-		Phase:     phase,
-		Section:   sectionName,
-		Text:      sectionName,
-		Timestamp: ts,
-	}); err != nil {
-		log.Printf("[WARN] failed to publish section event: %v", err)
+func (m *SessionManager) publishEvent(session *Session, event Event) {
+	if err := session.Publish(event); err != nil {
+		log.Printf("[WARN] failed to publish %s event: %v", event.Type, err)
 	}
 }
 

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,6 +170,46 @@ Started: 2026-01-22 10:00:00
 
 		// should not panic
 		m.loadProgressFileIntoSession(path, session)
+	})
+
+	t.Run("emits plain line before pending section", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-plain-after-section.txt")
+
+		content := `# Ralphex Progress Log
+Plan: docs/plan.md
+Branch: main
+Mode: full
+Started: 2026-01-22 10:00:00
+------------------------------------------------------------
+
+--- Review ---
+plain review output
+`
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		m := NewSessionManager()
+		defer m.Close()
+		session := NewSession("test-plain-after-section", path)
+		defer session.Close()
+
+		require.NoError(t, session.Publish(NewOutputEvent(status.PhaseTask, "seed")))
+		rawEvents, cleanup := subscribeSSEEvents(t, session)
+		defer cleanup()
+		_ = drainChannel(rawEvents, 50*time.Millisecond)
+
+		m.loadProgressFileIntoSession(path, session)
+
+		got := drainChannel(rawEvents, 50*time.Millisecond)
+		require.Len(t, got, 2)
+
+		var first, second Event
+		require.NoError(t, json.Unmarshal([]byte(got[0]), &first))
+		require.NoError(t, json.Unmarshal([]byte(got[1]), &second))
+		assert.Equal(t, EventTypeOutput, first.Type)
+		assert.Equal(t, "plain review output", first.Text)
+		assert.Equal(t, EventTypeSection, second.Type)
+		assert.Equal(t, "Review", second.Section)
 	})
 
 	t.Run("captures diffstats from output line", func(t *testing.T) {

--- a/pkg/web/session_test.go
+++ b/pkg/web/session_test.go
@@ -78,19 +78,6 @@ func TestSession_LastModified(t *testing.T) {
 	assert.Equal(t, now, s.GetLastModified())
 }
 
-func TestSession_Tailer(t *testing.T) {
-	s := NewSession("test", "/tmp/test.txt")
-
-	assert.Nil(t, s.GetTailer())
-
-	tailer := &Tailer{}
-	s.SetTailer(tailer)
-	assert.Equal(t, tailer, s.GetTailer())
-
-	s.SetTailer(nil)
-	assert.Nil(t, s.GetTailer())
-}
-
 func TestSession_Close(t *testing.T) {
 	s := NewSession("test", "/tmp/test.txt")
 	defer s.Close()

--- a/pkg/web/tail.go
+++ b/pkg/web/tail.go
@@ -423,20 +423,11 @@ func (t *Tailer) parseLine(line string) *Event {
 			Timestamp: time.Now(),
 		}
 	case ParsedLineTimestamp:
-		return &Event{
-			Type:      parsed.EventType,
-			Phase:     t.phase,
-			Text:      parsed.Text,
-			Timestamp: parsed.Timestamp,
-			Signal:    parsed.Signal,
-		}
+		event := eventFromParsed(parsed, t.phase)
+		return &event
 	case ParsedLinePlain:
-		return &Event{
-			Type:      EventTypeOutput,
-			Phase:     t.phase,
-			Text:      parsed.Text,
-			Timestamp: time.Now(),
-		}
+		event := eventFromParsed(parsed, t.phase)
+		return &event
 	default:
 		return nil
 	}
@@ -465,13 +456,7 @@ func (t *Tailer) parseLineDeferred(line string) []Event {
 		if t.pendingSection != "" {
 			events = append(events, t.emitPendingSection(parsed.Timestamp)...)
 		}
-		events = append(events, Event{
-			Type:      parsed.EventType,
-			Phase:     t.phase,
-			Text:      parsed.Text,
-			Timestamp: parsed.Timestamp,
-			Signal:    parsed.Signal,
-		})
+		events = append(events, eventFromParsed(parsed, t.phase))
 		return events
 	case ParsedLinePlain:
 		var events []Event
@@ -479,12 +464,8 @@ func (t *Tailer) parseLineDeferred(line string) []Event {
 		if t.pendingSection != "" {
 			events = append(events, t.emitPendingSection(now)...)
 		}
-		events = append(events, Event{
-			Type:      EventTypeOutput,
-			Phase:     t.phase,
-			Text:      parsed.Text,
-			Timestamp: now,
-		})
+		parsed.Timestamp = now
+		events = append(events, eventFromParsed(parsed, t.phase))
 		return events
 	default:
 		return nil
@@ -502,14 +483,18 @@ func (t *Tailer) emitPendingSection(ts time.Time) []Event {
 	t.pendingSection = ""
 	t.pendingPhase = ""
 
-	var events []Event
-	if matches := taskIterationRegex.FindStringSubmatch(sectionName); matches != nil {
+	return buildPendingSectionEvents(sectionName, phase, ts)
+}
+
+func buildPendingSectionEvents(name string, phase status.Phase, ts time.Time) []Event {
+	events := make([]Event, 0, 2)
+	if matches := taskIterationRegex.FindStringSubmatch(name); matches != nil {
 		if taskNum, err := strconv.Atoi(matches[1]); err == nil {
 			events = append(events, Event{
 				Type:      EventTypeTaskStart,
 				Phase:     phase,
 				TaskNum:   taskNum,
-				Text:      sectionName,
+				Text:      name,
 				Timestamp: ts,
 			})
 		}
@@ -518,12 +503,38 @@ func (t *Tailer) emitPendingSection(ts time.Time) []Event {
 	events = append(events, Event{
 		Type:      EventTypeSection,
 		Phase:     phase,
-		Section:   sectionName,
-		Text:      sectionName,
+		Section:   name,
+		Text:      name,
 		Timestamp: ts,
 	})
 
 	return events
+}
+
+func eventFromParsed(parsed ParsedLine, phase status.Phase) Event {
+	switch parsed.Type {
+	case ParsedLineTimestamp:
+		return Event{
+			Type:      parsed.EventType,
+			Phase:     phase,
+			Text:      parsed.Text,
+			Timestamp: parsed.Timestamp,
+			Signal:    parsed.Signal,
+		}
+	case ParsedLinePlain:
+		ts := parsed.Timestamp
+		if ts.IsZero() {
+			ts = time.Now()
+		}
+		return Event{
+			Type:      EventTypeOutput,
+			Phase:     phase,
+			Text:      parsed.Text,
+			Timestamp: ts,
+		}
+	default:
+		panic(fmt.Sprintf("eventFromParsed called with unsupported parsed line type %v", parsed.Type))
+	}
 }
 
 // detectEventType determines the event type from line content.
@@ -572,13 +583,13 @@ func normalizePlainSignal(text string) string {
 	}
 	switch trimmed {
 	case "ALL_TASKS_DONE", "COMPLETED":
-		return "COMPLETED"
+		return signalCompleted
 	case "TASK_FAILED", "ALL_TASKS_FAILED", "FAILED":
-		return "FAILED"
+		return signalFailed
 	case "REVIEW_DONE":
-		return "REVIEW_DONE"
+		return signalReviewDone
 	case "CODEX_REVIEW_DONE":
-		return "CODEX_REVIEW_DONE"
+		return signalCodexReviewDone
 	default:
 		return ""
 	}
@@ -588,13 +599,13 @@ func normalizePlainSignal(text string) string {
 func normalizeTokenSignal(rawSignal string) string {
 	switch rawSignal {
 	case "ALL_TASKS_DONE":
-		return "COMPLETED"
+		return signalCompleted
 	case "TASK_FAILED", "ALL_TASKS_FAILED":
-		return "FAILED"
+		return signalFailed
 	case "REVIEW_DONE":
-		return "REVIEW_DONE"
+		return signalReviewDone
 	case "CODEX_REVIEW_DONE":
-		return "CODEX_REVIEW_DONE"
+		return signalCodexReviewDone
 	default:
 		return rawSignal
 	}

--- a/pkg/web/tail_test.go
+++ b/pkg/web/tail_test.go
@@ -503,6 +503,15 @@ func TestTailer_ParseLineDeferred(t *testing.T) {
 		assert.Equal(t, "task iteration 2", tailer.pendingSection)
 	})
 
+	t.Run("eventFromParsed rejects non-event line types", func(t *testing.T) {
+		assert.Panics(t, func() {
+			_ = eventFromParsed(ParsedLine{Type: ParsedLineSkip}, status.PhaseTask)
+		})
+		assert.Panics(t, func() {
+			_ = eventFromParsed(ParsedLine{Type: ParsedLineSection}, status.PhaseTask)
+		})
+	})
+
 	t.Run("skips header lines", func(t *testing.T) {
 		tailer := NewTailer("/tmp/test.txt", DefaultTailerConfig())
 		tailer.inHeader = true


### PR DESCRIPTION
Behavior-preserving refactor to cut code smells and duplication surfaced by the refactor-analysis pass. No functional changes: INI keys, error strings, signal vocabulary, merge precedence, and concurrency contracts all stay identical.

**What changed, by package:**
- `pkg/config` - collapse the three identical duration parsers into `parseDurationKey`, reorganize the four-way field mirror, fix drifted godoc. Merge precedence and `*Set` sentinel handling unchanged.
- `pkg/processor/phase` - dedupe `executorName()` (was copied on 4 types) onto `Config`, share the 4 simple executor-error wrap sites via `wrapExecutorError`. `external_review.go`'s break-aware `handleExecutorError` and `finalize.go`'s best-effort path are kept distinct on purpose.
- `pkg/progress` - extract `timestampPrefix`/`writeOutput` for the timestamped write block (was repeated in ~8 methods), dedupe the mode-to-suffix switch.
- `pkg/web` - share Event construction (`eventFromParsed`, `buildPendingSectionEvents`) between the tailer and loader, drop dead `Session.SetTailer` and the deprecated `Event.JSON` shim.
- `cmd/ralphex` - consolidate the `model[:effort]` resolution (was inlined at 4 sites) and the two near-identical codex banner funcs.
- `pkg/processor` - unexport `ParseModelEffort` (no out-of-package caller), rename `executionPolicy` to `retryPolicy` to drop the `executor_factory` naming collision.
- `pkg/plan` - `FileHasUncompletedCheckbox` now reuses `Checkbox.IsActionable` instead of re-implementing it, fix misleading comments.

**Verification:**
- `make test` green, 87.6% coverage; `make lint` clean.
- New tests added only where an extracted helper had no coverage (`TestResolveModelSpecs`, `TestWrapExecutorError`, `TestConfig_JSONShape`, plus parse/tail/session_progress cases).
- code-review-plus (5 agents + codex) on the full branch diff found zero critical/major; all reviewers independently confirmed behavior preservation.
- codex-mode e2e toy run passed end-to-end (tasks, review, finalize, plan move). Claude-mode e2e was not run from CI context.

Plan: `docs/plans/completed/20260529-refactor-smells-and-duplication.md`
