### PR TITLE
feat: add new Anthropic model Fable to supported agent models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ Implementation:
 **Loading behavior:** agents are loaded with per-file fallback: local `.ralphex/agents/` → global `~/.config/ralphex/agents/` → embedded default. The 5 embedded agents are always the baseline — deleting an agent file from disk does not disable it, the embedded version is used as fallback. To disable a specific agent, remove its `{{agent:name}}` reference from the prompt files (`review_first.txt`, `review_second.txt`), not the agent file itself.
 
 **Frontmatter options:** Agent files support optional YAML frontmatter (`---` delimited) for per-agent model and subagent type:
-- `model: haiku|sonnet|opus` — Claude model for this agent
+- `model: haiku|sonnet|opus|fable` — Claude model for this agent
 - `agent: <type>` — Claude Code Task tool subagent type (default: `general-purpose`)
 - Parsed by `parseOptions()` in `pkg/config/frontmatter.go`, validated by `Options.Validate()`
 - Full model IDs (e.g. `claude-sonnet-4-5-20250929`) are normalized to short keywords (`sonnet`)

--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ ralphex --review-patience=3 docs/plans/feature.md
 ralphex --wait=1h docs/plans/feature.md
 
 # use a stronger model for plan creation
-ralphex --plan-model=opus:high --plan="add caching"
+ralphex --plan-model=fable:high --plan="add caching"
 
 # use different models for tasks and reviews
 ralphex --task-model=opus --review-model=sonnet:low docs/plans/feature.md
@@ -780,10 +780,10 @@ Review the code for quality issues...
 
 | Option | Values | Description |
 |--------|--------|-------------|
-| `model` | `haiku`, `sonnet`, `opus` | Claude model for this agent |
+| `model` | `haiku`, `sonnet`, `opus`, `fable` | Claude model for this agent |
 | `agent` | any string | Claude Code Task tool subagent type |
 
-Both options are optional. Without frontmatter, agents use default model and `general-purpose` subagent type. Full model IDs (e.g. `claude-sonnet-4-5-20250929`) are normalized to short keywords (`sonnet`) since Claude Code only accepts `haiku`, `sonnet`, `opus`. Invalid model values are dropped with a warning.
+Both options are optional. Without frontmatter, agents use default model and `general-purpose` subagent type. Full model IDs (e.g. `claude-sonnet-4-5-20250929`) are normalized to short keywords (`sonnet`) since Claude Code only accepts `haiku`, `sonnet`, `opus`, `fable`. Invalid model values are dropped with a warning.
 
 ### Template Syntax
 

--- a/llms.txt
+++ b/llms.txt
@@ -56,7 +56,7 @@ ralphex --review-patience=3 docs/plans/feature.md
 ralphex --wait=1h docs/plans/feature.md
 
 # use a stronger model for plan creation
-ralphex --plan-model=opus:high --plan="add caching"
+ralphex --plan-model=fable:high --plan="add caching"
 
 # use different models for tasks and reviews
 ralphex --task-model=opus --review-model=sonnet:low docs/plans/feature.md
@@ -147,7 +147,7 @@ Under the codex executor (`--codex` or `executor = codex`), `plan_model`/`task_m
 
 ```ini
 # in ~/.config/ralphex/config
