### PR TITLE
fix: strip all Claude Code session env vars from child processes

### DIFF
--- a/pkg/executor/codex.go
+++ b/pkg/executor/codex.go
@@ -36,22 +36,23 @@ type CodexRunner interface {
 // stripAnthropicKey scopes ANTHROPIC_API_KEY filtering to first-class --codex runs;
 // external codex review in default claude mode keeps the host env intact so custom
 // codex wrappers proxying through Anthropic (e.g., scripts/codex-as-claude/codex-as-claude.sh) keep
-// authenticating. CLAUDECODE is always stripped regardless of mode to prevent
-// nested-session errors when codex is launched from inside a Claude Code session.
+// authenticating. the Claude Code session markers are always stripped regardless of mode
+// to prevent nested-session errors when codex is launched from inside a Claude Code session.
 type execCodexRunner struct {
 	stdin             io.Reader
 	stripAnthropicKey bool
 }
 
-// childEnv builds the codex child-process env. CLAUDECODE is always stripped to
-// prevent nested-session errors. ANTHROPIC_API_KEY is stripped only when the
-// caller requested it (first-class --codex mode); default-claude external codex
-// review passes the key through so custom Anthropic-proxying wrappers keep working.
+// childEnv builds the codex child-process env. the Claude Code session markers (see
+// sessionEnvVars) are always stripped to prevent nested-session errors.
+// ANTHROPIC_API_KEY is stripped only when the caller requested it (first-class --codex
+// mode); default-claude external codex review passes the key through so custom
+// Anthropic-proxying wrappers keep working.
 func (r *execCodexRunner) childEnv(env []string) []string {
 	if r.stripAnthropicKey {
-		return filterEnv(env, "ANTHROPIC_API_KEY", "CLAUDECODE")
+		return filterEnv(env, append([]string{"ANTHROPIC_API_KEY"}, sessionEnvVars...)...)
 	}
-	return filterEnv(env, "CLAUDECODE")
+	return filterEnv(env, sessionEnvVars...)
 }
 
 func (r *execCodexRunner) Run(ctx context.Context, name string, args ...string) (CodexStreams, func() error, error) {

--- a/pkg/executor/codex_test.go
+++ b/pkg/executor/codex_test.go
@@ -81,6 +81,30 @@ func TestExecCodexRunner_childEnv(t *testing.T) {
 			env:               []string{"OPENAI_API_KEY=ok", "FOO=bar"},
 			want:              []string{"OPENAI_API_KEY=ok", "FOO=bar"},
 		},
+		{
+			name:              "every Claude Code session marker stripped regardless of mode",
+			stripAnthropicKey: false,
+			env: []string{
+				"PATH=/usr/bin", "CLAUDECODE=1", "CLAUDE_CODE_ENTRYPOINT=cli",
+				"CLAUDE_CODE_EXECPATH=/usr/bin/claude", "CLAUDE_CODE_SESSION_ID=abc",
+				"CLAUDE_CODE_CHILD_SESSION=1", "CLAUDE_CODE_BRIDGE_SESSION_ID=def",
+				"CLAUDE_CODE_MESSAGING_SOCKET=/tmp/sock", "CLAUDE_CODE_MESSAGING_TOKEN=tok",
+				"CLAUDE_PID=123", "CLAUDE_EFFORT=high", "HOME=/home/user",
+			},
+			want: []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name:              "keeps user-set CLAUDE_CODE_ config vars",
+			stripAnthropicKey: true,
+			env: []string{
+				"CLAUDE_CODE_USE_BEDROCK=1", "CLAUDE_CODE_MAX_OUTPUT_TOKENS=8192",
+				"CLAUDE_CONFIG_DIR=/custom/config", "CLAUDE_CODE_SESSION_ID=abc",
+			},
+			want: []string{
+				"CLAUDE_CODE_USE_BEDROCK=1", "CLAUDE_CODE_MAX_OUTPUT_TOKENS=8192",
+				"CLAUDE_CONFIG_DIR=/custom/config",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -92,7 +92,8 @@ func (r *execClaudeRunner) Run(ctx context.Context, name string, args ...string)
 	// to ensure the entire process group is killed, not just the direct child
 	cmd := exec.Command(name, args...) //nolint:noctx // intentional: we handle context cancellation via process group kill
 
-	// build child env: always strip CLAUDECODE (prevents nested session errors); strip
+	// build child env: always strip the Claude Code session markers (prevents nested
+	// session errors, see sessionEnvVars); strip
 	// ANTHROPIC_API_KEY by default so a host-set key cannot silently override OAuth/keychain
 	// auth and bill a different account. preserveAPIKey opts into keeping the key for users
 	// who authenticate Claude Code via API key.
@@ -197,15 +198,38 @@ func stripFlag(args []string, flag string) []string {
 	return result
 }
 
-// claudeChildEnv builds the environment for a child claude process. CLAUDECODE is always
-// stripped to prevent nested-session errors. ANTHROPIC_API_KEY is stripped unless
-// preserveAPIKey is true; preserving it is required for users who authenticate Claude Code
-// via API key rather than OAuth/keychain.
+// sessionEnvVars are the per-session markers Claude Code sets on processes it spawns.
+// any one of them left in a child env makes the spawned claude behave as a nested session:
+// it attaches to the parent's session plumbing, never writes its own transcript, and a PTY
+// wrapper such as fya then waits for output that never arrives until its turn timeout fires,
+// burning a full iteration per attempt with no work done. CLAUDECODE alone covered this
+// before Claude Code 2.1.x introduced the rest.
+//
+// deliberately an explicit list rather than a CLAUDE_CODE_* prefix strip: user-set config
+// vars share that prefix (CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_VERTEX,
+// CLAUDE_CODE_MAX_OUTPUT_TOKENS, CLAUDE_CODE_SUBAGENT_MODEL) and must reach the child.
+var sessionEnvVars = []string{
+	"CLAUDECODE",
+	"CLAUDE_CODE_ENTRYPOINT",
+	"CLAUDE_CODE_EXECPATH",
+	"CLAUDE_CODE_SESSION_ID",
+	"CLAUDE_CODE_CHILD_SESSION",
+	"CLAUDE_CODE_BRIDGE_SESSION_ID",
+	"CLAUDE_CODE_MESSAGING_SOCKET",
+	"CLAUDE_CODE_MESSAGING_TOKEN",
+	"CLAUDE_PID",
+	"CLAUDE_EFFORT",
+}
+
+// claudeChildEnv builds the environment for a child claude process. the Claude Code session
+// markers (see sessionEnvVars) are always stripped to prevent nested-session errors.
+// ANTHROPIC_API_KEY is stripped unless preserveAPIKey is true; preserving it is required for
+// users who authenticate Claude Code via API key rather than OAuth/keychain.
 func claudeChildEnv(env []string, preserveAPIKey bool) []string {
 	if preserveAPIKey {
-		return filterEnv(env, "CLAUDECODE")
+		return filterEnv(env, sessionEnvVars...)
 	}
-	return filterEnv(env, "ANTHROPIC_API_KEY", "CLAUDECODE")
+	return filterEnv(env, append([]string{"ANTHROPIC_API_KEY"}, sessionEnvVars...)...)
 }
 
 // filterEnv returns a copy of env with specified keys removed.

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -724,6 +724,47 @@ func TestClaudeChildEnv(t *testing.T) {
 			preserveAPIKey: true,
 			want:           []string{"ANTHROPIC_API_KEY_OLD=old", "ANTHROPIC_API_KEY=new"},
 		},
+		{
+			// names spelled out rather than derived from sessionEnvVars: dropping one from the
+			// production list must fail here, which a tautological loop over it would not catch
+			name: "strips every Claude Code session marker",
+			env: []string{
+				"PATH=/usr/bin", "CLAUDECODE=1", "CLAUDE_CODE_ENTRYPOINT=cli",
+				"CLAUDE_CODE_EXECPATH=/usr/bin/claude", "CLAUDE_CODE_SESSION_ID=abc",
+				"CLAUDE_CODE_CHILD_SESSION=1", "CLAUDE_CODE_BRIDGE_SESSION_ID=def",
+				"CLAUDE_CODE_MESSAGING_SOCKET=/tmp/sock", "CLAUDE_CODE_MESSAGING_TOKEN=tok",
+				"CLAUDE_PID=123", "CLAUDE_EFFORT=high", "HOME=/home/user",
+			},
+			preserveAPIKey: false,
+			want:           []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name: "preserve keeps api key but still strips every session marker",
+			env: []string{
+				"ANTHROPIC_API_KEY=secret", "CLAUDECODE=1", "CLAUDE_CODE_ENTRYPOINT=cli",
+				"CLAUDE_CODE_EXECPATH=/usr/bin/claude", "CLAUDE_CODE_SESSION_ID=abc",
+				"CLAUDE_CODE_CHILD_SESSION=1", "CLAUDE_CODE_BRIDGE_SESSION_ID=def",
+				"CLAUDE_CODE_MESSAGING_SOCKET=/tmp/sock", "CLAUDE_CODE_MESSAGING_TOKEN=tok",
+				"CLAUDE_PID=123", "CLAUDE_EFFORT=high", "PATH=/usr/bin",
+			},
+			preserveAPIKey: true,
+			want:           []string{"ANTHROPIC_API_KEY=secret", "PATH=/usr/bin"},
+		},
+		{
+			// a CLAUDE_CODE_* prefix strip would eat these; they configure the child and must survive
+			name: "keeps user-set CLAUDE_CODE_ config vars while stripping session markers",
+			env: []string{
+				"CLAUDE_CODE_USE_BEDROCK=1", "CLAUDE_CODE_USE_VERTEX=1",
+				"CLAUDE_CODE_MAX_OUTPUT_TOKENS=8192", "CLAUDE_CODE_SUBAGENT_MODEL=haiku",
+				"CLAUDE_CONFIG_DIR=/custom/config", "CLAUDE_CODE_SESSION_ID=abc", "CLAUDECODE=1",
+			},
+			preserveAPIKey: false,
+			want: []string{
+				"CLAUDE_CODE_USE_BEDROCK=1", "CLAUDE_CODE_USE_VERTEX=1",
+				"CLAUDE_CODE_MAX_OUTPUT_TOKENS=8192", "CLAUDE_CODE_SUBAGENT_MODEL=haiku",
+				"CLAUDE_CONFIG_DIR=/custom/config",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Problem

Stripping `CLAUDECODE` alone stopped being enough once Claude Code 2.1.x began marking spawned processes with a family of per-session vars. Any one of them left in the child env makes the spawned `claude` behave as a nested session: it attaches to the parent's session plumbing and never writes its own transcript. A PTY wrapper such as [fya](https://github.com/umputun/fya) then waits for output that never arrives, and every turn burns the full `--turn-timeout` (30m by default) having done no work.

The failure is near-silent — the only symptom is `FYA_TRANSIENT_TIMEOUT`, which ralphex correctly classifies as transient and retries, so the run loops at 30 minutes per iteration making no progress.

## Evidence

Running ralphex from inside a Claude Code session, Claude Code 2.1.228, fya 0.4.0, ralphex v1.6.1. `/proc/<pid>/environ` on the fya child:

```
CLAUDECODE                     (correctly stripped)
CLAUDE_CODE_CHILD_SESSION      set
CLAUDE_CODE_SESSION_ID         set
CLAUDE_CODE_MESSAGING_SOCKET   set
CLAUDE_CODE_MESSAGING_TOKEN    set
CLAUDE_CODE_BRIDGE_SESSION_ID  set
CLAUDE_CODE_ENTRYPOINT         set
CLAUDE_CODE_EXECPATH           set
CLAUDE_PID                     set
CLAUDE_EFFORT                  set
```

Two iterations timed out at 30m each, with no session transcript written under `~/.claude/projects/<cwd-slug>/` for the entire run. Relaunching the same plan with the full set scrubbed (`env -u …  ralphex …`) produced a child transcript in ~85 seconds and normal streaming progress.

## Change

Collect the markers in `sessionEnvVars` and strip them in both executors. `claudeChildEnv` (`executor.go`) and the codex runner's `childEnv` (`codex.go`) have the same defect, and in a full-mode run the codex loop is reached by the same invocation, so both are fixed here rather than split.

Deliberately an explicit list rather than a `CLAUDE_CODE_*` prefix strip: user-set config vars share that prefix (`CLAUDE_CODE_USE_BEDROCK`, `_USE_VERTEX`, `_MAX_OUTPUT_TOKENS`, `_SUBAGENT_MODEL`) and must still reach the child. A test covers that so the distinction doesn't get "simplified" away later.

## Tests

Cases added to the existing tables in `TestClaudeChildEnv` and `TestExecCodexRunner_childEnv`:

- every marker stripped, in both `preserveAPIKey` / `stripAnthropicKey` modes
- user-set `CLAUDE_CODE_*` config vars and `CLAUDE_CONFIG_DIR` survive

Var names are spelled out literally in the tests rather than looped over `sessionEnvVars`, so removing an entry from the production list fails the test instead of agreeing with itself.

`make fmt` clean, `make lint` 0 issues, `make test` passes (race, full suite, 87.9% total coverage).

## One caveat worth stating

The set is "every session-scoped marker", not a bisected minimal one. I verified that all-stripped works and all-present reproduces the wedge; I did not test each var individually, since the nested-session detection lives in Claude Code rather than here. `CLAUDE_PID` and `CLAUDE_EFFORT` are the two most likely to be unnecessary — happy to drop them if you'd rather keep the list tight. My reasoning for the wider net is that a wrapper is better off dropping anything session-scoped, including markers added in future releases.

AI-assisted, reviewed by me before submitting; I can explain any line.
