### PR TITLE
feat: surface the reason when ralphex refuses to run

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -295,7 +295,7 @@ func run(ctx context.Context, o opts) error {
 	// rev-parse --show-toplevel for repo validation instead (pure hg repos have no .git).
 	if cfg.VcsCommand == "" || cfg.VcsCommand == "git" {
 		if _, statErr := os.Stat(".git"); statErr != nil {
-			return errors.New("must run from repository root (no .git directory found)")
+			return errors.New("must run from repository root (no .git directory found); run from the repo root or 'git init' for a new project")
 		}
 	}
 
@@ -393,16 +393,33 @@ func getCurrentBranch(gitSvc *git.Service) string {
 }
 
 // tryAutoPlanMode attempts to switch to plan mode when no plans are found on the default branch.
-// returns (true, nil) if user canceled, (true, err) if plan mode was attempted, or (false, nil) if auto-plan-mode doesn't apply.
+// when no plans are found but auto-plan-mode does not apply, it returns (true, err) with an
+// explanatory error so the user always learns why interactive plan creation was not offered.
+// returns (true, nil) if the user canceled, (true, err) if plan mode was attempted or refused
+// with a reason, or (false, nil) if the selection error is unrelated to missing plans.
 func tryAutoPlanMode(ctx context.Context, err error, o opts, req executePlanRequest,
 	selector *plan.Selector) (bool, error) {
-	if !errors.Is(err, plan.ErrNoPlansFound) || o.Review || o.ExternalOnly || o.CodexOnly || o.TasksOnly {
+	// only a missing-plans error is a candidate for auto-plan-mode; other errors propagate as-is.
+	if !errors.Is(err, plan.ErrNoPlansFound) {
 		return false, nil
 	}
 
+	// interactive plan creation only runs in full execution mode; explain when another mode suppresses it.
+	if o.Review || o.ExternalOnly || o.CodexOnly || o.TasksOnly {
+		return true, fmt.Errorf("interactive plan creation is not available in this mode; provide an existing plan file: %w", err)
+	}
+
 	isDefault, branchErr := req.GitSvc.IsDefaultBranch(req.DefaultBranch)
-	if branchErr != nil || !isDefault {
-		return false, nil //nolint:nilerr // branchErr is intentionally ignored - if we can't get branch, skip auto-plan-mode
+	if branchErr != nil {
+		return true, fmt.Errorf(
+			"cannot offer interactive plan creation: failed to determine current branch (%v); "+
+				"pass a plan file or use --plan: %w", branchErr, err)
+	}
+	if !isDefault {
+		return true, fmt.Errorf(
+			"interactive plan creation is only offered on the default branch %q (currently on %q); "+
+				"switch to %q, pass a plan file, or use --plan: %w",
+			req.DefaultBranch, getCurrentBranch(req.GitSvc), req.DefaultBranch, err)
 	}
 
 	description := plan.PromptDescription(ctx, os.Stdin, req.Colors)
@@ -827,7 +844,7 @@ func checkClaudeDep(cfg *config.Config) error {
 		claudeCmd = "claude"
 	}
 	if _, err := exec.LookPath(claudeCmd); err != nil {
-		return fmt.Errorf("%s not found in PATH", claudeCmd)
+		return fmt.Errorf("%s not found in PATH; install Claude Code or set claude_command in config to a compatible CLI", claudeCmd)
 	}
 	return nil
 }
@@ -841,7 +858,7 @@ func checkCodexDep(cfg *config.Config) error {
 		codexCmd = "codex"
 	}
 	if _, err := exec.LookPath(codexCmd); err != nil {
-		return fmt.Errorf("%s not found in PATH", codexCmd)
+		return fmt.Errorf("%s not found in PATH; install the codex CLI or set codex_command in config", codexCmd)
 	}
 	return nil
 }
@@ -1339,7 +1356,7 @@ func initLocal(configDir string) error {
 	if !hasGit && !hasHg {
 		cfg, loadErr := config.LoadReadOnly(configDir)
 		if loadErr != nil || cfg.VcsCommand == "" || cfg.VcsCommand == "git" {
-			return errors.New("must run from repository root (no .git or .hg directory found)")
+			return errors.New("must run from repository root (no .git or .hg directory found); cd to the repository root before running --init")
 		}
 		// custom VCS backend configured — validate repo root using the backend command
 		if validErr := validateRepoRoot(cfg.VcsCommand); validErr != nil {
@@ -1390,7 +1407,7 @@ func validateRepoRoot(vcsCommand string) error {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}
 	if root != cwd {
-		return fmt.Errorf("not at repository root (root is %s)", root)
+		return fmt.Errorf("not at repository root (root is %s); cd %s and re-run", root, root)
 	}
 	return nil
 }

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -416,10 +416,17 @@ func tryAutoPlanMode(ctx context.Context, err error, o opts, req executePlanRequ
 				"pass a plan file or use --plan: %w", branchErr, err)
 	}
 	if !isDefault {
+		// normalize the default-branch name for display the same way matchesDefaultBranch compares it:
+		// strip the origin/ prefix and fall back to main/master when unset, so the hint names the
+		// local branch the user can actually switch to rather than "origin/main" or an empty string.
+		defaultName := strings.TrimPrefix(req.DefaultBranch, "origin/")
+		if defaultName == "" {
+			defaultName = "main/master"
+		}
 		return true, fmt.Errorf(
 			"interactive plan creation is only offered on the default branch %q (currently on %q); "+
 				"switch to %q, pass a plan file, or use --plan: %w",
-			req.DefaultBranch, getCurrentBranch(req.GitSvc), req.DefaultBranch, err)
+			defaultName, getCurrentBranch(req.GitSvc), defaultName, err)
 	}
 
 	description := plan.PromptDescription(ctx, os.Stdin, req.Colors)
@@ -1407,7 +1414,7 @@ func validateRepoRoot(vcsCommand string) error {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}
 	if root != cwd {
-		return fmt.Errorf("not at repository root (root is %s); cd %s and re-run", root, root)
+		return fmt.Errorf("not at repository root (root is %s); cd %q and re-run", root, root)
 	}
 	return nil
 }

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -451,6 +451,16 @@ func TestTryAutoPlanMode(t *testing.T) {
 		assert.Contains(t, err.Error(), "--plan")
 	})
 
