### PR TITLE
fix: stop review agents from spawning subagents of their own

### DIFF
--- a/pkg/processor/prompts.go
+++ b/pkg/processor/prompts.go
@@ -107,7 +107,13 @@ func (b *promptBuilder) replaceVariablesWithIteration(prompt string, isFirstIter
 // pointer to the branch diff or changed files unless told to fetch them itself,
 // and without the contract lines an agent may edit files (the parent loop owns
 // fixing), dump pre-existing repo-wide findings every iteration (stalls the
-// zero-findings REVIEW_DONE exit), or leave the no-findings case ambiguous.
+// zero-findings REVIEW_DONE exit), leave the no-findings case ambiguous, or
+// fan out further agents of its own. the no-delegation line has to live here
+// rather than in review_first.txt/review_second.txt: those reach only the root
+// session, while a spawned agent's whole prompt is this lead-in plus its body.
+// the default subagent type is general-purpose, which itself holds the agent
+// tool, so a reviewer handed a multi-section checklist will otherwise
+// sub-delegate and multiply the run's token cost.
 func (b *promptBuilder) reviewContextInstruction() string {
 	branch := b.getDefaultBranch()
 	return fmt.Sprintf("First run `git diff %s...HEAD` and `git diff --stat %s...HEAD` to get the "+
@@ -115,6 +121,7 @@ func (b *promptBuilder) reviewContextInstruction() string {
 		"Scope: review the changed code and code it directly interacts with; report pre-existing "+
 		"issues outside the changes only when severe.\n"+
 		"This is a read-only review - do not edit files and do not commit; describe fixes, do not apply them.\n"+
+		"Do the whole review yourself in this context - do not launch other agents or delegate any part of it.\n"+
 		"Report only issues supported by specific evidence in the code - when unsure, read more context first.\n"+
 		"If you find no issues, output exactly: NO ISSUES FOUND\n\n", branch, branch)
 }

--- a/pkg/processor/prompts_test.go
+++ b/pkg/processor/prompts_test.go
@@ -1294,6 +1294,7 @@ func TestRunner_reviewContextInstruction(t *testing.T) {
 		assert.Contains(t, got, "read-only review", "agents must not edit files")
 		assert.Contains(t, got, "NO ISSUES FOUND", "clean-case sentinel must be defined")
 		assert.Contains(t, got, "Scope: review the changed code", "findings must be scoped to the diff")
+		assert.Contains(t, got, "do not launch other agents", "agents must not sub-delegate the review")
 	})
 
 	t.Run("respects configured default branch", func(t *testing.T) {


### PR DESCRIPTION
the shared reviewer contract in `reviewContextInstruction` covers scope, read-only and the clean-case sentinel, but says nothing about delegation. The default subagent type is `general-purpose`, which itself holds the agent tool, so a reviewer handed a five-section checklist fans out instead of doing the work, and each child can do the same. Reported in #427 with a run that produced three dozen subagent contexts and over a thousand model responses.

the existing "do NOT use run_in_background" line cannot reach this. It lives in `review_first.txt` / `review_second.txt`, which only the root session reads. A spawned agent's whole prompt is this lead-in plus its agent body, so the contract line has to live here to be seen at all.

one line added, beside the read-only line:

```
Do the whole review yourself in this context - do not launch other agents or delegate any part of it.
```

the lead-in is prepended before the claude/codex branch in `formatAgentExpansion`, so it reaches Task-tool and `spawn_agent` reviewers alike, and applies to custom agents as well as the five defaults.

what this does not fix: #427 also reports Claude Code moving foreground Task calls to the background, and a short `placeholder` agent while waiting on them. That is CC's own scheduling, not something a prompt can bind. Collapsing the tree to depth 1 makes it cheaper, not absent.

Related to #427
