### PR TITLE
fix: preserve wrapper file mode on --update-script

### DIFF
--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -856,8 +856,12 @@ def handle_update_script(script_path: Path) -> int:
         answer = sys.stdin.readline()  # returns "" on EOF, treated as "no"
 
         if answer.strip().lower() == "y":
+            # capture the current mode before copy2 overwrites it with the
+            # tmpfile's restrictive 0600, otherwise the result is 0711 (rwx--x--x)
+            # and the interpreter can't read the script for any non-owner user
+            original_mode = script_path.stat().st_mode
             shutil.copy2(tmp_path, str(script_path))
-            script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            script_path.chmod(original_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
             print("wrapper updated", file=sys.stderr)
         else:
             print("wrapper update skipped", file=sys.stderr)

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -6,6 +6,7 @@ import io
 import os
 import platform
 import shutil
+import stat
 import sys
 import tempfile
 import threading
@@ -43,6 +44,7 @@ from ralphex_dk import (  # noqa: E402
     get_claude_provider,
     get_docker_socket_gid,
     get_global_gitignore,
+    handle_update_script,
     is_docker_enabled,
     is_sensitive_name,
     keychain_service_name,
@@ -1031,6 +1033,38 @@ class TestMainArgparse(EnvTestCase):
             result = main()
         self.assertEqual(len(calls), 1)
         self.assertEqual(result, 0)
+
+    def test_update_script_preserves_readable_mode(self) -> None:
+        """updated wrapper keeps its 0755 mode, not 0711 unreadable by non-owner (issue #397)."""
+        tmp = Path(tempfile.mkdtemp())
+        try:
+            script_path = tmp / "ralphex"
+            script_path.write_text("#!/usr/bin/env python3\n# old\n")
+            script_path.chmod(0o755)
+            new_content = b"#!/usr/bin/env python3\n# new\n"
+
+            class _Resp:
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, *_a):
+                    return False
+
+                def read(self_inner):
+                    return new_content
+
+            with unittest.mock.patch("ralphex_dk.urlopen", return_value=_Resp()), \
+                    unittest.mock.patch("sys.stdin", io.StringIO("y\n")), \
+                    unittest.mock.patch("sys.stderr", io.StringIO()):
+                rc = handle_update_script(script_path)
+
+            self.assertEqual(rc, 0)
+            mode = script_path.stat().st_mode & 0o777
+            self.assertTrue(mode & stat.S_IROTH, f"world-read bit lost, mode={oct(mode)}")
+            self.assertEqual(mode, 0o755, f"expected 0755 preserved, got {oct(mode)}")
+            self.assertEqual(script_path.read_text(), new_content.decode())
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_env_flags_build_cli_env(self) -> None:
         """CLI -E/--env flags are converted to docker -e flags."""


### PR DESCRIPTION
`ralphex-dk.sh --update-script` left the wrapper at mode `0711` (`rwx--x--x`), execute-only for group/other. The wrapper is a Python script, so the interpreter must read it to run. After an update, any non-owner user (e.g. a root-owned `/usr/local/bin/ralphex` updated via `sudo`) got `Permission denied`.

Cause: `shutil.copy2` copies the `mkstemp` tempfile's `0600` onto the destination, then the following `chmod` only OR-ed in execute bits, giving `0600 | 0111 = 0711`.

Fix: capture the original mode before `copy2` and restore it (still OR-ing exec bits), so the file keeps its `0755`.

Adds a regression test that drives the real update path and asserts the result stays group/other-readable. The full wrapper suite (233 tests) passes.

Related to #397
