### PR TITLE
feat: install latest fya in base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,14 @@ RUN npm install -g @anthropic-ai/claude-code @openai/codex && \
     command -v claude >/dev/null || { echo "error: claude CLI not found"; exit 1; } && \
     command -v codex >/dev/null || { echo "error: codex CLI not found"; exit 1; }
 
+# install latest fya (claude print-mode PTY wrapper), usable as an optional claude_command provider
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+    TAG=$(wget -qO- https://api.github.com/repos/umputun/fya/releases/latest | jq -r .tag_name) && \
+    { [ -n "$TAG" ] && [ "$TAG" != "null" ]; } || { echo "error: could not resolve latest fya release"; exit 1; } && \
+    wget -qO- "https://github.com/umputun/fya/releases/download/${TAG}/fya_${TAG#v}_linux_${ARCH}.tar.gz" | \
+        tar -xz -C /usr/local/bin fya && \
+    command -v fya >/dev/null || { echo "error: fya CLI not found"; exit 1; }
+
 # copy ralphex binary
 COPY --from=build /build/ralphex /srv/ralphex
 RUN chmod +x /srv/ralphex

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
     { [ -n "$TAG" ] && [ "$TAG" != "null" ]; } || { echo "error: could not resolve latest fya release"; exit 1; } && \
     wget -qO- "https://github.com/umputun/fya/releases/download/${TAG}/fya_${TAG#v}_linux_${ARCH}.tar.gz" | \
         tar -xz -C /usr/local/bin fya && \
-    command -v fya >/dev/null || { echo "error: fya CLI not found"; exit 1; }
+    fya --version >/dev/null || { echo "error: fya CLI not runnable"; exit 1; }
 
 # copy ralphex binary
 COPY --from=build /build/ralphex /srv/ralphex

--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ Two images are published:
 |------|---------|---------|
 | Claude Code | latest | AI coding assistant |
 | Codex | latest | External code review |
+| fya | latest | Optional claude print-mode wrapper (PTY-backed) |
 | Node.js/npm | 24.x | Required for Claude Code |
 | Python/pip | 3.x | Scripts and automation |
 | git | 2.x | Version control |

--- a/llms.txt
+++ b/llms.txt
@@ -210,7 +210,7 @@ ralphex provides Docker images for isolated execution:
 
 | Image | Contents |
 |-------|----------|
-| `ghcr.io/umputun/ralphex:latest` | Base: Claude Code, Codex, Node.js, Python, git, docker-cli, make, gcc, bash, fzf, ripgrep |
+| `ghcr.io/umputun/ralphex:latest` | Base: Claude Code, Codex, fya, Node.js, Python, git, docker-cli, make, gcc, bash, fzf, ripgrep |
 | `ghcr.io/umputun/ralphex-go:latest` | Go development: base + Go 1.26, golangci-lint, moq, goimports |
 
 **Using Docker wrapper** (requires Python 3.9+):


### PR DESCRIPTION
bundles `fya` (the claude print-mode PTY wrapper, `github.com/umputun/fya`) into the base `ghcr.io/umputun/ralphex` image so it's available out of the box as an optional `claude_command` provider. Previously users installed it themselves (`brew install` or a release binary) before pointing ralphex at it.

the new Dockerfile step resolves the **latest** fya github release at build time (`wget` + `jq`, no pinned version), downloads the static linux binary for the target arch, and drops `fya` on `PATH` at `/usr/local/bin/fya`. It verifies with `command -v fya` and fails the build loudly if the release can't be resolved, the same idiom `Dockerfile-go` already uses for golangci-lint.

fya stays opt-in: it's on `PATH` but not wired as the default executor, so nothing changes unless a user sets `claude_command = fya`. The change propagates to `ralphex-go` automatically (it's `FROM ghcr.io/umputun/ralphex`).

verified with a full local `docker build` of the base image: it builds clean and the resulting image runs `fya v0.3.3` alongside `claude` and `codex`.

docs: added fya to the base-image contents tables in `README.md` and `llms.txt`.
