### PR TITLE
fix: instruct default prompts to run long test commands in the foreground

### DIFF
--- a/pkg/config/defaults/prompts/finalize.txt
+++ b/pkg/config/defaults/prompts/finalize.txt
@@ -32,6 +32,7 @@ Steps:
 5. Verify the branch is ready:
    - Run tests using the project's test command (check CLAUDE.md or plan file for the correct command)
    - Run linter if applicable
+   - Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
 
 Report what was done. This step is best-effort - if rebase fails, explain why and the branch remains as-is.
 

--- a/pkg/config/defaults/prompts/finalize.txt
+++ b/pkg/config/defaults/prompts/finalize.txt
@@ -32,7 +32,7 @@ Steps:
 5. Verify the branch is ready:
    - Run tests using the project's test command (check CLAUDE.md or plan file for the correct command)
    - Run linter if applicable
-   - Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
+   - Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs headless one-shot and does not resume.
 
 Report what was done. This step is best-effort - if rebase fails, explain why and the branch remains as-is.
 

--- a/pkg/config/defaults/prompts/review_first.txt
+++ b/pkg/config/defaults/prompts/review_first.txt
@@ -64,7 +64,7 @@ Do NOT reject issues just because they existed before this branch - fix them any
 
 ### 3.3 Fix All Confirmed Issues
 1. Fix all CONFIRMED issues (all types: bugs, tests, smells, docs, etc.)
-2. Run tests and linter to verify fixes - ALL tests must pass, ALL linter issues resolved. Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
+2. Run tests and linter to verify fixes - ALL tests must pass, ALL linter issues resolved. Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs headless one-shot and does not resume.
 3. Commit fixes: `git commit -m "fix: address code review findings"`
 
 ## Step 4: Signal Completion

--- a/pkg/config/defaults/prompts/review_first.txt
+++ b/pkg/config/defaults/prompts/review_first.txt
@@ -64,7 +64,7 @@ Do NOT reject issues just because they existed before this branch - fix them any
 
 ### 3.3 Fix All Confirmed Issues
 1. Fix all CONFIRMED issues (all types: bugs, tests, smells, docs, etc.)
-2. Run tests and linter to verify fixes - ALL tests must pass, ALL linter issues resolved
+2. Run tests and linter to verify fixes - ALL tests must pass, ALL linter issues resolved. Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
 3. Commit fixes: `git commit -m "fix: address code review findings"`
 
 ## Step 4: Signal Completion

--- a/pkg/config/defaults/prompts/review_second.txt
+++ b/pkg/config/defaults/prompts/review_second.txt
@@ -63,7 +63,7 @@ Path A - NO issues found in this iteration:
 
 Path B - Issues found AND fixed:
 1. Fix verified critical/major issues only
-2. Run tests and linter - ALL tests must pass, ALL linter issues resolved. Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
+2. Run tests and linter - ALL tests must pass, ALL linter issues resolved. Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs headless one-shot and does not resume.
 3. Commit fixes: `git commit -m "fix: address code review findings"`
 4. STOP HERE. Do NOT output any signal. Do NOT output REVIEW_DONE.
    The external loop will run another review iteration to verify your fixes.

--- a/pkg/config/defaults/prompts/review_second.txt
+++ b/pkg/config/defaults/prompts/review_second.txt
@@ -63,7 +63,7 @@ Path A - NO issues found in this iteration:
 
 Path B - Issues found AND fixed:
 1. Fix verified critical/major issues only
-2. Run tests and linter - ALL tests must pass, ALL linter issues resolved
+2. Run tests and linter - ALL tests must pass, ALL linter issues resolved. Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
 3. Commit fixes: `git commit -m "fix: address code review findings"`
 4. STOP HERE. Do NOT output any signal. Do NOT output REVIEW_DONE.
    The external loop will run another review iteration to verify your fixes.

--- a/pkg/config/defaults/prompts/task.txt
+++ b/pkg/config/defaults/prompts/task.txt
@@ -34,7 +34,7 @@ STEP 1 - IMPLEMENT:
 
 STEP 2 - VALIDATE:
 - Run the test and lint commands specified in the plan (e.g., "cargo test", "go test ./...", etc.)
-- Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
+- Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs headless one-shot and does not resume.
 - Fix any failures, repeat until all validation passes
 
 STEP 3 - COMPLETE (after validation passes):

--- a/pkg/config/defaults/prompts/task.txt
+++ b/pkg/config/defaults/prompts/task.txt
@@ -34,6 +34,7 @@ STEP 1 - IMPLEMENT:
 
 STEP 2 - VALIDATE:
 - Run the test and lint commands specified in the plan (e.g., "cargo test", "go test ./...", etc.)
+- Run tests and any long-running commands in the foreground and wait for them to finish in this turn. Do not run them in the background or end your turn expecting to resume at a scheduled wakeup - this session runs claude headless (claude -p) and does not resume.
 - Fix any failures, repeat until all validation passes
 
 STEP 3 - COMPLETE (after validation passes):


### PR DESCRIPTION
## Summary

Wires the foreground-execution guidance from #398 into the four default prompt files at the exact points where they run tests / long commands:

- `pkg/config/defaults/prompts/finalize.txt` - Step 5 (Verify the branch is ready)
- `pkg/config/defaults/prompts/task.txt` - STEP 2 - VALIDATE
- `pkg/config/defaults/prompts/review_first.txt` - Step 3.3 (Fix All Confirmed Issues)
- `pkg/config/defaults/prompts/review_second.txt` - Path B (Issues found AND fixed)

Prompt text only, no Go changes. The embedded FS picks up the edited files at build time, and no markdown formatting is introduced (each file's OUTPUT FORMAT rule). `go build ./...` and `go test ./pkg/config/...` pass.

## Why this matters

ralphex drives the coding-agent CLI in headless, one-shot `-p` mode. Newer CLI behavior can push a long-running command (a full test suite) into the background, end the turn, and expect a scheduled wakeup to resume and collect results. Under one-shot `-p` there is no resume: the process exits, the backgrounded tests die with it, and ralphex sees the turn end and marks the step complete. The reporter's `finalize` log in #398 shows exactly this - the suite is started in the background, "waiting for the scheduled wakeup" lines follow, and "all phases completed successfully" is reported without the tests ever finishing.

In https://github.com/umputun/ralphex/issues/398#issuecomment-4950080427 you confirmed the mechanism and identified the practical fix as prompt-side - instruct the agent to run long verification commands in the foreground and block until they finish in the same turn - and named the exact files (`finalize.txt` step 5, `task.txt`, and the review prompts). This uses wording close to what you proposed.

You framed folding this into the defaults as conditional on the reporter confirming the fix holds. This is the exact guidance you proposed, wired into the four files you named - feel free to hold it until that confirmation if you'd prefer.

Closes #398

AI was used for assistance.
