### PR TITLE
fix(pi-as-claude): pass max thinking level through to pi

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -381,8 +381,7 @@ ralphex appends `--model <m>` / `--effort <e>` per phase. The wrapper forwards `
 
 | ralphex effort | pi thinking |
 |---|---|
-| `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | passed through verbatim |
-| `max` | `xhigh` (pi has no `max`; a one-line note is printed to stderr) |
+| `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` | passed through verbatim |
 
 ### Event translation
 

--- a/scripts/pi-as-claude/README.md
+++ b/scripts/pi-as-claude/README.md
@@ -40,7 +40,7 @@ ralphex docs/plans/feature.md
 
 Alternatively, disable extensions entirely with `export PI_EXTRA_ARGS="--no-extensions"`, or remove the gating extension while running ralphex.
 
-**Model and effort:** ralphex appends `--model <m>` / `--effort <e>` per phase. `--model` is forwarded to pi's `--model`; `--effort` maps to pi's `--thinking` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh` pass through; `max` → `xhigh` with a stderr note since pi has no `max` level).
+**Model and effort:** ralphex appends `--model <m>` / `--effort <e>` per phase. `--model` is forwarded to pi's `--model`; `--effort` maps to pi's `--thinking` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` pass through verbatim). `max` requires a pi version that supports it (verified with pi 0.84.1); older pi releases reject unknown thinking levels.
 
 ## Testing
 

--- a/scripts/pi-as-claude/pi-as-claude.sh
+++ b/scripts/pi-as-claude/pi-as-claude.sh
@@ -71,16 +71,11 @@ model="$model_flag"
 [[ -z "$model" ]] && model="$PI_MODEL"
 
 # resolve thinking level: explicit --effort flag wins over PI_THINKING env.
-# pi accepts off|minimal|low|medium|high|xhigh; ralphex's effort levels map directly
-# except `max`, which pi lacks — fall back to `xhigh` with a one-line note (like codex).
+# pi accepts off|minimal|low|medium|high|xhigh|max; ralphex's effort levels pass
+# through verbatim and pi validates them.
 thinking=""
 if [[ -n "$effort_flag" ]]; then
-    if [[ "$effort_flag" == "max" ]]; then
-        thinking="xhigh"
-        echo "note: pi has no 'max' thinking level; using 'xhigh' instead" >&2
-    else
-        thinking="$effort_flag" # passthrough; pi validates the rest
-    fi
+    thinking="$effort_flag" # passthrough; pi validates the rest
 elif [[ -n "$PI_THINKING" ]]; then
     thinking="$PI_THINKING"
 fi

--- a/scripts/pi-as-claude/pi-as-claude_test.sh
+++ b/scripts/pi-as-claude/pi-as-claude_test.sh
@@ -251,7 +251,7 @@ fi
 # ---------------------------------------------------------------------------
 echo "test: effort to thinking mapping"
 
-for level in off minimal low medium high xhigh; do
+for level in off minimal low medium high xhigh max; do
     rm -f "$TMPDIR_TEST/pi_args"
     run_wrapper --effort "$level" -p "test prompt" >/dev/null 2>&1
     recorded=$(cat "$TMPDIR_TEST/pi_args")
@@ -261,26 +261,6 @@ for level in off minimal low medium high xhigh; do
         fail "effort '$level' not mapped" "args: $recorded"
     fi
 done
-
-# ---------------------------------------------------------------------------
-# test: --effort max → --thinking xhigh with stderr note
-# ---------------------------------------------------------------------------
-echo "test: effort max maps to xhigh with note"
-
-rm -f "$TMPDIR_TEST/pi_args"
-err_out=$(run_wrapper --effort max -p "test prompt" 2>&1 >/dev/null)
-recorded=$(cat "$TMPDIR_TEST/pi_args")
-if echo "$recorded" | grep -q -- "--thinking xhigh"; then
-    pass "effort max mapped to --thinking xhigh"
-else
-    fail "effort max not mapped to xhigh" "args: $recorded"
-fi
-
-if echo "$err_out" | grep -qi "no 'max' thinking level"; then
-    pass "max effort prints stderr note"
-else
-    fail "max effort note missing" "stderr: $err_out"
-fi
 
 # an unrecognized effort value passes through verbatim (pi validates it).
 rm -f "$TMPDIR_TEST/pi_args"


### PR DESCRIPTION
pi added a native `max` thinking level (https://github.com/earendil-works/pi/issues/6097#issuecomment-4946495274), but the pi-as-claude wrapper still downgraded ralphex's `max` effort to `xhigh` with a stderr note. this removes the special case: all effort levels pass through to pi's `--thinking` verbatim and pi validates them. docs and mock-pi tests updated accordingly.

verified with ralphex 1.6.0 and pi 0.84.1: `--task-model="k3:max"` reaches pi as `--thinking max`; wrapper tests 70/70, shellcheck clean.