+	t.Run("origin_prefixed_default_branch_is_normalized_for_display", func(t *testing.T) {
+		req, selector := newReq(t, "master")
+		req.DefaultBranch = "origin/main"
+		handled, err := tryAutoPlanMode(t.Context(), plan.ErrNoPlansFound, opts{}, req, selector)
+		assert.True(t, handled)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"main"`, "origin/ prefix stripped for display")
+		assert.NotContains(t, err.Error(), "origin/main", "raw remote-tracking ref not shown to user")
+	})
+
 	t.Run("tasks_only_mode_refuses_with_reason", func(t *testing.T) {
 		req, selector := newReq(t, "master")
 		handled, err := tryAutoPlanMode(t.Context(), plan.ErrNoPlansFound, opts{TasksOnly: true}, req, selector)

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -426,6 +426,48 @@ func TestAutoPlanModeDetection(t *testing.T) {
 	})
 }
 
+func TestTryAutoPlanMode(t *testing.T) {
+	newReq := func(t *testing.T, branch string) (executePlanRequest, *plan.Selector) {
+		t.Helper()
+		dir := setupTestRepo(t)
+		gitSvc, err := git.NewService(dir, testColors().Info())
+		require.NoError(t, err)
+		if branch != "master" {
+			require.NoError(t, gitSvc.CreateBranch(branch))
+		}
+		selector := plan.NewSelector(filepath.Join(dir, "docs", "plans"), testColors())
+		req := executePlanRequest{GitSvc: gitSvc, DefaultBranch: "master", Colors: testColors()}
+		return req, selector
+	}
+
+	t.Run("non_default_branch_refuses_with_reason", func(t *testing.T) {
+		req, selector := newReq(t, "feature-x")
+		handled, err := tryAutoPlanMode(t.Context(), plan.ErrNoPlansFound, opts{}, req, selector)
+		assert.True(t, handled, "missing-plans error on feature branch is handled")
+		require.Error(t, err)
+		require.ErrorIs(t, err, plan.ErrNoPlansFound, "wrapped sentinel preserved for callers")
+		assert.Contains(t, err.Error(), "default branch")
+		assert.Contains(t, err.Error(), "feature-x")
+		assert.Contains(t, err.Error(), "--plan")
+	})
+
+	t.Run("tasks_only_mode_refuses_with_reason", func(t *testing.T) {
+		req, selector := newReq(t, "master")
+		handled, err := tryAutoPlanMode(t.Context(), plan.ErrNoPlansFound, opts{TasksOnly: true}, req, selector)
+		assert.True(t, handled)
+		require.Error(t, err)
+		require.ErrorIs(t, err, plan.ErrNoPlansFound)
+		assert.Contains(t, err.Error(), "not available in this mode")
+	})
+
+	t.Run("unrelated_error_is_not_handled", func(t *testing.T) {
+		req, selector := newReq(t, "master")
+		handled, err := tryAutoPlanMode(t.Context(), errors.New("fzf not found"), opts{}, req, selector)
+		assert.False(t, handled, "non-missing-plans error propagates to caller untouched")
+		require.NoError(t, err)
+	})
+}
+
 func TestCheckClaudeDep(t *testing.T) {
 	t.Run("uses_configured_command", func(t *testing.T) {
 		cfg := &config.Config{ClaudeCommand: "nonexistent-command-12345"}


### PR DESCRIPTION
running ralphex without a plan on a non-default branch used to fail with a bare `select plan: no plans found: docs/plans`, with nothing explaining that interactive plan creation was skipped *because* of the current branch. that was the whole confusion behind "works in an empty repo, refuses in a real project" - empty repos start on the default branch, real projects are usually on a feature branch.

`tryAutoPlanMode` now returns an explanatory error for each suppressed case, still wrapping `ErrNoPlansFound` so callers and existing tests are unaffected:
- **non-default branch**: names the default branch, the current branch, and the three ways out (switch branch, pass a plan file, `--plan`)
- **branch detection failure**: surfaces the underlying git error instead of swallowing it (dropped the `//nolint:nilerr`)
- **review / external / codex / tasks-only modes**: says interactive plan creation is not available in this mode

while in there, added hints to the other terse precondition refusals:
- missing `.git` -> suggests running from repo root or `git init`
- `claude` / `codex` not in PATH -> suggests installing or setting `claude_command` / `codex_command`
- `--init` repo-root checks -> say where to `cd`

left already-clear refusals alone (`--plan` vs plan-file conflict, the non-negative duration checks, the codex mutual-exclusion errors).

added `TestTryAutoPlanMode` covering the non-default-branch and tasks-only refusals plus pass-through of unrelated errors - no claude binary needed since refusals short-circuit before the interactive prompt. `make test` and `make lint` clean.