### PR TITLE
feat: add orcarouter claude provider to docker wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,14 @@ Key functions in `scripts/ralphex-dk.sh`:
 - `export_aws_profile_credentials()` - exports credentials from AWS profile
 - `validate_bedrock_config()` - validates bedrock config, returns warnings
 
+### OrcaRouter Provider (Docker Wrapper Only)
+
+`scripts/ralphex-dk.sh` supports [OrcaRouter](https://www.orcarouter.ai) as a Claude provider (`--claude-provider orcarouter` / `RALPHEX_CLAUDE_PROVIDER`). See `docs/orcarouter-setup.md`.
+
+Key functions in `scripts/ralphex-dk.sh`:
+- `get_claude_provider()` - returns provider from CLI flag or env var
+- `build_orcarouter_env_args()` - builds docker -e flags for ORCAROUTER_ENV_VARS; translates `ORCAROUTER_API_KEY` to `ANTHROPIC_AUTH_TOKEN` via the inherit form, always sets `ANTHROPIC_BASE_URL=https://api.orcarouter.ai`, and pins `anthropic/`-namespaced default model vars (bare Anthropic model IDs fail on the gateway with `model_not_found`)
+
 ### Docker Socket Support (Docker Wrapper Only)
 
 `--docker` flag (or `RALPHEX_DOCKER_SOCKET`) mounts the host Docker socket for testcontainers. Socket path from `DOCKER_HOST` (unix://) or `/var/run/docker.sock`; GID auto-detected and passed via `DOCKER_GID`. Missing socket = fail-fast error.

--- a/README.md
+++ b/README.md
@@ -497,6 +497,30 @@ ralphex docs/plans/feature.md
 
 See [Bedrock setup documentation](docs/bedrock-setup.md) for detailed IAM policies and setup instructions.
 
+**OrcaRouter support:**
+
+When `--claude-provider=orcarouter` or `RALPHEX_CLAUDE_PROVIDER=orcarouter` is set:
+- Keychain credential extraction is skipped (not needed for gateway auth)
+- `ORCAROUTER_API_KEY` is translated to `ANTHROPIC_AUTH_TOKEN` using the docker inherit form (the key value never appears on the command line)
+- Required env vars are passed to container: `ANTHROPIC_BASE_URL` (set to `https://api.orcarouter.ai`), `ANTHROPIC_AUTH_TOKEN`, and default model pins (`anthropic/`-prefixed gateway model IDs)
+
+Required environment for OrcaRouter:
+- `ORCAROUTER_API_KEY` - OrcaRouter API key (starts with `sk-orca-`)
+
+Note: `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` and `anthropic/`-namespaced default model pins are automatically set when using `--claude-provider=orcarouter`. Bare Anthropic model IDs are rejected by the gateway with `model_not_found`.
+
+```bash
+# with API key
+export ORCAROUTER_API_KEY=sk-orca-...
+ralphex --claude-provider=orcarouter docs/plans/feature.md
+
+# or use env var for session-wide setting
+export RALPHEX_CLAUDE_PROVIDER=orcarouter
+ralphex docs/plans/feature.md
+```
+
+See [OrcaRouter setup documentation](docs/orcarouter-setup.md) for detailed setup instructions.
+
 **Extra volume mounts:**
 ```bash
 # via CLI flags (can use multiple -v)

--- a/docs/orcarouter-setup.md
+++ b/docs/orcarouter-setup.md
@@ -1,0 +1,145 @@
+# OrcaRouter Setup Guide
+
+This guide explains how to use ralphex with Claude models hosted on [OrcaRouter](https://www.orcarouter.ai).
+
+## Overview
+
+OrcaRouter is a unified AI gateway that routes requests to Claude and other leading models through a single API endpoint (`https://api.orcarouter.ai/v1`). It runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Using OrcaRouter lets you:
+- Run the full ralphex pipeline (Claude Code executor) through one gateway endpoint
+- Route to Claude models without a direct Anthropic API subscription
+- Keep your API key on the host — it is never written into the container image or the command line
+
+## Security Best Practices
+
+**Never expose your API key.** OrcaRouter API keys start with `sk-orca-` and unlock billing — treat them like any other secret:
+
+1. Set `ORCAROUTER_API_KEY` in your shell environment, not in files that get committed
+2. The wrapper translates it to `ANTHROPIC_AUTH_TOKEN` using the docker **inherit form** (`-e VAR`), so the key value never appears in `ps` output or the docker command line
+3. ralphex never mounts your key file into the container — it is passed via environment only
+
+**Avoid passing secrets on the command line.** When using `-E` to pass extra environment variables:
+- Prefer `-E VAR` (inherit form) over `-E VAR=value` for secrets
+- Values in `-E VAR=value` are visible in `ps` output to other users on the system
+
+## Setup Instructions
+
+### 1. Create an API key
+
+Sign up at [orcarouter.ai](https://www.orcarouter.ai) and create an API key in the dashboard. Keys start with `sk-orca-`.
+
+### 2. Export the key
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+```
+
+### 3. Run ralphex with the OrcaRouter provider
+
+```bash
+ralphex --claude-provider=orcarouter docs/plans/feature.md
+```
+
+The wrapper automatically:
+- Sets `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` (the gateway endpoint)
+- Translates `ORCAROUTER_API_KEY` to `ANTHROPIC_AUTH_TOKEN` (inherit form — the key value never appears on the docker command line)
+- Pins the default model vars to anthropic-namespaced gateway models (`anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4.5`) — bare Anthropic model IDs are rejected by the gateway with `model_not_found`
+
+## Environment Variables
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `ORCAROUTER_API_KEY` | OrcaRouter API key (starts with `sk-orca-`). Translated to `ANTHROPIC_AUTH_TOKEN` automatically |
+
+Alternatively, set `ANTHROPIC_AUTH_TOKEN` directly to the OrcaRouter key if you prefer not to use the `ORCAROUTER_API_KEY` name.
+
+### ralphex Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `RALPHEX_CLAUDE_PROVIDER` | Set to `orcarouter` to enable OrcaRouter mode (alternative to `--claude-provider` flag) |
+
+### Optional Model Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_MODEL` | Override default Claude model |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | Custom Opus model on the gateway |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Custom Sonnet model on the gateway |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Custom Haiku model on the gateway |
+| `ANTHROPIC_SMALL_FAST_MODEL` | Model for fast operations |
+| `ANTHROPIC_BASE_URL` | Custom gateway endpoint (defaults to `https://api.orcarouter.ai`) |
+| `DISABLE_PROMPT_CACHING` | Set to disable prompt caching |
+
+Any of these can be overridden per-run with `-E` flags, e.g.:
+
+```bash
+ralphex --claude-provider=orcarouter -E ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4-5 docs/plans/feature.md
+```
+
+## Example Usage
+
+### Basic usage
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+ralphex --claude-provider=orcarouter docs/plans/feature.md
+```
+
+### Session-wide OrcaRouter mode
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+export RALPHEX_CLAUDE_PROVIDER=orcarouter
+
+# All ralphex commands now use OrcaRouter
+ralphex docs/plans/feature.md
+ralphex --review
+```
+
+### Dry run (verify the docker command without running)
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+ralphex --claude-provider=orcarouter --dry-run docs/plans/feature.md
+```
+
+The output shows the exact docker command. The key value is not present — only `ANTHROPIC_AUTH_TOKEN` is passed via the inherit form.
+
+## Startup Output
+
+When using OrcaRouter mode, ralphex shows the provider configuration:
+
+**With `ORCAROUTER_API_KEY` set:**
+```
+using image: ghcr.io/umputun/ralphex-go:latest
+claude provider: orcarouter (keychain skipped)
+  using ORCAROUTER_API_KEY (translated to ANTHROPIC_AUTH_TOKEN)
+  passing: ANTHROPIC_BASE_URL, ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL, ANTHROPIC_SMALL_FAST_MODEL, ORCAROUTER_API_KEY, ANTHROPIC_AUTH_TOKEN
+```
+
+**With no key set:**
+```
+using image: ghcr.io/umputun/ralphex-go:latest
+claude provider: orcarouter (keychain skipped)
+  warning: no API key set (set ORCAROUTER_API_KEY or ANTHROPIC_AUTH_TOKEN)
+  passing: ANTHROPIC_BASE_URL, ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL, ANTHROPIC_SMALL_FAST_MODEL
+```
+
+## Troubleshooting
+
+### `model_not_found` errors
+
+The gateway rejects bare Anthropic model IDs (e.g. `claude-sonnet-4-5`). The wrapper pins `anthropic/`-namespaced model IDs by default, but if you override them with `-E`, make sure to keep the `anthropic/` prefix (e.g. `anthropic/claude-sonnet-5`).
+
+### `AuthenticationError` / `401 Unauthorized`
+
+Your API key is missing or invalid:
+1. Verify `ORCAROUTER_API_KEY` is set in the shell that runs ralphex: `echo "${#ORCAROUTER_API_KEY}"` (prints the length, not the value)
+2. Confirm the key starts with `sk-orca-`
+3. If you set `ANTHROPIC_AUTH_TOKEN` directly, make sure it holds the OrcaRouter key
+
+### No `~/.claude` directory error on Linux
+
+When using OrcaRouter mode, ralphex skips the Claude configuration directory check. If you see this error, ensure you're using `--claude-provider=orcarouter` flag.

--- a/llms.txt
+++ b/llms.txt
@@ -108,6 +108,11 @@ RALPHEX_CONFIG_DIR=~/my-config ralphex docs/plans/feature.md
 ralphex --claude-provider=bedrock docs/plans/feature.md
 RALPHEX_CLAUDE_PROVIDER=bedrock ralphex docs/plans/feature.md
 
+# use OrcaRouter gateway for Claude (Docker wrapper only)
+export ORCAROUTER_API_KEY=sk-orca-...
+ralphex --claude-provider=orcarouter docs/plans/feature.md
+RALPHEX_CLAUDE_PROVIDER=orcarouter ralphex docs/plans/feature.md
+
 # preserve ANTHROPIC_API_KEY in the claude child env (for API-key auth users)
 ralphex --preserve-anthropic-api-key docs/plans/feature.md
 ```
@@ -238,7 +243,7 @@ ralphex --dry-run docs/plans/feature.md
 - `RALPHEX_DOCKER_NETWORK` - Docker network mode (e.g., `host`, `my-network`). CLI flag: `--network`
 - `RALPHEX_CLI_UPDATE` - Refresh claude/codex to their current npm releases at container start: `1`, `true`, or `yes` (Docker images only). Off by default in the base image; baked on in `ralphex-go`
 - `TZ` - Override container timezone (default: auto-detected from host)
-- `RALPHEX_CLAUDE_PROVIDER` - Claude provider mode: `default` or `bedrock` (Docker wrapper only)
+- `RALPHEX_CLAUDE_PROVIDER` - Claude provider mode: `default`, `bedrock`, or `orcarouter` (Docker wrapper only)
 
 **CLI freshness in the container:**
 
@@ -273,6 +278,20 @@ Required environment for Bedrock:
 Note: `CLAUDE_CODE_USE_BEDROCK=1` is automatically set when using `--claude-provider=bedrock`.
 
 See `docs/bedrock-setup.md` for detailed setup instructions and IAM policies.
+
+**OrcaRouter support** (Docker wrapper only):
+
+When `--claude-provider=orcarouter` or `RALPHEX_CLAUDE_PROVIDER=orcarouter` is set:
+- Keychain credential extraction is skipped (not needed for gateway auth)
+- `ORCAROUTER_API_KEY` is translated to `ANTHROPIC_AUTH_TOKEN` using the docker inherit form (key value never appears on the command line)
+- Required env vars are passed to container: `ANTHROPIC_BASE_URL` (set to `https://api.orcarouter.ai`), `ANTHROPIC_AUTH_TOKEN`, and `anthropic/`-namespaced default model pins
+
+Required environment for OrcaRouter:
+- `ORCAROUTER_API_KEY` - OrcaRouter API key (starts with `sk-orca-`)
+
+Note: `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` and `anthropic/`-prefixed default model pins are automatically set when using `--claude-provider=orcarouter`. Bare Anthropic model IDs are rejected by the gateway with `model_not_found`.
+
+See `docs/orcarouter-setup.md` for detailed setup instructions.
 
 **Creating custom images for other languages:**
 

--- a/scripts/ralphex-dk.sh
+++ b/scripts/ralphex-dk.sh
@@ -72,7 +72,7 @@ DEFAULT_IMAGE = "ghcr.io/umputun/ralphex-go:latest"
 DEFAULT_PORT = "8080"
 SCRIPT_URL = "https://raw.githubusercontent.com/umputun/ralphex/master/scripts/ralphex-dk.sh"
 SENSITIVE_PATTERNS = ["KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "CREDENTIAL", "AUTH"]
-VALID_CLAUDE_PROVIDERS = ["default", "bedrock"]
+VALID_CLAUDE_PROVIDERS = ["default", "bedrock", "orcarouter"]
 DEFAULT_DOCKER_SOCKET = "/var/run/docker.sock"
 
 # environment variables to pass through when using bedrock provider
@@ -100,6 +100,37 @@ BEDROCK_ENV_VARS = [
     "ANTHROPIC_BEDROCK_BASE_URL",
     "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
 ]
+
+# environment variables to pass through when using orcarouter provider.
+# ANTHROPIC_BASE_URL is auto-set to the OrcaRouter endpoint when the provider is
+# selected (unless the user pins it via -E); the default model pins below are
+# required because bare Anthropic model ids (e.g. "claude-sonnet-4-5") fail on
+# the gateway with model_not_found unless namespaced with the "anthropic/" prefix.
+ORCAROUTER_ENV_VARS = [
+    # api key (translated to ANTHROPIC_AUTH_TOKEN by build_orcarouter_env_args)
+    "ORCAROUTER_API_KEY",
+    # optional explicit token/base-url override (ANTHROPIC_BASE_URL is auto-set)
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    # optional model configuration (overrides the gateway default pins below)
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    # optional
+    "DISABLE_PROMPT_CACHING",
+]
+
+# gateway default model pins for the orcarouter provider (auto-set unless the user
+# provides one via -E flags). bare model ids fail on the gateway with
+# model_not_found - the "anthropic/" prefix is required.
+ORCAROUTER_DEFAULT_MODELS = {
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "anthropic/claude-opus-5",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "anthropic/claude-sonnet-5",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "anthropic/claude-haiku-4.5",
+    "ANTHROPIC_SMALL_FAST_MODEL": "anthropic/claude-haiku-4.5",
+}
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -137,7 +168,7 @@ def build_parser() -> argparse.ArgumentParser:
                         help="show this help and ralphex help, then exit")
     parser.add_argument("--claude-provider", dest="claude_provider", metavar="PROVIDER",
                         choices=VALID_CLAUDE_PROVIDERS,
-                        help="claude provider: 'default' or 'bedrock' (env: RALPHEX_CLAUDE_PROVIDER)")
+                        help="claude provider: 'default', 'bedrock', or 'orcarouter' (env: RALPHEX_CLAUDE_PROVIDER)")
     parser.add_argument("--docker", action="store_true", dest="docker",
                         help="mount host Docker socket into container (env: RALPHEX_DOCKER_SOCKET)")
     parser.add_argument("--network", dest="network", metavar="MODE",
@@ -542,7 +573,7 @@ def merge_volume_flags(args_volume: list[str]) -> list[str]:
 
 
 def get_claude_provider(cli_provider: Optional[str]) -> str:
-    """get claude provider from CLI flag or env var. returns 'default' or 'bedrock'.
+    """get claude provider from CLI flag or env var. returns 'default', 'bedrock', or 'orcarouter'.
 
     priority: CLI flag > RALPHEX_CLAUDE_PROVIDER env var > 'default'
     raises ValueError if provider value is invalid.
@@ -667,6 +698,55 @@ def build_bedrock_env_args(existing_env: Optional[list[str]] = None) -> list[str
             continue
         # skip session token when user provides explicit credential values to avoid mixing
         if skip_session_token and var == "AWS_SESSION_TOKEN":
+            continue
+        # only pass vars that exist in env AND have non-empty values
+        value = os.environ.get(var, "")
+        if value:
+            result.extend(["-e", var])
+    return result
+
+
+def build_orcarouter_env_args(existing_env: Optional[list[str]] = None) -> list[str]:
+    """build docker -e flags for orcarouter env vars.
+
+    always sets ANTHROPIC_BASE_URL to the OrcaRouter endpoint and pins the default
+    model vars to anthropic-namespaced gateway model ids (bare ids fail on the
+    gateway with model_not_found). ORCAROUTER_API_KEY is translated to
+    ANTHROPIC_AUTH_TOKEN using the inherit form (-e VAR) so the key value never
+    appears on the docker command line / in ps output. other vars are passed
+    through only if they have values in the host environment.
+    skips vars that are already explicitly set in existing_env (from -E flags).
+    """
+    parsed = parse_env_flags(existing_env)
+    already_set = set(parsed.values.keys())
+
+    # translate ORCAROUTER_API_KEY to ANTHROPIC_AUTH_TOKEN unless the user already
+    # provided an explicit token (via -E flag or host environment). the inherit
+    # form keeps the key value out of the command line.
+    if (
+        "ANTHROPIC_AUTH_TOKEN" not in already_set
+        and not os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    ):
+        key = os.environ.get("ORCAROUTER_API_KEY", "")
+        if key:
+            os.environ["ANTHROPIC_AUTH_TOKEN"] = key
+
+    result: list[str] = []
+    auto_set_vars: set[str] = set()  # track auto-set vars so pass-through skips them
+
+    # always set the gateway base url and default model pins when orcarouter
+    # provider is selected (this function is only called in that case)
+    if "ANTHROPIC_BASE_URL" not in already_set:
+        result.extend(["-e", "ANTHROPIC_BASE_URL=https://api.orcarouter.ai"])
+        auto_set_vars.add("ANTHROPIC_BASE_URL")
+    for var, default in ORCAROUTER_DEFAULT_MODELS.items():
+        if var not in already_set:
+            result.extend(["-e", f"{var}={default}"])
+            auto_set_vars.add(var)
+
+    for var in ORCAROUTER_ENV_VARS:
+        # skip vars already set via -E flags or auto-set above (avoids duplicate -e flags)
+        if var in already_set or var == "ANTHROPIC_BASE_URL" or var in auto_set_vars:
             continue
         # only pass vars that exist in env AND have non-empty values
         value = os.environ.get(var, "")
@@ -1084,16 +1164,16 @@ def main() -> int:
         return 1
 
     # handle --help: show wrapper help unconditionally, then try container help if config exists
-    # skip claude_home check when using bedrock provider (no anthropic credentials needed)
+    # skip claude_home check when using bedrock or orcarouter provider (no local claude credentials needed)
     if parsed.help:
         parser.print_help()
         print("\n" + "-" * 70)
-        if provider != "bedrock" and not claude_home.is_dir():
+        if provider not in ("bedrock", "orcarouter") and not claude_home.is_dir():
             print("ralphex options: (cannot show - claude config not found)")
             print("  run 'claude' first to authenticate, then re-run --help")
             return 0
         print("ralphex options (from container):\n")
-        creds_temp = None if provider == "bedrock" else extract_macos_credentials(claude_home)
+        creds_temp = None if provider in ("bedrock", "orcarouter") else extract_macos_credentials(claude_home)
         try:
             volumes = build_volumes(creds_temp, claude_home)
             cmd = ["docker", "run", "--rm"]
@@ -1117,20 +1197,20 @@ def main() -> int:
                     pass
 
     # check required directories (after --help handling)
-    # skip claude_home check when using bedrock provider (no anthropic credentials needed)
-    if provider != "bedrock" and not claude_home.is_dir():
+    # skip claude_home check when using bedrock or orcarouter provider (no local claude credentials needed)
+    if provider not in ("bedrock", "orcarouter") and not claude_home.is_dir():
         print(f"error: {claude_home} directory not found (run 'claude' first to authenticate)", file=sys.stderr)
         return 1
 
     # extract macOS credentials (needed for volume mounts)
-    # skip when using bedrock provider (uses AWS credentials instead)
-    creds_temp = None if provider == "bedrock" else extract_macos_credentials(claude_home)
+    # skip when using bedrock or orcarouter provider (uses gateway credentials instead)
+    creds_temp = None if provider in ("bedrock", "orcarouter") else extract_macos_credentials(claude_home)
 
     # fail fast on macOS if there are no credentials at all: no on-disk file AND
     # keychain extraction returned None. starting the container would surface a
     # confusing "Not logged in" inside claude later.
     if (
-        provider != "bedrock"
+        provider not in ("bedrock", "orcarouter")
         and platform.system() == "Darwin"
         and creds_temp is None
         and not (claude_home / ".credentials.json").exists()
@@ -1157,6 +1237,17 @@ def main() -> int:
         # pass existing extra_env to avoid overriding user's explicit -E values
         bedrock_env_args = build_bedrock_env_args(extra_env)
         extra_env.extend(bedrock_env_args)
+
+    # add orcarouter env vars when using orcarouter provider
+    orcarouter_env_args: list[str] = []  # track for diagnostics
+    orcarouter_user_env: dict[str, str] = {}  # user's -E flags only (pre-merge, for diagnostics)
+    if provider == "orcarouter":
+        # capture user -E flags before extending extra_env so diagnostics can tell
+        # user-overridden vars apart from the ones the wrapper auto-sets
+        orcarouter_user_env = extract_env_from_flags(extra_env)
+        # pass existing extra_env to avoid overriding user's explicit -E values
+        orcarouter_env_args = build_orcarouter_env_args(extra_env)
+        extra_env.extend(orcarouter_env_args)
 
     # merge env var entries with CLI -v/--volume flags (env first, CLI appends)
     extra_volumes = merge_volume_flags(parsed.volume)
@@ -1244,6 +1335,29 @@ def main() -> int:
             bedrock_warnings = validate_bedrock_config(extra_env)
             for warning in bedrock_warnings:
                 print(f"  warning: {warning}", file=sys.stderr)
+        elif provider == "orcarouter":
+            print("claude provider: orcarouter (keychain skipped)", file=sys.stderr)
+            # show credential source (from host env or user -E flags)
+            if os.environ.get("ORCAROUTER_API_KEY") or "ORCAROUTER_API_KEY" in orcarouter_user_env:
+                print("  using ORCAROUTER_API_KEY (translated to ANTHROPIC_AUTH_TOKEN)", file=sys.stderr)
+            elif os.environ.get("ANTHROPIC_AUTH_TOKEN") or "ANTHROPIC_AUTH_TOKEN" in orcarouter_user_env:
+                print("  using ANTHROPIC_AUTH_TOKEN", file=sys.stderr)
+            else:
+                print("  warning: no API key set (set ORCAROUTER_API_KEY or ANTHROPIC_AUTH_TOKEN)", file=sys.stderr)
+            # show which orcarouter env vars are actually being passed (bare names, deduped)
+            passed_vars: list[str] = []
+            # auto-set by the wrapper: gateway base url + default model pins (unless user overrode via -E)
+            for var in ["ANTHROPIC_BASE_URL"] + list(ORCAROUTER_DEFAULT_MODELS.keys()):
+                if var not in orcarouter_user_env:
+                    passed_vars.append(var)
+            # user -E flags and host-env pass-through (inherit form)
+            for var in ORCAROUTER_ENV_VARS:
+                if var == "ANTHROPIC_BASE_URL" or var in passed_vars:
+                    continue
+                if var in orcarouter_user_env or os.environ.get(var):
+                    passed_vars.append(var)
+            if passed_vars:
+                print(f"  passing: {', '.join(passed_vars)}", file=sys.stderr)
 
         # determine port binding
         bind_port = should_bind_port(ralphex_args)

--- a/scripts/ralphex-dk/ralphex_dk_test.py
+++ b/scripts/ralphex-dk/ralphex_dk_test.py
@@ -26,12 +26,15 @@ from ralphex_dk import (  # noqa: E402
     DEFAULT_IMAGE,
     DEFAULT_PORT,
     DEFAULT_DOCKER_SOCKET,
+    ORCAROUTER_DEFAULT_MODELS,
+    ORCAROUTER_ENV_VARS,
     VALID_CLAUDE_PROVIDERS,
     ParsedEnvFlags,
     build_base_env_vars,
     build_bedrock_env_args,
     build_docker_command,
     build_env_vars,
+    build_orcarouter_env_args,
     build_parser,
     build_volumes,
     detect_explicit_secrets,
@@ -1730,6 +1733,115 @@ class TestClaudeProvider(EnvTestCase):
         os.environ["RALPHEX_CLAUDE_PROVIDER"] = ""
         provider = get_claude_provider(None)
         self.assertEqual(provider, "default")
+
+class TestOrcaRouterProvider(EnvTestCase):
+    """tests for orcarouter provider selection and env var handling."""
+    env_vars = [
+        "RALPHEX_CLAUDE_PROVIDER",
+        "ORCAROUTER_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "DISABLE_PROMPT_CACHING",
+    ]
+
+    def test_orcarouter_in_valid_providers(self) -> None:
+        """orcarouter is a recognized claude provider."""
+        self.assertIn("orcarouter", VALID_CLAUDE_PROVIDERS)
+
+    def test_cli_flag_orcarouter(self) -> None:
+        """--claude-provider orcarouter → provider is 'orcarouter'."""
+        provider = get_claude_provider("orcarouter")
+        self.assertEqual(provider, "orcarouter")
+
+    def test_env_var_fallback_orcarouter(self) -> None:
+        """no flag, RALPHEX_CLAUDE_PROVIDER=orcarouter → provider is 'orcarouter'."""
+        os.environ["RALPHEX_CLAUDE_PROVIDER"] = "orcarouter"
+        provider = get_claude_provider(None)
+        self.assertEqual(provider, "orcarouter")
+
+    def test_orcarouter_default_provider_no_env(self) -> None:
+        """no flag, no env → provider is 'default'."""
+        provider = get_claude_provider(None)
+        self.assertEqual(provider, "default")
+
+    def test_orcarouter_sets_base_url_and_pins(self) -> None:
+        """always sets gateway base url and default model pins (bare ids fail on gateway)."""
+        args = build_orcarouter_env_args()
+        self.assertIn("-e", args)
+        self.assertIn("ANTHROPIC_BASE_URL=https://api.orcarouter.ai", args)
+        for var, default in ORCAROUTER_DEFAULT_MODELS.items():
+            self.assertIn(f"{var}={default}", args)
+
+    def test_orcarouter_translates_key_inherit_form(self) -> None:
+        """ORCAROUTER_API_KEY → ANTHROPIC_AUTH_TOKEN via inherit form (no value on cmdline)."""
+        os.environ["ORCAROUTER_API_KEY"] = "sk-orca-test123"
+        args = build_orcarouter_env_args()
+        # key value must never appear in the docker args
+        self.assertNotIn("sk-orca-test123", args)
+        # inherit form passes the token from host env
+        self.assertIn("ANTHROPIC_AUTH_TOKEN", args)
+        self.assertEqual(os.environ["ANTHROPIC_AUTH_TOKEN"], "sk-orca-test123")
+
+    def test_orcarouter_no_key_still_sets_base_url(self) -> None:
+        """no key set → gateway base url + pins still applied, no token flag."""
+        args = build_orcarouter_env_args()
+        self.assertIn("ANTHROPIC_BASE_URL=https://api.orcarouter.ai", args)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", args)
+
+    def test_orcarouter_passes_set_vars(self) -> None:
+        """only passes ORCAROUTER_ENV_VARS that are actually set."""
+        os.environ["ANTHROPIC_MODEL"] = "anthropic/claude-sonnet-5"
+        os.environ["DISABLE_PROMPT_CACHING"] = "1"
+        args = build_orcarouter_env_args()
+        self.assertIn("ANTHROPIC_MODEL", args)
+        self.assertIn("DISABLE_PROMPT_CACHING", args)
+        # ORCAROUTER_API_KEY unset → not passed, and no token translation
+        self.assertNotIn("ORCAROUTER_API_KEY", args)
+
+    def test_orcarouter_skips_user_base_url_override(self) -> None:
+        """user -E ANTHROPIC_BASE_URL wins over auto gateway base url."""
+        existing_env = ["-e", "ANTHROPIC_BASE_URL=https://custom.gateway.ai"]
+        args = build_orcarouter_env_args(existing_env)
+        self.assertNotIn("ANTHROPIC_BASE_URL", args)
+
+    def test_orcarouter_skips_user_model_pins(self) -> None:
+        """user -E overrides a default model pin."""
+        existing_env = ["-e", "ANTHROPIC_DEFAULT_OPUS_MODEL=anthropic/claude-opus-4"]
+        args = build_orcarouter_env_args(existing_env)
+        self.assertNotIn("ANTHROPIC_DEFAULT_OPUS_MODEL", args)
+        # other pins still applied
+        self.assertIn("ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-5", args)
+
+    def test_orcarouter_skips_user_inherit(self) -> None:
+        """-E VAR inherit form counts as already-set and is skipped."""
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = "host-token"
+        existing_env = ["-e", "ANTHROPIC_AUTH_TOKEN"]
+        args = build_orcarouter_env_args(existing_env)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", args)
+
+    def test_orcarouter_honors_host_auth_token(self) -> None:
+        """host ANTHROPIC_AUTH_TOKEN set → used directly, no key translation."""
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = "host-token"
+        os.environ["ORCAROUTER_API_KEY"] = "sk-orca-test123"
+        args = build_orcarouter_env_args()
+        self.assertIn("ANTHROPIC_AUTH_TOKEN", args)
+        self.assertNotIn("sk-orca-test123", args)
+        # key translation must NOT override host token
+        self.assertEqual(os.environ["ANTHROPIC_AUTH_TOKEN"], "host-token")
+
+    def test_orcarouter_no_duplicate_model_pins(self) -> None:
+        """model pins auto-set by the wrapper are not re-added by pass-through (no duplicate -e)."""
+        os.environ["ANTHROPIC_SMALL_FAST_MODEL"] = "anthropic/claude-haiku-4.5"
+        args = build_orcarouter_env_args()
+        # value-form pin present exactly once
+        self.assertEqual(args.count("ANTHROPIC_SMALL_FAST_MODEL=anthropic/claude-haiku-4.5"), 1)
+        # no bare inherit-form duplicate
+        self.assertNotIn("ANTHROPIC_SMALL_FAST_MODEL", args)
 
 class TestDockerEnabled(EnvTestCase):
     """tests for docker socket flag and env var detection."""


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a Claude provider for the Docker wrapper. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `scripts/ralphex-dk.sh`: adds `--claude-provider=orcarouter` / `RALPHEX_CLAUDE_PROVIDER=orcarouter` as a third provider mode. Translates `ORCAROUTER_API_KEY` to `ANTHROPIC_AUTH_TOKEN` via the docker inherit form (the key value never appears on the command line), auto-sets `ANTHROPIC_BASE_URL=https://api.orcarouter.ai`, and pins `anthropic/`-namespaced default model vars (bare Anthropic model ids fail on the gateway with `model_not_found`). Skips claude_home/keychain checks like the bedrock path.
- `scripts/ralphex-dk/ralphex_dk_test.py`: 13 unit tests covering provider selection, env translation, base-url/model pinning, `-E` overrides, and no-duplicate `-e` flags.
- `docs/orcarouter-setup.md`: setup guide mirroring `docs/bedrock-setup.md`.
- `README.md`, `llms.txt`, `CLAUDE.md`: usage notes and env var documentation.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how AWS Bedrock is wired in this repo — the wrapper already treats Claude providers as first-class `--claude-provider` modes, so OrcaRouter slots into the same flag, diagnostics, and env-passing path.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Run:

   ```bash
   ralphex --claude-provider=orcarouter docs/plans/feature.md
   ```

   The wrapper auto-sets the gateway base URL and `anthropic/`-namespaced model pins; each can be overridden per-run with `-E`.

## Verification

- Unit tests: 13 `TestOrcaRouterProvider` tests pass (full wrapper suite matches the pre-change baseline: `failures=5, errors=28`, all pre-existing Windows-host environment issues unrelated to this change).
- Live API: all four auto-set model pins (`anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4.5`) return `ORCA-OK` from the Anthropic-compatible `/v1/messages` endpoint using the wrapper env form.
- Ran locally: wrapper `--dry-run --claude-provider=orcarouter` builds the docker command with the gateway base URL, model pins, and the auth token passed via the inherit form.
