### PR TITLE
fix: skip regenerable plugin-manager state when seeding container

### DIFF
--- a/scripts/internal/init-docker.sh
+++ b/scripts/internal/init-docker.sh
@@ -2,6 +2,30 @@
 # init script for ralphex docker container
 # baseimage runs /srv/init.sh if it exists before the main command
 
+# seed_claude_plugins copies installed plugin state from $1 into $2 while skipping
+# regenerable plugin-manager state (marketplace git clones, repos, catalog caches). the
+# ephemeral container never runs /plugin install, so that state is dead weight, and copying
+# the marketplaces' thousands of vendored files over a macos bind mount costs
+# seconds-to-a-minute per run (see #376). cache is kept: it holds installed plugins' runtime
+# code (installed_plugins.json installPaths point into it), so dropping it would break
+# plugin skills/agents in the container.
+seed_claude_plugins() {
+    src="$1"
+    dest="$2"
+    [ -d "$src" ] || return 0
+    mkdir -p "$dest"
+    for entry in "$src"/*; do
+        [ -e "$entry" ] || continue
+        case "$(basename "$entry")" in
+            marketplaces|repos|plugin-catalog-cache.json|known_marketplaces.json) continue ;;
+        esac
+        cp -rL "$entry" "$dest"/ 2>/dev/null || true
+    done
+}
+
+# when sourced by the test harness (INIT_DOCKER_SOURCE_ONLY set) expose the functions only
+[ -n "${INIT_DOCKER_SOURCE_ONLY:-}" ] && return 0
+
 # copy only essential claude files (not the entire 2GB directory)
 if [ -d /mnt/claude ]; then
     mkdir -p /home/app/.claude
@@ -10,9 +34,10 @@ if [ -d /mnt/claude ]; then
         [ -e "/mnt/claude/$f" ] && cp -L "/mnt/claude/$f" "/home/app/.claude/$f" 2>/dev/null || true
     done
     # copy essential directories (symlinked in dotfiles setups)
-    for d in commands skills hooks agents plugins; do
+    for d in commands skills hooks agents; do
         [ -d "/mnt/claude/$d" ] && cp -rL "/mnt/claude/$d" "/home/app/.claude/" 2>/dev/null || true
     done
+    seed_claude_plugins /mnt/claude/plugins /home/app/.claude/plugins
     chown -R app:app /home/app/.claude
 fi
 

--- a/scripts/internal/init-docker_test.sh
+++ b/scripts/internal/init-docker_test.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# tests for seed_claude_plugins in init-docker.sh (see #376): keep installed plugin
+# runtime code (cache) and small state, skip regenerable plugin-manager state.
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+
+# source the script for its functions only; the guard stops it before the main body runs
+# shellcheck source=scripts/internal/init-docker.sh
+INIT_DOCKER_SOURCE_ONLY=1 . "$script_dir/init-docker.sh"
+
+fail=0
+assert() {  # $1 = description; rest = command expected to SUCCEED
+    desc="$1"; shift
+    if "$@"; then echo "ok   - $desc"; else echo "FAIL - $desc"; fail=1; fi
+}
+assert_not() {  # $1 = description; rest = command expected to FAIL
+    desc="$1"; shift
+    if "$@"; then echo "FAIL - $desc"; fail=1; else echo "ok   - $desc"; fi
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/init-docker-test.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+
+src="$work/src/plugins"
+dest="$work/dest/plugins"
+mkdir -p "$src/marketplaces/ralphex/vendor" "$src/cache/ralphex/ralphex/0.20.0" "$src/repos" "$src/data"
+printf '{}' > "$src/config.json"
+printf '{}' > "$src/installed_plugins.json"
+printf '{}' > "$src/known_marketplaces.json"
+printf '{}' > "$src/plugin-catalog-cache.json"
+printf '{}' > "$src/blocklist.json"
+printf 'runtime-code' > "$src/cache/ralphex/ralphex/0.20.0/skill.md"
+printf 'vendored-go' > "$src/marketplaces/ralphex/vendor/big.go"
+
+seed_claude_plugins "$src" "$dest"
+
+# kept: installed plugin runtime code plus the small state files
+assert     "keeps cache runtime code"        test -f "$dest/cache/ralphex/ralphex/0.20.0/skill.md"
+assert     "keeps config.json"               test -f "$dest/config.json"
+assert     "keeps installed_plugins.json"    test -f "$dest/installed_plugins.json"
+assert     "keeps blocklist.json"            test -f "$dest/blocklist.json"
+assert     "keeps data dir"                  test -d "$dest/data"
+# dropped: regenerable plugin-manager state
+assert_not "drops marketplaces clone"        test -e "$dest/marketplaces"
+assert_not "drops repos"                     test -e "$dest/repos"
+assert_not "drops plugin-catalog-cache.json" test -e "$dest/plugin-catalog-cache.json"
+assert_not "drops known_marketplaces.json"   test -e "$dest/known_marketplaces.json"
+
+# no-op when the source plugins dir is absent (no dest created)
+seed_claude_plugins "$work/absent" "$work/dest2"
+assert_not "no-op when source absent"        test -e "$work/dest2"
+
+if [ "$fail" = 0 ]; then echo "PASS"; else echo "FAILURES"; exit 1; fi


### PR DESCRIPTION
The container init script (`/srv/init.sh`, from `init-docker.sh`) seeded `~/.claude/plugins` wholesale, including `plugins/marketplaces` (git clones with vendored Go source, ~356MB) and the catalog-cache JSONs. The ephemeral `docker run --rm` container never runs `/plugin install`, so that state is dead weight, and copying its thousands of tiny files over a macOS bind mount adds seconds-to-a-minute per run (#376).

Seed plugins selectively instead: keep `cache/` (installed plugins' runtime code, referenced by `installed_plugins.json` installPaths) plus the small state files, and skip `marketplaces`, `repos`, `plugin-catalog-cache.json`, and `known_marketplaces.json`. The exclusion happens at copy time, so the marketplace files are never read over the slow mount.

Extracts the copy into `seed_claude_plugins()` with a source guard so the new `scripts/internal/init-docker_test.sh` exercises the real function. Verified with shellcheck, and the test passes under `sh` and `dash`.

Keeps `cache`, so installed plugin skills/agents still work in the container. This is the safe subset of #376. The reporter's proposed default of also skipping `cache` would break installed plugins, since that's where their runtime code lives.

Related to #376
