### PR TITLE
fix: bound force-exit cleanup so a stuck worktree removal cannot prevent exit

### DIFF
--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -1463,7 +1463,9 @@ func isResetOnly(o opts) bool {
 
 // startInterruptWatcher prints immediate feedback when context is canceled.
 // if graceful shutdown doesn't complete within 5 seconds, force exits.
-// cleanup, if not nil, is called only on the force-exit (5s timeout) path before os.Exit.
+// cleanup, if not nil, is called only on the force-exit (5s timeout) path before
+// os.Exit; it gets an additional bounded wait (2s, via runCleanupBounded) so a
+// stuck cleanup cannot prevent the exit — worst-case total is ~7s after cancel.
 // returns a cleanup function that must be called (via defer) to prevent goroutine leaks.
 func startInterruptWatcher(ctx context.Context, cleanup func()) func() {
 	done := make(chan struct{})
@@ -1474,9 +1476,7 @@ func startInterruptWatcher(ctx context.Context, cleanup func()) func() {
 			select {
 			case <-time.After(5 * time.Second):
 				fmt.Fprintf(os.Stderr, "force exit\n")
-				if cleanup != nil {
-					cleanup()
-				}
+				runCleanupBounded(cleanup, 2*time.Second)
 				os.Exit(1)
 			case <-done:
 			}
@@ -1484,6 +1484,28 @@ func startInterruptWatcher(ctx context.Context, cleanup func()) func() {
 		}
 	}()
 	return func() { close(done) }
+}
+
+// runCleanupBounded runs cleanup in a separate goroutine and waits for it to
+// finish, but no longer than timeout. this bounds the force-exit path: cleanup
+// shares a sync.Once with the graceful shutdown's deferred worktree cleanup, so
+// when that cleanup is already in flight and stuck (e.g. a hanging git worktree
+// remove), calling it directly would block inside Once.Do forever and os.Exit
+// would never be reached.
+func runCleanupBounded(cleanup func(), timeout time.Duration) {
+	if cleanup == nil {
+		return
+	}
+	doneCh := make(chan struct{})
+	go func() {
+		cleanup()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(timeout):
+		fmt.Fprintf(os.Stderr, "cleanup did not finish in time, exiting anyway\n")
+	}
 }
 
 // applyCLIOverrides applies CLI flag overrides to config.

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -3044,6 +3044,50 @@ func TestMakePauseHandler_EOFAborts(t *testing.T) {
 	assert.False(t, result, "handler should return false on EOF (stdin closed = abort)")
 }
 
+func TestRunCleanupBounded(t *testing.T) {
+	tests := []struct {
+		name        string
+		nilCleanup  bool
+		stuck       bool
+		maxDuration time.Duration
+	}{
+		{name: "nil cleanup returns immediately", nilCleanup: true, maxDuration: 50 * time.Millisecond},
+		{name: "fast cleanup runs to completion", maxDuration: 50 * time.Millisecond},
+		{name: "stuck cleanup returns after timeout instead of blocking forever", stuck: true, maxDuration: 500 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unblock := make(chan struct{})
+			ran := make(chan struct{})
+			defer close(unblock) // release a stuck cleanup goroutine at test end
+
+			var cleanup func()
+			switch {
+			case tt.nilCleanup:
+				cleanup = nil
+			case tt.stuck:
+				cleanup = func() { <-unblock } // models a hung Once.Do (git worktree remove stuck)
+			default:
+				cleanup = func() { close(ran) }
+			}
+
+			start := time.Now()
+			runCleanupBounded(cleanup, 100*time.Millisecond)
+			elapsed := time.Since(start)
+
+			assert.Less(t, elapsed, tt.maxDuration, "runCleanupBounded must not block past its timeout")
+			if !tt.nilCleanup && !tt.stuck {
+				select {
+				case <-ran:
+				default:
+					t.Fatal("cleanup should have run to completion")
+				}
+			}
+		})
+	}
+}
+
 // branchExists checks if a branch exists in the given git repository.
 func branchExists(t *testing.T, dir, branch string) bool {
 	t.Helper()


### PR DESCRIPTION
## Problem

The interrupt watcher's 5s force-exit path (`startInterruptWatcher`) calls the worktree cleanup directly before `os.Exit(1)`. That cleanup shares a `sync.Once` with the graceful shutdown's deferred cleanup in `runWithWorktree`, and `Once.Do` blocks until the first invocation completes. When the deferred cleanup is already in flight and stuck — e.g. `git worktree remove` hanging on a child process still holding the tree — the watcher prints `force exit` and then blocks forever inside `Once.Do`; the promised force exit never happens. This is exactly the scenario the 5s escape hatch exists for.

## Fix

Run the cleanup on the force-exit path through `runCleanupBounded`: execute it in a goroutine and wait at most 2s before proceeding to `os.Exit(1)` regardless (worst-case ~7s after cancel, noted in the function contract). A fast cleanup still completes normally; a stuck one gets a `cleanup did not finish in time, exiting anyway` notice instead of hanging the process.

Covered by a table-driven test for the nil / fast / stuck cleanup cases.