### PR TITLE
fix: refresh claude and codex at container start (opt-in)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,20 @@ Key functions in `scripts/ralphex-dk.sh`:
 
 `--network MODE` flag (or `RALPHEX_DOCKER_NETWORK`) passes `--network <value>` to `docker run` — lets the container reach docker-compose services on localhost.
 
+### CLI Refresh at Container Start
+
+The Dockerfile installs claude/codex unpinned, so a published tag freezes both at whatever npm served on that build (#410). Since they ship far more often than ralphex is tagged, a stale image silently resolves a short model alias (`sonnet`) to an older model rather than failing. Claude's own updater cannot apply here: npm installs it root-owned under `/usr/local/lib/node_modules` and the container runs as `app`, so the check only prints a startup notice — hence `ENV DISABLE_AUTOUPDATER=1` in the Dockerfile. The refresh is opt-in (`RALPHEX_CLI_UPDATE`): the base `ralphex` image leaves it off so authors building on it get no surprise npm install, network call, or version drift at start; `Dockerfile-go` bakes `ENV RALPHEX_CLI_UPDATE=1` so the wrapper's default image (`ralphex-go`) stays current.
+
+`update_cli_tools()` in `scripts/internal/init-docker.sh` runs `npm install -g @anthropic-ai/claude-code@latest @openai/codex@latest` at start when the refresh is enabled, as root, before baseimage drops to `app`. Usually ~5s, bounded by `CLI_UPDATE_TIMEOUT` (90s) plus `--fetch-timeout=20000 --fetch-retries=1` — npm's own defaults (300s fetch-timeout, 2 retries) would let a black-holed registry stall every start for minutes. Best effort by design: install failure or deadline leaves the baked versions in place and returns 0. npm exit 0 does not imply working CLIs, so both are smoke-checked via `cli_version()` (bounded by `CLI_SMOKE_TIMEOUT`, 20s); the install replaces the baked packages in place, leaving no fallback, so a broken or hung CLI is reported loudly (pointing at re-running without `RALPHEX_CLI_UPDATE`) rather than failing later unexplained.
+
+Every `timeout` here passes `-k "$CLI_KILL_GRACE"`. Busybox `timeout` sends only SIGTERM by default, and a process ignoring it runs to completion **and exits 0** — so a bare `timeout` would neither bind the deadline nor report the overrun as a failure.
+
+`run_cli_install()` and `cli_version()` exist as stub seams: both wrap a `timeout` that execs a real binary, so a shell-function `npm`/`claude` stub would not intercept and the suite would install for real on the test machine. `cli_update_enabled()` gates on `RALPHEX_CLI_UPDATE` (opt-in, off by default; truthy `1`/`true`/`yes`), lowercasing and stripping whitespace to match `is_docker_enabled()` in `scripts/ralphex-dk.sh`. `build_base_env_vars()` there forwards a host-set `RALPHEX_CLI_UPDATE` into the container; when unset it forwards nothing, leaving the image's own default in charge (off for base, on for `ralphex-go`). The `--help` path pins `RALPHEX_CLI_UPDATE=0` on its own `docker run`, overriding a forwarded opt-in or the baked go-image default: the entrypoint is `/init.sh` and runs `/srv/init.sh` whatever command it is given, so rendering help would otherwise trigger the install.
+
+Exercised by `scripts/internal/init-docker_test.sh` via the `INIT_DOCKER_SOURCE_ONLY` guard — run it by hand (`sh scripts/internal/init-docker_test.sh`), no CI job or make target invokes it. `CLI_UPDATE_LOG` exists so that suite does not write to the caller's real `/tmp`.
+
+Known trade-off (applies only when enabled): this pulls `@latest` as root on every start, after the credential/workspace mounts are attached, so an upstream compromise executes npm lifecycle scripts with those mounts present (build-time installs had no user mounts). Off-by-default in the base image keeps that exposure opt-in. `--ignore-scripts` is not an option — claude-code's postinstall fetches its native binary, so the CLI is unusable without it.
+
 ### Git Package API
 
 Single public entry point: `git.NewService(path, logger, vcsCmd...) (*Service, error)`

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ ENV USE_BUILTIN_RIPGREP=0
 # mark container environment for ralphex (used to auto-disable codex sandbox)
 ENV RALPHEX_DOCKER=1
 
+# claude's own updater can never apply here: npm installs it root-owned and the container runs as
+# app, so the check only prints a startup notice and changes nothing. disable it; init.sh can refresh
+# both CLIs as root when RALPHEX_CLI_UPDATE is set, which this base image leaves off by default.
+ENV DISABLE_AUTOUPDATER=1
+
 # install claude code and codex globally, verify CLI commands exist
 RUN npm install -g @anthropic-ai/claude-code @openai/codex && \
     command -v claude >/dev/null || { echo "error: claude CLI not found"; exit 1; } && \

--- a/Dockerfile-go
+++ b/Dockerfile-go
@@ -4,6 +4,12 @@ FROM ghcr.io/umputun/ralphex:${BASE_TAG}
 
 LABEL org.opencontainers.image.description="Autonomous plan execution with Claude Code - Go development"
 
+# opt this image into the claude/codex refresh at container start. ralphex-go is the wrapper's
+# default image, so the common path stays current even when this tag is weeks old (see #410); the
+# base ralphex image leaves this off so downstream authors decide. override per run with
+# RALPHEX_CLI_UPDATE=0.
+ENV RALPHEX_CLI_UPDATE=1
+
 # install latest go from official distribution
 ARG GO_VERSION=1.26.1
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \

--- a/README.md
+++ b/README.md
@@ -433,8 +433,28 @@ Then use `ralphex` as usual - it runs in a container with Claude Code and Codex 
 - `RALPHEX_EXTRA_ENV` - Extra environment variables, comma-separated (e.g., `DEBUG=1,API_KEY`). Format: `VAR=value` or `VAR` (inherit from host). Security warning emitted for sensitive names (KEY, SECRET, TOKEN, etc.) with explicit values - use name-only form for secure credential passing
 - `RALPHEX_DOCKER_SOCKET` - Enable Docker socket mount: `1`, `true`, or `yes` (Docker wrapper only). CLI flag: `--docker`
 - `RALPHEX_DOCKER_NETWORK` - Docker network mode (e.g., `host`, `my-network`). Useful for reaching docker-compose services. CLI flag: `--network`
+- `RALPHEX_CLI_UPDATE` - Refresh claude/codex to their current npm releases at container start: `1`, `true`, or `yes` (Docker images only). Off by default in the base image; baked on in `ralphex-go`
 - `TZ` - Override container timezone (default: auto-detected from host via `/etc/localtime`). Example: `TZ=Europe/Berlin ralphex docs/plans/feature.md`
 - `RALPHEX_CLAUDE_PROVIDER` - Claude provider mode: `default` or `bedrock` (Docker wrapper only)
+
+**CLI freshness in the container:**
+
+The image installs claude and codex unpinned, so a published tag freezes them at whatever npm served on that build. Both ship far more often than ralphex is tagged, and a stale claude fails silently rather than loudly: a short model alias like `sonnet` resolves to whatever that build knew about, so `--task-model=sonnet` can quietly run an older model. Claude's own updater cannot help here, since npm installs it root-owned and the container runs as the `app` user.
+
+Setting `RALPHEX_CLI_UPDATE=1` refreshes both CLIs to their current npm releases on start, before dropping privileges. It usually adds about 5 seconds and is capped by a 90 second deadline. Best effort: if npm fails or the deadline is hit, the versions baked into the image are used and the run continues. If the install succeeds but a CLI does not run, the container says so rather than failing later without explanation.
+
+The base `ralphex` image leaves this **off** so anyone building on it gets no surprise npm install, network call, or version drift at container start. The `ralphex-go` image (the wrapper's default) bakes it **on**, so the common path stays current. Enable it yourself for a single run:
+
+```bash
+RALPHEX_CLI_UPDATE=1 ralphex docs/plans/feature.md
+```
+
+Or bake it into a custom image so every run refreshes:
+
+```dockerfile
+FROM ghcr.io/umputun/ralphex:latest
+ENV RALPHEX_CLI_UPDATE=1
+```
 
 **Docker socket support:**
 
@@ -589,6 +609,8 @@ ENV CARGO_HOME=/home/app/.cargo PATH="${PATH}:${CARGO_HOME}/bin"
 RUN apk add --no-cache openjdk21-jdk
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH="${PATH}:${JAVA_HOME}/bin"
 ```
+
+Add `ENV RALPHEX_CLI_UPDATE=1` to your image if you want it to refresh claude/codex to the latest npm release on every container start, the way `ralphex-go` does. The base image leaves it off.
 
 Build and use:
 ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -236,8 +236,15 @@ ralphex --dry-run docs/plans/feature.md
 - `RALPHEX_EXTRA_ENV` - Extra environment variables, comma-separated. Format: `VAR=value` or `VAR` (inherit from host). Warns when sensitive names (KEY, SECRET, TOKEN, etc.) have explicit values - use name-only form for secure credential passing. CLI flag: `-E`/`--env` (uppercase E to avoid conflict with ralphex's `-e`/`--external-only`)
 - `RALPHEX_DOCKER_SOCKET` - Enable Docker socket mount: `1`, `true`, or `yes` (Docker wrapper only). CLI flag: `--docker`
 - `RALPHEX_DOCKER_NETWORK` - Docker network mode (e.g., `host`, `my-network`). CLI flag: `--network`
+- `RALPHEX_CLI_UPDATE` - Refresh claude/codex to their current npm releases at container start: `1`, `true`, or `yes` (Docker images only). Off by default in the base image; baked on in `ralphex-go`
 - `TZ` - Override container timezone (default: auto-detected from host)
 - `RALPHEX_CLAUDE_PROVIDER` - Claude provider mode: `default` or `bedrock` (Docker wrapper only)
+
+**CLI freshness in the container:**
+
+The image installs claude and codex unpinned, so a published tag freezes them at whatever npm served on that build. Both ship far more often than ralphex is tagged, and a stale claude fails silently rather than loudly: a short model alias like `sonnet` resolves to whatever that build knew about, so `--task-model=sonnet` can quietly run an older model. Claude's own updater cannot fix this here, since npm installs it root-owned and the container runs as the `app` user.
+
+When `RALPHEX_CLI_UPDATE` is set (case-insensitive `1`/`true`/`yes`), `/srv/init.sh` refreshes both CLIs to their current npm releases at container start, as root, before dropping privileges. It usually costs about 5 seconds and is capped by a 90 second deadline. Best effort: if npm fails or the deadline is hit, the versions baked into the image are used and the run continues; if the install succeeds but a CLI does not run, the container reports it. The base `ralphex` image leaves it off so downstream images get no surprise npm install, network call, or version drift at start; the `ralphex-go` image (the wrapper's default) bakes it on so the common path stays current. Enable it per run with `RALPHEX_CLI_UPDATE=1 ralphex ...`, or bake `ENV RALPHEX_CLI_UPDATE=1` into a custom image.
 
 **Docker socket support** (Docker wrapper only):
 

--- a/scripts/internal/init-docker.sh
+++ b/scripts/internal/init-docker.sh
@@ -23,8 +23,91 @@ seed_claude_plugins() {
     done
 }
 
+# cli_update_enabled reports whether claude/codex should be refreshed before the run. off by default
+# so the base image stays quiet: authors building on it get no surprise npm install, network call, or
+# version drift at container start. the image installs both CLIs unpinned, so a published tag freezes
+# them at whatever npm served on that build, and both ship far more often than ralphex is tagged (see
+# #410). a stale claude does not fail loudly, it resolves a short model alias like `sonnet` to an
+# older model. opt in with RALPHEX_CLI_UPDATE=1: our ralphex-go image bakes it in, custom images add
+# `ENV RALPHEX_CLI_UPDATE=1`, or set it per run via the wrapper.
+cli_update_enabled() {
+    # same truthy set and case-insensitivity as is_docker_enabled() in scripts/ralphex-dk.sh
+    val=$(printf '%s' "${RALPHEX_CLI_UPDATE:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+    case "$val" in
+        1|true|yes) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# hard deadline for the whole refresh. npm's own defaults are far too slow to rely on here
+# (fetch-timeout 300s, 2 retries), so a black-holed registry would stall every container start for
+# minutes. the bounded npm settings keep a single attempt short; the timeout caps the total.
+CLI_UPDATE_TIMEOUT=${CLI_UPDATE_TIMEOUT:-90}
+
+# deadline for a single `<cli> --version` smoke check
+CLI_SMOKE_TIMEOUT=${CLI_SMOKE_TIMEOUT:-20}
+
+# grace before SIGKILL. busybox timeout only sends SIGTERM by default, and a process that ignores it
+# runs to completion *and reports success* — so without -k neither deadline above actually binds.
+CLI_KILL_GRACE=${CLI_KILL_GRACE:-10}
+
+# overridable so tests do not write to the caller's real /tmp
+CLI_UPDATE_LOG=${CLI_UPDATE_LOG:-/tmp/cli-update.log}
+CLI_VERSION_FILE=${CLI_VERSION_FILE:-/tmp/cli-version.txt}
+
+# update_cli_tools refreshes claude and codex to their current npm releases. best effort by design:
+# on failure (offline, registry down, deadline hit) the image's baked versions stay in place and the
+# run continues. runs as root, before baseimage drops to the app user, because the npm global dir is
+# root-owned.
+# run_cli_install performs the install itself, kept separate so tests can stub it: `timeout` execs a
+# real binary, so a shell-function npm stub would not intercept and the suite would install for real.
+run_cli_install() {
+    timeout -k "$CLI_KILL_GRACE" "$CLI_UPDATE_TIMEOUT" npm install -g \
+        --fetch-timeout=20000 --fetch-retries=1 \
+        @anthropic-ai/claude-code@latest @openai/codex@latest >"$CLI_UPDATE_LOG" 2>&1
+}
+
+# cli_version prints $1's version, or nothing if it fails or hangs. same stub-seam reason as
+# run_cli_install: timeout execs a real binary, so a shell-function stub would not intercept.
+#
+# the version goes through a file rather than straight up the caller's command substitution: timeout
+# kills the CLI, but a child it spawned inherits the substitution's pipe and keeps it open, so $()
+# would block on the grandchild long past the deadline (measured: 30s against a 2s deadline).
+cli_version() {
+    if timeout -k "$CLI_KILL_GRACE" "$CLI_SMOKE_TIMEOUT" "$1" --version >"$CLI_VERSION_FILE" 2>/dev/null; then
+        cat "$CLI_VERSION_FILE" 2>/dev/null
+    fi
+}
+
+update_cli_tools() {
+    cli_update_enabled || return 0
+    if ! run_cli_install; then
+        # report why: the fallback is a silently older claude, which is the failure this whole step
+        # exists to prevent, and the log dies with the container
+        echo "ralphex: cli update failed, using versions baked into the image"
+        tail -3 "$CLI_UPDATE_LOG" 2>/dev/null | sed 's/^/ralphex:   /'
+        return 0
+    fi
+    # npm exiting 0 only means the install completed, not that either CLI runs. the install replaced
+    # the baked packages in place, so there is no fallback left to return to: say so loudly rather
+    # than let the run fail later with no hint of the cause. empty means missing, broken, or hung.
+    claude_ver=$(cli_version claude)
+    codex_ver=$(cli_version codex)
+    if [ -z "$claude_ver" ]; then
+        echo "ralphex: claude is broken after the update - re-run without RALPHEX_CLI_UPDATE to use the baked versions" >&2
+        return 0
+    fi
+    if [ -z "$codex_ver" ]; then
+        echo "ralphex: codex is broken after the update - re-run without RALPHEX_CLI_UPDATE to use the baked versions" >&2
+        return 0
+    fi
+    echo "ralphex: cli updated, claude $claude_ver, codex $codex_ver"
+}
+
 # when sourced by the test harness (INIT_DOCKER_SOURCE_ONLY set) expose the functions only
 [ -n "${INIT_DOCKER_SOURCE_ONLY:-}" ] && return 0
+
+update_cli_tools
 
 # copy only essential claude files (not the entire 2GB directory)
 if [ -d /mnt/claude ]; then

--- a/scripts/internal/init-docker_test.sh
+++ b/scripts/internal/init-docker_test.sh
@@ -17,6 +17,12 @@ assert_not() {  # $1 = description; rest = command expected to FAIL
     desc="$1"; shift
     if "$@"; then echo "FAIL - $desc"; fail=1; else echo "ok   - $desc"; fi
 }
+assert_contains() {  # $1 = description; $2 = haystack; $3 = needle
+    case "$2" in
+        *"$3"*) echo "ok   - $1" ;;
+        *) echo "FAIL - $1 (no '$3' in '$2')"; fail=1 ;;
+    esac
+}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/init-docker-test.XXXXXX")
 trap 'rm -rf "$work"' EXIT
@@ -49,5 +55,73 @@ assert_not "drops known_marketplaces.json"   test -e "$dest/known_marketplaces.j
 # no-op when the source plugins dir is absent (no dest created)
 seed_claude_plugins "$work/absent" "$work/dest2"
 assert_not "no-op when source absent"        test -e "$work/dest2"
+
+# cli update gating (#410): off by default so the base image stays quiet, on for the documented
+# opt-in values
+unset RALPHEX_CLI_UPDATE
+assert_not "cli update off when unset"        cli_update_enabled
+RALPHEX_CLI_UPDATE="" assert_not "cli update off when empty" cli_update_enabled
+RALPHEX_CLI_UPDATE=1 assert "cli update on for 1"          cli_update_enabled
+RALPHEX_CLI_UPDATE=true assert "cli update on for true"    cli_update_enabled
+RALPHEX_CLI_UPDATE=yes assert "cli update on for yes"      cli_update_enabled
+RALPHEX_CLI_UPDATE=0 assert_not "cli update off for 0"     cli_update_enabled
+# case and whitespace tolerance, matching is_docker_enabled() in scripts/ralphex-dk.sh
+RALPHEX_CLI_UPDATE=TRUE assert "cli update on for TRUE"    cli_update_enabled
+RALPHEX_CLI_UPDATE=Yes assert "cli update on for Yes"      cli_update_enabled
+RALPHEX_CLI_UPDATE=" 1 " assert "cli update on for padded 1" cli_update_enabled
+RALPHEX_CLI_UPDATE=maybe assert_not "cli update off for unknown value" cli_update_enabled
+
+# update_cli_tools is best effort: a failing install must not fail the run, and must say so.
+# run_cli_install is stubbed rather than npm itself — it wraps npm in `timeout`, which execs a real
+# binary and would bypass a shell-function npm stub, installing for real on the test machine.
+# keep these inside the test workdir; the defaults are the caller's real /tmp
+CLI_UPDATE_LOG="$work/cli-update.log"
+CLI_VERSION_FILE="$work/cli-version.txt"
+# these tests exercise the install path, so opt in for the duration
+RALPHEX_CLI_UPDATE=1; export RALPHEX_CLI_UPDATE
+printf 'npm error boom\n' > "$CLI_UPDATE_LOG"
+run_cli_install() { return 1; }
+quiet_update() { update_cli_tools >/dev/null 2>&1; }
+out=$(update_cli_tools 2>&1)
+assert     "install failure does not abort"  quiet_update
+assert_contains "install failure is reported" "$out" "update failed"
+assert_contains "install failure says why"   "$out" "npm error boom"
+
+# install succeeds but a CLI is broken or hangs: cli_version yields nothing for it. must not claim
+# success, must name the opt-out, must not abort
+run_cli_install() { return 0; }
+cli_version() { case "$1" in claude) return 0 ;; codex) echo "codex-cli 9.9.9" ;; esac; }
+out=$(update_cli_tools 2>&1)
+assert     "broken cli does not abort"       quiet_update
+assert_contains "broken cli is reported"     "$out" "claude is broken"
+assert_contains "broken cli names the toggle" "$out" "RALPHEX_CLI_UPDATE"
+case "$out" in *"cli updated"*) echo "FAIL - broken cli must not claim success"; fail=1 ;; *) echo "ok   - broken cli must not claim success" ;; esac
+
+# a broken codex is caught too, not just claude
+cli_version() { case "$1" in claude) echo "2.1.212 (Claude Code)" ;; codex) return 0 ;; esac; }
+out=$(update_cli_tools 2>&1)
+assert_contains "broken codex is reported"   "$out" "codex is broken"
+
+# both CLIs healthy: reports the resulting versions
+cli_version() { case "$1" in claude) echo "2.1.212 (Claude Code)" ;; codex) echo "codex-cli 9.9.9" ;; esac; }
+out=$(update_cli_tools 2>&1)
+assert_contains "healthy update reports claude" "$out" "2.1.212"
+assert_contains "healthy update reports codex"  "$out" "9.9.9"
+
+# disabled (the default) short-circuits before the install runs at all
+run_cli_install() { echo "install must not run"; return 0; }
+out=$(RALPHEX_CLI_UPDATE=0 update_cli_tools 2>&1)
+assert     "disabled skips install entirely" test -z "$out"
+unset -f run_cli_install cli_version
+
+# run_cli_install and cli_version are stubbed everywhere above, so assert the real commands against
+# the source: a typo in a package spec would silently install nothing useful, and busybox timeout
+# without -k neither kills a SIGTERM-ignoring child nor reports its overrun as a failure
+src=$(cat "$script_dir/init-docker.sh")
+assert_contains "installs claude-code@latest" "$src" "@anthropic-ai/claude-code@latest"
+assert_contains "installs codex@latest"       "$src" "@openai/codex@latest"
+# both timeouts must force a kill; a bare `timeout` lets a SIGTERM-ignoring child overrun and still
+# reports success, so neither deadline would bind
+assert "both deadlines force kill" test "$(printf '%s\n' "$src" | grep -c 'timeout -k')" -eq 2
 
 if [ "$fail" = 0 ]; then echo "PASS"; else echo "FAILURES"; exit 1; fi

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -39,6 +39,7 @@ Environment variables:
   RALPHEX_PORT           Web dashboard port with --serve (default: 8080)
   RALPHEX_DOCKER_SOCKET  Enable Docker socket mount ("1", "true", "yes")
   RALPHEX_DOCKER_NETWORK Docker network mode (e.g., "host", "my-network")
+  RALPHEX_CLI_UPDATE     Update claude/codex at start ("1", "true", "yes"), off by default
   RALPHEX_EXTRA_ENV      Comma-separated env vars (VAR=value or VAR to inherit)
   RALPHEX_EXTRA_VOLUMES  Comma-separated volume mounts (src:dst[:opts])
 
@@ -115,6 +116,7 @@ def build_parser() -> argparse.ArgumentParser:
               RALPHEX_PORT           Web dashboard port with --serve (default: 8080)
               RALPHEX_DOCKER_SOCKET  Enable Docker socket mount ("1", "true", "yes")
               RALPHEX_DOCKER_NETWORK Docker network mode (e.g., "host", "my-network")
+              RALPHEX_CLI_UPDATE     Update claude/codex at start ("1", "true", "yes"), off by default
               RALPHEX_EXTRA_ENV      Comma-separated env vars (VAR=value or VAR)
               RALPHEX_EXTRA_VOLUMES  Comma-separated volume mounts (src:dst[:opts])
 
@@ -899,7 +901,7 @@ def build_base_env_vars() -> list[str]:
     tz = detect_timezone()
     # TIME_ZONE configures baseimage's /etc/localtime; TZ is what Go's time
     # package reads for time.Local, so both must be set for consistent timestamps.
-    return [
+    result = [
         "-e", f"APP_UID={os.getuid()}",
         "-e", f"TIME_ZONE={tz}",
         "-e", f"TZ={tz}",
@@ -907,6 +909,12 @@ def build_base_env_vars() -> list[str]:
         "-e", "INIT_QUIET=1",
         "-e", "CLAUDE_CONFIG_DIR=/home/app/.claude",
     ]
+    # forward the opt-in so init.sh refreshes the CLIs; unset leaves the image's own default
+    # (off for the base image, baked on for ralphex-go) in charge
+    cli_update = os.environ.get("RALPHEX_CLI_UPDATE", "")
+    if cli_update:
+        result.extend(["-e", f"RALPHEX_CLI_UPDATE={cli_update}"])
+    return result
 
 
 def build_docker_command(
@@ -1061,6 +1069,10 @@ def main() -> int:
             volumes = build_volumes(creds_temp, claude_home)
             cmd = ["docker", "run", "--rm"]
             cmd.extend(build_base_env_vars())
+            # rendering help resolves no models, and the image entrypoint runs init.sh regardless of
+            # the command. force the refresh off here (overriding a forwarded opt-in or the ralphex-go
+            # image's baked-in default) so help is not preceded by a two-package npm install
+            cmd.extend(["-e", "RALPHEX_CLI_UPDATE=0"])
             cmd.extend(volumes)
             cmd.extend(["-w", "/workspace"])
             cmd.extend([image, "/srv/ralphex", "--help"])

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -358,6 +358,46 @@ class TestDetectTimezone(unittest.TestCase):
             else:
                 os.environ["TZ"] = old
 
+    def test_cli_update_forwarded_when_set(self) -> None:
+        """RALPHEX_CLI_UPDATE reaches the container so init.sh runs the cli refresh."""
+        old = os.environ.get("RALPHEX_CLI_UPDATE")
+        try:
+            os.environ["RALPHEX_CLI_UPDATE"] = "1"
+            self.assertIn("RALPHEX_CLI_UPDATE=1", build_base_env_vars())
+        finally:
+            if old is None:
+                os.environ.pop("RALPHEX_CLI_UPDATE", None)
+            else:
+                os.environ["RALPHEX_CLI_UPDATE"] = old
+
+    def test_help_forces_cli_update_off(self) -> None:
+        """--help renders help only, but the image entrypoint runs init.sh whatever the command is,
+        so the help path forces the refresh off instead of paying for an npm install it cannot use."""
+        src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "ralphex-dk.sh")
+        with open(src) as f:
+            body = f.read()
+        marker = '[image, "/srv/ralphex", "--help"]'
+        self.assertIn(marker, body)
+        # the docker run that builds the help command must force the refresh off
+        help_block = body[:body.index(marker)]
+        help_block = help_block[help_block.rindex('["docker", "run", "--rm"]'):]
+        self.assertIn('"RALPHEX_CLI_UPDATE=0"', help_block)
+
+    def test_cli_update_absent_by_default(self) -> None:
+        """update is opt-in: nothing is forwarded when the flag is unset or empty, leaving the
+        image's own default in charge."""
+        old = os.environ.get("RALPHEX_CLI_UPDATE")
+        try:
+            os.environ.pop("RALPHEX_CLI_UPDATE", None)
+            self.assertFalse([e for e in build_base_env_vars() if e.startswith("RALPHEX_CLI_UPDATE=")])
+            os.environ["RALPHEX_CLI_UPDATE"] = ""
+            self.assertFalse([e for e in build_base_env_vars() if e.startswith("RALPHEX_CLI_UPDATE=")])
+        finally:
+            if old is None:
+                os.environ.pop("RALPHEX_CLI_UPDATE", None)
+            else:
+                os.environ["RALPHEX_CLI_UPDATE"] = old
+
 class TestExtractCredentials(unittest.TestCase):
     def test_write_pattern_adds_trailing_newline(self) -> None:
         """credential write pattern appends newline (matching bash echo behavior)."""


### PR DESCRIPTION
The base ralphex image installs claude and codex unpinned, so a published image tag freezes both at whatever npm served on that build. Both ship far more often than ralphex is tagged, so the wrapper's default image drifted: it was still the 2026-06-26 v1.6.0 build carrying claude 2.1.195 and codex 0.142.3. A short model alias like `sonnet` then resolves to whatever that build knew about, so `--task-model=sonnet` runs an older model with no warning (#410).

`update_cli_tools()` in `scripts/internal/init-docker.sh` refreshes both CLIs to their current npm releases at container start, as root, before privileges drop to `app`. Claude's own updater can't do this here: npm installs it root-owned and the container runs as `app`, so `DISABLE_AUTOUPDATER=1` plus the init-time refresh replace it. Best effort: npm failure or the 90s deadline leaves the baked versions in place and the run continues; both CLIs are smoke-checked after install so a broken or hung release is reported rather than failing later unexplained.

**Opt-in by design** (`RALPHEX_CLI_UPDATE=1`). The base image leaves it off so anyone building on it gets no surprise npm install, network call, or version drift at start, and no root `@latest` pull next to their mounts. The `ralphex-go` image (the wrapper's default) bakes it on, so the common path stays current. Custom images enable it with one line:

```dockerfile
FROM ghcr.io/umputun/ralphex:latest
ENV RALPHEX_CLI_UPDATE=1
```

Docker images only. The wrapper forwards a host-set `RALPHEX_CLI_UPDATE` into the container, and the `--help` path forces it off so rendering help never triggers an install. Covered by `scripts/internal/init-docker_test.sh` (shell) and `scripts/ralphex-dk/ralphex_dk_test.py` (python); README, llms.txt, and CLAUDE.md updated.

Related to #410
