### PR TITLE
feat: display user-set run parameters (models, executor) in web dashboard

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -442,6 +442,7 @@ func setupProgressLogger(o opts, req executePlanRequest, branch string) (progres
 			Mode:           string(req.Mode),
 			Branch:         branch,
 			BranchOverride: req.BranchOverride,
+			Params:         runHeaderParams(o, req.Config, req.Mode),
 			NoColor:        o.NoColor,
 		}, req.Colors, holder)
 		if err != nil {
@@ -552,12 +553,14 @@ func executePlan(ctx context.Context, o opts, req executePlanRequest) error {
 	// wrap logger with broadcast logger if --serve is enabled
 	var runnerLog processor.Logger = plr.baseLog
 	if o.Serve {
+		params := runHeaderParams(o, req.Config, req.Mode)
 		dashboard := web.NewDashboard(web.DashboardConfig{
 			BaseLog:         plr.baseLog,
 			Port:            o.Port,
 			Host:            o.Host,
 			PlanFile:        req.PlanFile,
 			Branch:          branch,
+			RunParams:       web.FormatRunParams(params.Executor, params.PlanModel, params.TaskModel, params.ReviewModel),
 			WatchDirs:       o.Watch,
 			ConfigWatchDirs: req.Config.WatchDirs,
 			Colors:          req.Colors,
@@ -711,6 +714,7 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 		Mode:           string(req.Mode),
 		Branch:         branch,
 		BranchOverride: req.BranchOverride,
+		Params:         runHeaderParams(o, req.Config, req.Mode),
 		NoColor:        o.NoColor,
 	}, req.Colors, holder)
 	if err != nil {
@@ -1063,6 +1067,28 @@ func resolveSpec(cliVal, cfgVal string) string {
 	return cfgVal
 }
 
+// runHeaderParams returns the user-set run parameters recorded in the progress
+// file header (and shown in the web dashboard). only explicitly configured
+// values are included: the review model is recorded only when set directly
+// (not its task_model fallback), while plan mode records the effective plan
+// spec since plan_model falls back to task_model by design.
+func runHeaderParams(o opts, cfg *config.Config, mode processor.Mode) progress.RunParams {
+	p := progress.RunParams{}
+	if cfg == nil {
+		return p
+	}
+	if cfg.Executor == config.ExecutorCodex {
+		p.Executor = config.ExecutorCodex
+	}
+	if mode == processor.ModePlan {
+		p.PlanModel = resolvePlanSpec(o, cfg)
+		return p
+	}
+	p.TaskModel = resolveSpec(o.TaskModel, cfg.TaskModel)
+	p.ReviewModel = resolveSpec(o.ReviewModel, cfg.ReviewModel)
+	return p
+}
+
 func resolvePlanSpec(o opts, cfg *config.Config) string {
 	if planSpec := resolveSpec(o.PlanModel, cfg.PlanModel); planSpec != "" {
 		return planSpec
@@ -1128,6 +1154,7 @@ func runPlanMode(ctx context.Context, o opts, req executePlanRequest, selector *
 		PlanDescription: o.PlanDescription,
 		Mode:            string(processor.ModePlan),
 		Branch:          branch,
+		Params:          runHeaderParams(o, req.Config, processor.ModePlan),
 		NoColor:         o.NoColor,
 	}, req.Colors, holder)
 	if err != nil {

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -1190,6 +1190,50 @@ func TestResolveModelSpecs(t *testing.T) {
 	})
 }
 
+func TestRunHeaderParams(t *testing.T) {
+	t.Run("nil config returns empty params", func(t *testing.T) {
+		got := runHeaderParams(opts{}, nil, processor.ModeFull)
+		assert.Equal(t, progress.RunParams{}, got)
+	})
+
+	t.Run("nothing set returns empty params", func(t *testing.T) {
+		got := runHeaderParams(parseTestOpts(t), &config.Config{}, processor.ModeFull)
+		assert.Equal(t, progress.RunParams{}, got)
+	})
+
+	t.Run("cli task and review models", func(t *testing.T) {
+		got := runHeaderParams(parseTestOpts(t, "--task-model", "opus:high", "--review-model", "sonnet:low"), &config.Config{}, processor.ModeFull)
+		assert.Equal(t, progress.RunParams{TaskModel: "opus:high", ReviewModel: "sonnet:low"}, got)
+	})
+
+	t.Run("cli flags override config values", func(t *testing.T) {
+		cfg := &config.Config{TaskModel: "sonnet", ReviewModel: "haiku"}
+		got := runHeaderParams(parseTestOpts(t, "--task-model", "opus"), cfg, processor.ModeFull)
+		assert.Equal(t, progress.RunParams{TaskModel: "opus", ReviewModel: "haiku"}, got)
+	})
+
+	t.Run("review model fallback to task is not recorded", func(t *testing.T) {
+		got := runHeaderParams(parseTestOpts(t, "--task-model", "opus"), &config.Config{}, processor.ModeFull)
+		assert.Equal(t, progress.RunParams{TaskModel: "opus"}, got, "review inherits task implicitly, no separate header line")
+	})
+
+	t.Run("codex executor recorded", func(t *testing.T) {
+		cfg := &config.Config{Executor: config.ExecutorCodex}
+		got := runHeaderParams(parseTestOpts(t, "--codex"), cfg, processor.ModeFull)
+		assert.Equal(t, progress.RunParams{Executor: "codex"}, got)
+	})
+
+	t.Run("plan mode records effective plan model", func(t *testing.T) {
+		got := runHeaderParams(parseTestOpts(t, "--plan-model", "opus:high"), &config.Config{}, processor.ModePlan)
+		assert.Equal(t, progress.RunParams{PlanModel: "opus:high"}, got)
+	})
+
+	t.Run("plan mode falls back to task model", func(t *testing.T) {
+		got := runHeaderParams(parseTestOpts(t, "--task-model", "opus"), &config.Config{}, processor.ModePlan)
+		assert.Equal(t, progress.RunParams{PlanModel: "opus"}, got, "plan_model falls back to task_model by design")
+	})
+}
+
 func TestCodexModelBanner(t *testing.T) {
 	t.Run("task_model_sets_task_and_review", func(t *testing.T) {
 		cfg := &config.Config{CodexModel: "gpt-5.5", CodexReasoningEffort: "xhigh"}

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -140,12 +140,23 @@ type Logger struct {
 
 // Config holds logger configuration.
 type Config struct {
-	PlanFile        string // plan filename (used to derive progress filename)
-	PlanDescription string // plan description for plan mode (used for filename)
-	Mode            string // execution mode: full, review, codex-only, plan
-	Branch          string // current git branch
-	BranchOverride  string // explicit branch name override (--branch flag); when set, used as filename stem instead of plan file
-	NoColor         bool   // disable color output (sets color.NoColor globally)
+	PlanFile        string    // plan filename (used to derive progress filename)
+	PlanDescription string    // plan description for plan mode (used for filename)
+	Mode            string    // execution mode: full, review, codex-only, plan
+	Branch          string    // current git branch
+	BranchOverride  string    // explicit branch name override (--branch flag); when set, used as filename stem instead of plan file
+	Params          RunParams // user-set run parameters recorded in the header
+	NoColor         bool      // disable color output (sets color.NoColor globally)
+}
+
+// RunParams holds user-set executor/model parameters written to the progress
+// file header. empty fields are omitted from the header so only explicitly
+// configured parameters appear in the dashboard.
+type RunParams struct {
+	Executor    string // executor name when not the default claude (e.g. "codex")
+	PlanModel   string // model[:effort] spec for plan creation
+	TaskModel   string // model[:effort] spec for task execution
+	ReviewModel string // model[:effort] spec for review phases
 }
 
 // NewLogger creates a logger writing to both a progress file and stdout.
@@ -252,6 +263,18 @@ func (l *Logger) writeHeader(cfg Config) {
 	l.writeFileLocked("Plan: %s\n", planStr)
 	l.writeFileLocked("Branch: %s\n", cfg.Branch)
 	l.writeFileLocked("Mode: %s\n", cfg.Mode)
+	if cfg.Params.Executor != "" {
+		l.writeFileLocked("Executor: %s\n", cfg.Params.Executor)
+	}
+	if cfg.Params.PlanModel != "" {
+		l.writeFileLocked("Plan model: %s\n", cfg.Params.PlanModel)
+	}
+	if cfg.Params.TaskModel != "" {
+		l.writeFileLocked("Task model: %s\n", cfg.Params.TaskModel)
+	}
+	if cfg.Params.ReviewModel != "" {
+		l.writeFileLocked("Review model: %s\n", cfg.Params.ReviewModel)
+	}
 	l.writeFileLocked("Started: %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	l.writeFileLocked("%s\n\n", separatorLine)
 }

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -76,6 +76,62 @@ func TestNewLogger(t *testing.T) {
 	}
 }
 
+func TestNewLogger_HeaderRunParams(t *testing.T) {
+	colors := testColors()
+
+	tests := []struct {
+		name        string
+		params      RunParams
+		wantLines   []string
+		absentLines []string
+	}{
+		{
+			name:        "no params set omits all lines",
+			params:      RunParams{},
+			absentLines: []string{"Executor: ", "Plan model: ", "Task model: ", "Review model: "},
+		},
+		{
+			name:        "task model only",
+			params:      RunParams{TaskModel: "opus:high"},
+			wantLines:   []string{"Task model: opus:high\n"},
+			absentLines: []string{"Executor: ", "Plan model: ", "Review model: "},
+		},
+		{
+			name:      "codex executor with task and review models",
+			params:    RunParams{Executor: "codex", TaskModel: "gpt-5.5:high", ReviewModel: "gpt-5.5:low"},
+			wantLines: []string{"Executor: codex\n", "Task model: gpt-5.5:high\n", "Review model: gpt-5.5:low\n"},
+		},
+		{
+			name:        "plan model only",
+			params:      RunParams{PlanModel: "opus:high"},
+			wantLines:   []string{"Plan model: opus:high\n"},
+			absentLines: []string{"Executor: ", "Task model: ", "Review model: "},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origDir, _ := os.Getwd()
+			require.NoError(t, os.Chdir(t.TempDir()))
+			defer func() { _ = os.Chdir(origDir) }()
+
+			holder := &status.PhaseHolder{}
+			l, err := NewLogger(Config{PlanFile: "docs/plans/feature.md", Mode: "full", Branch: "main", Params: tc.params}, colors, holder)
+			require.NoError(t, err)
+			defer l.Close()
+
+			content, err := os.ReadFile(l.Path())
+			require.NoError(t, err)
+			for _, want := range tc.wantLines {
+				assert.Contains(t, string(content), want)
+			}
+			for _, absent := range tc.absentLines {
+				assert.NotContains(t, string(content), absent)
+			}
+		})
+	}
+}
+
 func TestNewLogger_AppendOnRestart(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()

--- a/pkg/web/dashboard.go
+++ b/pkg/web/dashboard.go
@@ -31,6 +31,7 @@ type DashboardConfig struct {
 	Host            string           // host/IP to bind to (default "127.0.0.1")
 	PlanFile        string           // path to plan file (empty for watch-only mode)
 	Branch          string           // current git branch
+	RunParams       string           // formatted run parameters (executor/models) for header display
 	WatchDirs       []string         // CLI watch directories
 	ConfigWatchDirs []string         // config file watch directories
 	Colors          *progress.Colors // colors for output
@@ -42,6 +43,7 @@ type Dashboard struct {
 	host            string
 	planFile        string
 	branch          string
+	runParams       string
 	baseLog         Logger
 	watchDirs       []string
 	configWatchDirs []string
@@ -56,6 +58,7 @@ func NewDashboard(cfg DashboardConfig, holder *status.PhaseHolder) *Dashboard {
 		host:            cfg.Host,
 		planFile:        cfg.PlanFile,
 		branch:          cfg.Branch,
+		runParams:       cfg.RunParams,
 		baseLog:         cfg.BaseLog,
 		watchDirs:       cfg.WatchDirs,
 		configWatchDirs: cfg.ConfigWatchDirs,
@@ -79,11 +82,12 @@ func (d *Dashboard) Start(ctx context.Context) (*BroadcastLogger, error) {
 	}
 
 	cfg := ServerConfig{
-		Port:     d.port,
-		Host:     d.host,
-		PlanName: planName,
-		Branch:   d.branch,
-		PlanFile: d.planFile,
+		Port:      d.port,
+		Host:      d.host,
+		PlanName:  planName,
+		Branch:    d.branch,
+		RunParams: d.runParams,
+		PlanFile:  d.planFile,
 	}
 
 	// determine if we should use multi-session mode

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/umputun/ralphex/pkg/plan"
@@ -24,11 +25,12 @@ var embeddedFS embed.FS
 
 // ServerConfig holds configuration for the web server.
 type ServerConfig struct {
-	Port     int    // port to listen on
-	Host     string // host/IP to bind to (default "127.0.0.1")
-	PlanName string // plan name to display in dashboard
-	Branch   string // git branch name
-	PlanFile string // path to plan file for /api/plan endpoint
+	Port      int    // port to listen on
+	Host      string // host/IP to bind to (default "127.0.0.1")
+	PlanName  string // plan name to display in dashboard
+	Branch    string // git branch name
+	RunParams string // formatted run parameters (executor/models) to display in dashboard
+	PlanFile  string // path to plan file for /api/plan endpoint
 }
 
 // host returns the bind address, defaulting to "127.0.0.1" if not set.
@@ -137,8 +139,29 @@ func (s *Server) Session() *Session {
 
 // templateData holds data for the dashboard template.
 type templateData struct {
-	PlanName string
-	Branch   string
+	PlanName  string
+	Branch    string
+	RunParams string
+}
+
+// FormatRunParams builds the display string for user-set run parameters,
+// e.g. "codex · task gpt-5.5:high · review gpt-5.5:low". empty fields are
+// skipped; returns "" when no parameters were set.
+func FormatRunParams(executor, planModel, taskModel, reviewModel string) string {
+	parts := make([]string, 0, 4)
+	if executor != "" {
+		parts = append(parts, executor)
+	}
+	if planModel != "" {
+		parts = append(parts, "plan "+planModel)
+	}
+	if taskModel != "" {
+		parts = append(parts, "task "+taskModel)
+	}
+	if reviewModel != "" {
+		parts = append(parts, "review "+reviewModel)
+	}
+	return strings.Join(parts, " · ")
 }
 
 // handleIndex serves the main dashboard page.
@@ -151,8 +174,9 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	data := templateData{
-		PlanName: s.cfg.PlanName,
-		Branch:   s.cfg.Branch,
+		PlanName:  s.cfg.PlanName,
+		Branch:    s.cfg.Branch,
+		RunParams: s.cfg.RunParams,
 	}
 
 	if err := s.tmpl.Execute(w, data); err != nil {
@@ -300,10 +324,12 @@ type SessionInfo struct {
 	// dir is the short display name for the project (last path segment of session directory).
 	Dir string `json:"dir"`
 	// DirPath is the full filesystem path to the session directory (used for grouping and copy-to-clipboard).
-	DirPath      string     `json:"dirPath,omitempty"`
-	PlanPath     string     `json:"planPath,omitempty"`
-	Branch       string     `json:"branch,omitempty"`
-	Mode         string     `json:"mode,omitempty"`
+	DirPath  string `json:"dirPath,omitempty"`
+	PlanPath string `json:"planPath,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	// RunParams is the formatted user-set run parameters (executor/models) for header display.
+	RunParams    string     `json:"runParams,omitempty"`
 	StartTime    time.Time  `json:"startTime"`
 	LastModified time.Time  `json:"lastModified"`
 	DiffStats    *DiffStats `json:"diffStats,omitempty"`
@@ -352,6 +378,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 			PlanPath:     meta.PlanPath,
 			Branch:       meta.Branch,
 			Mode:         meta.Mode,
+			RunParams:    FormatRunParams(meta.Executor, meta.PlanModel, meta.TaskModel, meta.ReviewModel),
 			StartTime:    meta.StartTime,
 			LastModified: session.GetLastModified(),
 			DiffStats:    session.GetDiffStats(),

--- a/pkg/web/server_test.go
+++ b/pkg/web/server_test.go
@@ -37,9 +37,10 @@ func TestServer_HandleIndex(t *testing.T) {
 	session := NewSession("test", "/tmp/test.txt")
 	defer session.Close()
 	srv, err := NewServer(ServerConfig{
-		Port:     8080,
-		PlanName: "my-plan.md",
-		Branch:   "feature-branch",
+		Port:      8080,
+		PlanName:  "my-plan.md",
+		Branch:    "feature-branch",
+		RunParams: "codex · task gpt-5.5:high",
 	}, session)
 	require.NoError(t, err)
 
@@ -62,6 +63,7 @@ func TestServer_HandleIndex(t *testing.T) {
 		assert.Contains(t, bodyStr, "Ralphex Dashboard")
 		assert.Contains(t, bodyStr, "my-plan.md")
 		assert.Contains(t, bodyStr, "feature-branch")
+		assert.Contains(t, bodyStr, "codex · task gpt-5.5:high")
 	})
 
 	t.Run("returns 404 for non-root paths", func(t *testing.T) {
@@ -394,6 +396,9 @@ func TestServer_HandleSessions(t *testing.T) {
 Plan: docs/plans/test-plan.md
 Branch: feature-branch
 Mode: full
+Executor: codex
+Task model: gpt-5.5:high
+Review model: gpt-5.5:low
 Started: 2026-01-22 10:30:00
 ------------------------------------------------------------
 [10:30:00] Starting execution
@@ -432,6 +437,7 @@ Started: 2026-01-22 10:30:00
 		assert.Equal(t, "docs/plans/test-plan.md", sessions[0].PlanPath)
 		assert.Equal(t, "feature-branch", sessions[0].Branch)
 		assert.Equal(t, "full", sessions[0].Mode)
+		assert.Equal(t, "codex · task gpt-5.5:high · review gpt-5.5:low", sessions[0].RunParams)
 	})
 
 	t.Run("rejects non-GET methods", func(t *testing.T) {
@@ -820,6 +826,27 @@ func TestExtractProjectDir(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := extractProjectDir(tc.path)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFormatRunParams(t *testing.T) {
+	tests := []struct {
+		name                                        string
+		executor, planModel, taskModel, reviewModel string
+		want                                        string
+	}{
+		{name: "all empty", want: ""},
+		{name: "executor only", executor: "codex", want: "codex"},
+		{name: "task model only", taskModel: "opus:high", want: "task opus:high"},
+		{name: "task and review models", taskModel: "opus", reviewModel: "sonnet:low", want: "task opus · review sonnet:low"},
+		{name: "executor with models", executor: "codex", taskModel: "gpt-5.5:high", reviewModel: "gpt-5.5:low", want: "codex · task gpt-5.5:high · review gpt-5.5:low"},
+		{name: "plan model only", planModel: "opus:high", want: "plan opus:high"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, FormatRunParams(tc.executor, tc.planModel, tc.taskModel, tc.reviewModel))
 		})
 	}
 }

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -54,10 +54,14 @@ const (
 
 // SessionMetadata holds parsed information from progress file header.
 type SessionMetadata struct {
-	PlanPath  string    // path to plan file (from "Plan:" header line)
-	Branch    string    // git branch (from "Branch:" header line)
-	Mode      string    // execution mode: full, review, codex-only (from "Mode:" header line)
-	StartTime time.Time // start time (from "Started:" header line)
+	PlanPath    string    // path to plan file (from "Plan:" header line)
+	Branch      string    // git branch (from "Branch:" header line)
+	Mode        string    // execution mode: full, review, codex-only (from "Mode:" header line)
+	Executor    string    // executor name when not the default claude (from "Executor:" header line)
+	PlanModel   string    // model[:effort] spec for plan creation (from "Plan model:" header line)
+	TaskModel   string    // model[:effort] spec for task execution (from "Task model:" header line)
+	ReviewModel string    // model[:effort] spec for review phases (from "Review model:" header line)
+	StartTime   time.Time // start time (from "Started:" header line)
 }
 
 // defaultTopic is the SSE topic used for all events within a session.

--- a/pkg/web/session_progress.go
+++ b/pkg/web/session_progress.go
@@ -20,8 +20,15 @@ import (
 //	Plan: path/to/plan.md
 //	Branch: feature-branch
 //	Mode: full
+//	Executor: codex
+//	Plan model: opus:high
+//	Task model: gpt-5.5:high
+//	Review model: gpt-5.5:low
 //	Started: 2026-01-22 10:30:00
 //	------------------------------------------------------------
+//
+// the Executor and model lines are optional — they appear only when the
+// corresponding parameter was set for the run.
 //
 // the second return value reports whether the terminating separator line was
 // observed, which means the header is fully written. during a truncate+rewrite
@@ -52,18 +59,7 @@ func ParseProgressHeader(path string) (meta SessionMetadata, complete bool, err 
 
 		// parse key-value pairs (process line before checking error,
 		// as ReadString may return partial data alongside an error)
-		if val, found := strings.CutPrefix(line, "Plan: "); found {
-			meta.PlanPath = val
-		} else if val, found := strings.CutPrefix(line, "Branch: "); found {
-			meta.Branch = val
-		} else if val, found := strings.CutPrefix(line, "Mode: "); found {
-			meta.Mode = val
-		} else if val, found := strings.CutPrefix(line, "Started: "); found {
-			// header timestamps are written in local time without a zone offset
-			if t, parseErr := time.ParseInLocation("2006-01-02 15:04:05", val, time.Local); parseErr == nil {
-				meta.StartTime = t
-			}
-		}
+		parseHeaderField(&meta, line)
 
 		if readErr != nil {
 			if !errors.Is(readErr, io.EOF) {
@@ -74,6 +70,35 @@ func ParseProgressHeader(path string) (meta SessionMetadata, complete bool, err 
 	}
 
 	return meta, complete, nil
+}
+
+// parseHeaderField applies a single header key-value line to meta.
+// unknown lines are ignored.
+func parseHeaderField(meta *SessionMetadata, line string) {
+	fields := []struct {
+		prefix string
+		dst    *string
+	}{
+		{"Plan: ", &meta.PlanPath},
+		{"Branch: ", &meta.Branch},
+		{"Mode: ", &meta.Mode},
+		{"Executor: ", &meta.Executor},
+		{"Plan model: ", &meta.PlanModel},
+		{"Task model: ", &meta.TaskModel},
+		{"Review model: ", &meta.ReviewModel},
+	}
+	for _, f := range fields {
+		if val, found := strings.CutPrefix(line, f.prefix); found {
+			*f.dst = val
+			return
+		}
+	}
+	if val, found := strings.CutPrefix(line, "Started: "); found {
+		// header timestamps are written in local time without a zone offset
+		if t, parseErr := time.ParseInLocation("2006-01-02 15:04:05", val, time.Local); parseErr == nil {
+			meta.StartTime = t
+		}
+	}
 }
 
 // loadProgressFileIntoSession reads a progress file and publishes events to the session's SSE server.

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -38,6 +38,37 @@ Started: 2026-01-22 10:30:00
 		assert.Equal(t, "feature-branch", meta.Branch)
 		assert.Equal(t, "full", meta.Mode)
 		assert.Equal(t, time.Date(2026, 1, 22, 10, 30, 0, 0, time.Local), meta.StartTime)
+		assert.Empty(t, meta.Executor, "executor line absent → empty")
+		assert.Empty(t, meta.TaskModel)
+		assert.Empty(t, meta.ReviewModel)
+	})
+
+	t.Run("parses optional executor and model fields", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: docs/plans/my-plan.md
+Branch: feature-branch
+Mode: full
+Executor: codex
+Plan model: opus:high
+Task model: gpt-5.5:high
+Review model: gpt-5.5:low
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+`
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		meta, complete, err := ParseProgressHeader(path)
+		require.NoError(t, err)
+		assert.True(t, complete)
+
+		assert.Equal(t, "codex", meta.Executor)
+		assert.Equal(t, "opus:high", meta.PlanModel)
+		assert.Equal(t, "gpt-5.5:high", meta.TaskModel)
+		assert.Equal(t, "gpt-5.5:low", meta.ReviewModel)
+		assert.Equal(t, "docs/plans/my-plan.md", meta.PlanPath, "Plan model line must not shadow Plan line")
 	})
 
 	t.Run("handles review-only mode", func(t *testing.T) {

--- a/pkg/web/static/app.js
+++ b/pkg/web/static/app.js
@@ -40,6 +40,7 @@
     const projectCopyBtn = document.getElementById('project-copy');
     const planNameEl = document.getElementById('plan-name');
     const branchNameEl = document.getElementById('branch-name');
+    const runParamsEl = document.getElementById('run-params');
 
     // SSE reconnection constants
     var SSE_INITIAL_RECONNECT_MS = 1000;
@@ -1497,6 +1498,9 @@
             if (branchNameEl) {
                 branchNameEl.textContent = session.branch || '';
             }
+            if (runParamsEl) {
+                runParamsEl.textContent = session.runParams || '';
+            }
             state.currentSession = session;
             updateDiffStats(session.diffStats);
             seedExecutionStartTimeFromSession(session);
@@ -1908,11 +1912,13 @@
     function collectSessionData() {
         const planNameEl = document.querySelector('.plan');
         const branchEl = document.querySelector('.branch');
+        const modelsEl = document.querySelector('.models');
 
         return {
             title: document.title,
             planName: planNameEl ? planNameEl.textContent : 'session',
             branch: branchEl ? branchEl.textContent : '',
+            runParams: modelsEl ? modelsEl.textContent : '',
             elapsed: elapsedTimeEl.textContent || '',
             status: statusBadge.textContent || '',
             statusClass: statusBadge.className.replace('status-badge', '').trim()
@@ -1941,7 +1947,7 @@
     }
 
     // build export HTML header section
-    function buildExportHeader(safeElapsed, safeStatus, safeStatusClass, safePlanName, safeBranch) {
+    function buildExportHeader(safeElapsed, safeStatus, safeStatusClass, safePlanName, safeBranch, safeRunParams) {
         return '<header>\n' +
             '<div class="header-top">\n' +
             '<h1>Ralphex Dashboard</h1>\n' +
@@ -1952,6 +1958,7 @@
             '<div class="info">\n' +
             '<span class="plan">' + safePlanName + '</span>\n' +
             '<span class="branch">' + safeBranch + '</span>\n' +
+            '<span class="models">' + safeRunParams + '</span>\n' +
             '</div>\n</header>\n';
     }
 
@@ -1995,13 +2002,14 @@
         var safeTitle = escapeHtml(data.title);
         var safePlanName = escapeHtml(data.planName);
         var safeBranch = escapeHtml(data.branch);
+        var safeRunParams = escapeHtml(data.runParams);
         var safeElapsed = escapeHtml(data.elapsed);
         var safeStatus = escapeHtml(data.status);
         var safeStatusClass = escapeHtml(data.statusClass);
 
         return buildExportHead(safeTitle, css) +
             '<body>\n' +
-            buildExportHeader(safeElapsed, safeStatus, safeStatusClass, safePlanName, safeBranch) +
+            buildExportHeader(safeElapsed, safeStatus, safeStatusClass, safePlanName, safeBranch, safeRunParams) +
             buildExportNav() +
             buildExportMain(clones);
     }

--- a/pkg/web/static/styles.css
+++ b/pkg/web/static/styles.css
@@ -667,6 +667,14 @@ header h1 {
     content: 'Branch';
 }
 
+.models::before {
+    content: 'Models';
+}
+
+.models:empty {
+    display: none;
+}
+
 /* ═══════════════════════════════════════════════════════════════
    PHASE NAVIGATION
    ═══════════════════════════════════════════════════════════════ */

--- a/pkg/web/templates/base.html
+++ b/pkg/web/templates/base.html
@@ -42,6 +42,7 @@
                 </div>
                 <span class="plan" id="plan-name" title="Plan">{{.PlanName}}</span>
                 <span class="branch" id="branch-name" title="Branch">{{.Branch}}</span>
+                <span class="models" id="run-params" title="Run parameters">{{.RunParams}}</span>
             </div>
         </header>
 


### PR DESCRIPTION
## What

Closes #379

Adds user-set run parameters (executor, plan/task/review model specs) to the web dashboard header, next to Project / Plan / Branch.

## How

Per the implementation guidance in the issue discussion, the values flow through the progress-file header so both display paths are covered:

- `pkg/progress/progress.go` — `writeHeader` writes optional `Executor:`, `Plan model:`, `Task model:`, `Review model:` lines next to `Plan:`/`Branch:`. Empty values are omitted entirely.
- `pkg/web/session_progress.go` — `ParseProgressHeader` parses the new lines into `SessionMetadata` (covers the watch / compare-after-the-fact view, including old files where the lines are simply absent).
- `pkg/web/server.go` — new `FormatRunParams` helper builds the display string (e.g. `codex · task gpt-5.5:high · review gpt-5.5:low`); exposed via the template for single-session `--serve` mode and as `runParams` in `/api/sessions` for multi-session mode.
- `base.html` / `app.js` / `styles.css` — new `Models` span in the header info row, hidden when empty (`:empty`), updated on session switch and included in HTML export.
- `cmd/ralphex/main.go` — `runHeaderParams` resolves what gets recorded (CLI flag > config): only explicitly set values, per the discussion. The review model is recorded only when set directly (its implicit task_model fallback is not repeated); plan mode records the effective plan spec since `plan_model` falls back to `task_model` by design. `executor: codex` is recorded whenever the codex executor is active.

## Testing

- `go test -race ./...` and `golangci-lint run` clean; `GOOS=windows` cross-compile verified
- new table tests: header write (`TestNewLogger_HeaderRunParams`), header parse (incl. `Plan model:` not shadowing `Plan:`), `TestFormatRunParams`, `TestRunHeaderParams`
- existing index/sessions handler tests extended to assert the new field end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)