### PR TITLE
fix: tighten signal rules in review prompts

### DIFF
--- a/pkg/config/defaults/prompts/review_first.txt
+++ b/pkg/config/defaults/prompts/review_first.txt
@@ -73,19 +73,22 @@ SIGNAL LOGIC - READ CAREFULLY:
 
 IMPORTANT: Do not decide on a signal path until you have completed Steps 1-3 in full — all agents finished, all results collected, all findings verified and acted on.
 
+IMPORTANT: A signal marker is irreversible. The moment you write one it takes effect, and you cannot retract it by explaining afterwards that you did not mean it. If you emit a marker it MUST be the final non-empty line of your output, with nothing after it. While you are still reasoning about which path applies, emit nothing.
+
 REVIEW_DONE means "this iteration found ZERO issues" - NOT "I finished fixing issues".
 
 Path A - NO confirmed issues found:
 - You reviewed the code and found nothing to fix
-- Output: <<<RALPHEX:REVIEW_DONE>>>
+- End your output with: <<<RALPHEX:REVIEW_DONE>>>
 
 Path B - Issues found AND fixed:
 - You found issues, fixed them, and committed
-- STOP HERE. Do NOT output any signal. Do NOT output REVIEW_DONE.
+- End your output with a plain-text summary of what you fixed. Emit NO marker at all - not REVIEW_DONE, not TASK_FAILED.
 - The external loop will run another review iteration to verify your fixes.
 - Your fixes might have introduced new issues - another iteration must check.
 
 Path C - Issues found but cannot fix:
-- Output: <<<RALPHEX:TASK_FAILED>>>
+- This is only for issues you were UNABLE to fix. If you fixed and committed anything this iteration, you are on Path B - describe the remaining issues in plain text and let the next iteration handle them.
+- End your output with: <<<RALPHEX:TASK_FAILED>>>
 
 OUTPUT FORMAT: No markdown formatting (no **bold**, `code`, # headers). Plain text and - lists are fine.

--- a/pkg/config/defaults/prompts/review_second.txt
+++ b/pkg/config/defaults/prompts/review_second.txt
@@ -55,21 +55,24 @@ SIGNAL LOGIC - READ CAREFULLY:
 
 IMPORTANT: Do not decide on a signal path until you have completed Steps 1-3 in full — all agents finished, all results collected, all findings verified and acted on.
 
+IMPORTANT: A signal marker is irreversible. The moment you write one it takes effect, and you cannot retract it by explaining afterwards that you did not mean it. If you emit a marker it MUST be the final non-empty line of your output, with nothing after it. While you are still reasoning about which path applies, emit nothing.
+
 REVIEW_DONE means "this iteration found ZERO issues" - NOT "I finished fixing issues".
 
 Path A - NO issues found in this iteration:
 - You reviewed the code and found nothing critical/major to fix
-- Output: <<<RALPHEX:REVIEW_DONE>>>
+- End your output with: <<<RALPHEX:REVIEW_DONE>>>
 
 Path B - Issues found AND fixed:
 1. Fix verified critical/major issues only
 2. Run tests and linter - ALL tests must pass, ALL linter issues resolved
 3. Commit fixes: `git commit -m "fix: address code review findings"`
-4. STOP HERE. Do NOT output any signal. Do NOT output REVIEW_DONE.
+4. End your output with a plain-text summary of what you fixed. Emit NO marker at all - not REVIEW_DONE, not TASK_FAILED.
    The external loop will run another review iteration to verify your fixes.
    Your fixes might have introduced new issues - another iteration must check.
 
 Path C - Issues found but cannot fix:
-- Output: <<<RALPHEX:TASK_FAILED>>>
+- This is only for issues you were UNABLE to fix. If you fixed and committed anything this iteration, you are on Path B - describe the remaining issues in plain text and let the next iteration handle them.
+- End your output with: <<<RALPHEX:TASK_FAILED>>>
 
 OUTPUT FORMAT: No markdown formatting (no **bold**, `code`, # headers). Plain text and - lists are fine.


### PR DESCRIPTION
claude can emit a signal marker mid-reasoning and retract it one text block later. The marker is captured by then and cannot be un-seen, so a first-review `TASK_FAILED` aborts the run even when the review found, fixed and committed its findings correctly.

reported in #422 on sonnet, and before that in #294 on opus 4.7. Same shape both times:

```
[26-07-29 10:06:19] All 3 tests pass. Committing the fix.
[26-07-29 10:06:23] TASK_FAILED
[26-07-29 10:06:23] Wait - per the signal logic, since issues were found and fixed, I should not output a completion signal
error: runner: first review: review failed (FAILED signal received)
```

this is the prompt-level fix proposed in #294 that was never actually made. Three changes to `review_first.txt` and `review_second.txt`:

- a marker is irreversible and must be the final non-empty line, nothing after it. The log shows the model knew the rule and thought prose could take the marker back, so stating the rule alone was not enough
- Path B reworded as a positive action. It was `STOP HERE. Do NOT output any signal`, a negation sitting in a choose-one list of three
- Path C now says a committed fix means Path B. In #422 the model had committed, which by itself rules out Path C

on the partial-fix case, 4 of 6 fixed and 2 unfixable now routes to Path B. The next iteration re-reviews, finds the 2, has committed nothing and correctly takes Path C. Costs one extra iteration and converges.

no Go change. `review.go:131` still treats FAILED as a hard abort, and `<<<RALPHEX:CANCEL>>>` stays unbuilt, only worth it if this doesn't hold.

reaches users on embedded defaults only. Anyone who customized `review_first.txt` keeps their copy until they run `/ralphex-update`.

`task.txt` and `make_plan.txt` also emit `TASK_FAILED` with no final-line rule. Left alone for now, the task phase retries on FAILED so the blast radius there is smaller.
