### PR TITLE
fix: skip 65MB parse test under -race to unhang go test -race ./pkg/web

### DIFF
--- a/pkg/web/race_disabled_test.go
+++ b/pkg/web/race_disabled_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package web
+
+// raceEnabled reports whether the race detector is active in this test build.
+// used to skip tests whose runtime under -race exceeds the test binary timeout.
+const raceEnabled = false

--- a/pkg/web/race_enabled_test.go
+++ b/pkg/web/race_enabled_test.go
@@ -1,0 +1,7 @@
+//go:build race
+
+package web
+
+// raceEnabled reports whether the race detector is active in this test build.
+// used to skip tests whose runtime under -race exceeds the test binary timeout.
+const raceEnabled = true

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -765,6 +765,9 @@ Started: 2026-01-22 10:00:00
 		if testing.Short() {
 			t.Skip("skipping 65MB allocation in short mode")
 		}
+		if raceEnabled {
+			t.Skip("skipping under -race: parsing a 65MB line takes ~90s without the race detector and exceeds the test binary timeout with it")
+		}
 		dir := t.TempDir()
 		path := filepath.Join(dir, "progress-huge.txt")
 


### PR DESCRIPTION
## Problem

`go test -race ./pkg/web` hangs until the 10-minute test binary timeout. The culprit is `TestSessionManager_LoadProgressFileIntoSessionLargeBuffer/handles_lines_larger_than_64MB_(no_limit)` — parsing a single 65MB line through `parseProgressLine` (regexp, full-string `ToLower`, `json.Marshal`, SSE `AppendData`) takes ~90s without the race detector and exceeds the timeout with it. The goroutine dump at panic time points at an idle `feedEvents` select, which is misleading — the actually-running goroutine is the parser grinding through the huge line.

## Fix

Gate the subtest behind a `raceEnabled` constant defined via a `//go:build race` / `//go:build !race` file pair. The subtest still runs in regular (non-race) test runs; the sibling 65MB subtest in `TestParseProgressHeaderLargeBuffer` is untouched since `ParseProgressHeader` stops at the header separator and never reads the huge line.

## Verification

- `go test -race ./pkg/web`: hung before, now completes in ~16s with the subtest skipped
- `go test ./pkg/web` (no `-race`): subtest still runs and passes
- full `go test -race ./...` + `golangci-lint run`: clean