-plan_model = opus:high
+plan_model = fable:high
 task_model = sonnet:medium
 review_model = sonnet:low
 ```

--- a/pkg/config/defaults/config
+++ b/pkg/config/defaults/config
@@ -23,7 +23,7 @@ claude_command = claude
 claude_args = --dangerously-skip-permissions --output-format stream-json --verbose
 
 # plan_model: model to use for interactive plan creation
-# syntax: model[:effort] where model is opus/sonnet/haiku (or a full model ID like
+# syntax: model[:effort] where model is fable/opus/sonnet/haiku (or a full model ID like
 # claude-sonnet-4-5-20250929) and effort is low/medium/high/xhigh/max.
 # either part is optional: "opus" sets model only, ":high" sets effort only,
 # "opus:high" sets both. falls back to task_model when empty.

--- a/pkg/config/frontmatter.go
+++ b/pkg/config/frontmatter.go
@@ -13,7 +13,7 @@ type Options struct {
 	AgentType string `yaml:"agent"`
 }
 
-var validModels = map[string]bool{"haiku": true, "sonnet": true, "opus": true}
+var validModels = map[string]bool{"haiku": true, "sonnet": true, "opus": true, "fable": true}
 
 // String returns a human-readable summary of the options for logging.
 func (o Options) String() string {
@@ -33,12 +33,12 @@ func (o Options) String() string {
 func (o Options) Validate() []string {
 	var warnings []string
 	if o.Model != "" && !validModels[o.Model] {
-		warnings = append(warnings, fmt.Sprintf("unknown model %q, must be one of: haiku, sonnet, opus", o.Model))
+		warnings = append(warnings, fmt.Sprintf("unknown model %q, must be one of: haiku, sonnet, opus, fable", o.Model))
 	}
 	return warnings
 }
 
-// normalizeModel extracts the keyword (haiku, sonnet, opus) from a model string.
+// normalizeModel extracts the keyword (haiku, sonnet, opus, fable) from a model string.
 // e.g. "claude-sonnet-4-5-20250929" → "sonnet", "opus" → "opus", "" → "".
 func normalizeModel(model string) string {
 	lower := strings.ToLower(model)

--- a/pkg/config/frontmatter_test.go
+++ b/pkg/config/frontmatter_test.go
@@ -36,6 +36,7 @@ func TestParseOptions(t *testing.T) {
 		{"full model id normalized", "---\nmodel: claude-sonnet-4-5-20250929\n---\nbody", Options{Model: "sonnet"}, "body"},
 		{"full model id haiku normalized", "---\nmodel: claude-haiku-4-5-20251001\n---\nbody", Options{Model: "haiku"}, "body"},
 		{"full model id opus normalized", "---\nmodel: claude-opus-4-6\n---\nbody", Options{Model: "opus"}, "body"},
+		{"full model id fable normalized", "---\nmodel: claude-fable-5\n---\nbody", Options{Model: "fable"}, "body"},
 		{"model keyword preserved", "---\nmodel: sonnet\n---\nbody", Options{Model: "sonnet"}, "body"},
 		{"unknown model kept as-is", "---\nmodel: gpt-5\n---\nbody", Options{Model: "gpt-5"}, "body"},
 
@@ -83,9 +84,10 @@ func TestOptions_Validate(t *testing.T) {
 		{"valid model haiku", Options{Model: "haiku"}, nil},
 		{"valid model sonnet", Options{Model: "sonnet"}, nil},
 		{"valid model opus", Options{Model: "opus"}, nil},
-		{"unknown model", Options{Model: "gpt-5"}, []string{`unknown model "gpt-5", must be one of: haiku, sonnet, opus`}},
+		{"valid model fable", Options{Model: "fable"}, nil},
+		{"unknown model", Options{Model: "gpt-5"}, []string{`unknown model "gpt-5", must be one of: haiku, sonnet, opus, fable`}},
 		{"agent type not validated", Options{AgentType: "anything-goes"}, nil},
-		{"unknown model with agent", Options{Model: "bad", AgentType: "reviewer"}, []string{`unknown model "bad", must be one of: haiku, sonnet, opus`}},
+		{"unknown model with agent", Options{Model: "bad", AgentType: "reviewer"}, []string{`unknown model "bad", must be one of: haiku, sonnet, opus, fable`}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/values.go
+++ b/pkg/config/values.go
@@ -18,7 +18,7 @@ type Values struct {
 	ClaudeCommand              string
 	ClaudeArgs                 string
 	PlanModel                  string // model for plan creation (falls back to TaskModel if empty)
-	TaskModel                  string // model for task execution (e.g., "opus", "sonnet", "haiku")
+	TaskModel                  string // model for task execution (e.g., "fable", "opus", "sonnet", "haiku")
 	ReviewModel                string // model for review phases (falls back to TaskModel if empty)
 	ClaudeErrorPatterns        []string
 	CodexErrorPatterns         []string

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -244,7 +244,7 @@ type ClaudeExecutor struct {
 	Command        string            // command to execute, defaults to "claude"
 	Args           string            // additional arguments (space-separated), defaults to standard args
 	ArgsSet        bool              // true when Args was explicitly set, including an empty value
-	Model          string            // model override (e.g., "opus", "sonnet", "haiku"); empty = CLI default
+	Model          string            // model override (e.g., "fable", "opus", "sonnet", "haiku"); empty = CLI default
 	Effort         string            // reasoning effort override (e.g., "low", "medium", "high", "xhigh", "max"); empty = CLI default
 	OutputHandler  func(text string) // called for each text chunk, can be nil
 	Debug          bool              // enable debug output


### PR DESCRIPTION
## What

Anthropic released a new model class — **Fable** (`claude-fable-5`), a tier above Opus.
Agent frontmatter validation accepted only `haiku`/`sonnet`/`opus`, so `model: fable`
(or a full ID like `claude-fable-5`) in an agent file was silently dropped with a warning.

## Changes

- `pkg/config/frontmatter.go` — add `fable` to `validModels`; update `Validate` warning
  text and `normalizeModel` doc comment
- `pkg/config/frontmatter_test.go` — new cases: `fable` keyword validation and
  `claude-fable-5` full-ID normalization; updated warning expectations
- `pkg/config/defaults/config`, `pkg/config/values.go`, `pkg/executor/executor.go`
  — extend model enumerations in comments
- `README.md`, `CLAUDE.md`, `llms.txt` — document `fable` as an accepted agent model
  keyword; update examples