### PR TITLE
fix: serve the worktree's plan copy to the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ Key files:
 
 - Worktrees created at `.ralphex/worktrees/<branch-name>` inside main repo
 - Progress logger created before chdir so files land in main repo's `.ralphex/progress/`
+- The header records two plan paths: `Plan:` is the main-checkout path the run was launched with, `Worktree plan:` (worktree mode only) is the copy the run actually ticks, computed by `worktreePlanFile()` before the logger is built. `handleSessionPlan` (`pkg/web/server.go`) serves the worktree copy while it exists and falls back to `Plan:` once the worktree is removed, so a watch-mode dashboard shows live checkbox state instead of the untouched main copy (#440). Unknown header lines are ignored by `parseHeaderField`, so older readers are unaffected. Not fixed by this: `MovePlanToCompleted` archives the main-checkout copy, which is still unticked, so a finished worktree run's plan panel reads 0 done
 - `MainGitSvc` in `executePlanRequest` handles cross-boundary ops (plan file moves in main repo)
 - Worktree auto-removed on completion, failure, or SIGINT; branch preserved for PR
 - Only active for `ModeFull` and `ModeTasksOnly` (review/plan/external modes skip worktree)

--- a/cmd/ralphex/main.go
+++ b/cmd/ralphex/main.go
@@ -729,17 +729,22 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 		return fmt.Errorf("get working directory: %w", err)
 	}
 
+	// resolve the plan copy inside the worktree - the file the run actually ticks. computed here
+	// rather than after the chdir so the progress header can record it for the dashboard.
+	wtPlanFile := worktreePlanFile(req.PlanFile, req.GitSvc.Root(), wtPath)
+
 	// create progress logger BEFORE chdir so progress files land in main repo's .ralphex/progress/.
 	// use branch name derived from plan file since gitSvc still points at the main repo (on master).
 	holder := &status.PhaseHolder{}
 	branch := req.GitSvc.EffectiveBranchName(req.PlanFile, req.BranchOverride)
 	baseLog, err := progress.NewLogger(progress.Config{
-		PlanFile:       req.PlanFile,
-		Mode:           string(req.Mode),
-		Branch:         branch,
-		BranchOverride: req.BranchOverride,
-		Params:         runHeaderParams(o, req.Config, req.Mode),
-		NoColor:        o.NoColor,
+		PlanFile:         req.PlanFile,
+		WorktreePlanFile: wtPlanFile,
+		Mode:             string(req.Mode),
+		Branch:           branch,
+		BranchOverride:   req.BranchOverride,
+		Params:           runHeaderParams(o, req.Config, req.Mode),
+		NoColor:          o.NoColor,
 	}, req.Colors, holder)
 	if err != nil {
 		return fmt.Errorf("create progress logger: %w", err)
@@ -784,10 +789,6 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 	}
 	wtGitSvc.SetCommitTrailer(req.Config.CommitTrailer)
 
-	// resolve plan file path inside the worktree so Claude operates on the local copy,
-	// not the original in the main repo. the plan was copied by CreateWorktreeForPlan.
-	wtPlanFile := resolveWorktreePlanFile(req.PlanFile, req.GitSvc.Root())
-
 	// commit plan file on the feature branch (inside worktree), not on the default branch
 	if planNeedsCommit {
 		if commitErr := wtGitSvc.CommitPlanFile(req.PlanFile, req.GitSvc.Root()); commitErr != nil {
@@ -795,8 +796,15 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 		}
 	}
 
+	// a relative plan path leaves wtPlanFile empty; it still resolves correctly from inside
+	// the worktree, so run with it unchanged.
+	runPlanFile := wtPlanFile
+	if runPlanFile == "" {
+		runPlanFile = req.PlanFile
+	}
+
 	return executePlan(ctx, o, executePlanRequest{
-		PlanFile:      wtPlanFile,
+		PlanFile:      runPlanFile,
 		MainPlanFile:  req.PlanFile, // original path in main repo for MovePlanToCompleted
 		Mode:          req.Mode,
 		GitSvc:        wtGitSvc,
@@ -811,13 +819,15 @@ func runWithWorktree(ctx context.Context, o opts, req executePlanRequest) (err e
 	})
 }
 
-// resolveWorktreePlanFile maps an absolute plan path from the main repo into the worktree CWD.
+// worktreePlanFile maps an absolute plan path from the main repo onto its copy inside wtPath.
 // It resolves symlinks on the plan path to match the repo root (macOS: /tmp -> /private/tmp),
-// then makes the path relative to the root and absolute within the worktree.
-// Falls back to the original path if any step fails or the path is not absolute.
-func resolveWorktreePlanFile(planFile, repoRoot string) string {
+// then joins the repo-relative remainder onto the worktree root, mirroring the layout
+// copyToWorktree writes to. A plan outside repoRoot therefore maps to a path outside wtPath
+// too, which is where the copy really lands. Returns "" only when planFile is relative or
+// filepath.Rel cannot relate the two, leaving the caller to keep the original path.
+func worktreePlanFile(planFile, repoRoot, wtPath string) string {
 	if !filepath.IsAbs(planFile) {
-		return planFile
+		return ""
 	}
 	resolved := planFile
 	if r, err := filepath.EvalSymlinks(resolved); err == nil {
@@ -825,13 +835,9 @@ func resolveWorktreePlanFile(planFile, repoRoot string) string {
 	}
 	rel, err := filepath.Rel(repoRoot, resolved)
 	if err != nil {
-		return planFile
+		return ""
 	}
-	abs, err := filepath.Abs(rel)
-	if err != nil {
-		return planFile
-	}
-	return abs
+	return filepath.Join(wtPath, rel)
 }
 
 // openGitService creates a git.Service for the current directory.

--- a/cmd/ralphex/main_test.go
+++ b/cmd/ralphex/main_test.go
@@ -2667,6 +2667,66 @@ func TestRunWithWorktree_UntrackedPlan(t *testing.T) {
 	assert.NoDirExists(t, wtPath, "worktree should be removed")
 }
 
+// pins #440: the dashboard reads the header path, so it must name the copy the run ticks
+func TestRunWithWorktree_RecordsWorktreePlanInHeader(t *testing.T) {
+	dir := setupTestRepo(t)
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs", "plans"), 0o750))
+	planPath := filepath.Join(dir, "docs", "plans", "wt-header.md")
+	require.NoError(t, os.WriteFile(planPath, []byte("# WT Header\n\n- [ ] task 1\n"), 0o600))
+	runGit(t, dir, "add", "docs/plans/wt-header.md")
+	runGit(t, dir, "commit", "-m", "add wt header plan")
+
+	gitSvc, err := git.NewService(dir, noopLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = runWithWorktree(ctx, opts{MaxIterations: 1, NoColor: true}, executePlanRequest{
+		PlanFile: planPath, Mode: processor.ModeFull, GitSvc: gitSvc, Config: &config.Config{WorktreeEnabled: true},
+		Colors: testColors(), DefaultBranch: "master", WtCleanup: &worktreeCleanupFn{},
+	})
+	require.Error(t, err, "runner fails on the canceled context, but the header is already written")
+
+	content, readErr := os.ReadFile(filepath.Join(dir, ".ralphex", "progress", "progress-wt-header.txt")) //nolint:gosec // test
+	require.NoError(t, readErr)
+
+	wantWt := filepath.Join(gitSvc.Root(), ".ralphex", "worktrees", "wt-header", "docs", "plans", "wt-header.md")
+	assert.Contains(t, string(content), "Worktree plan: "+wantWt+"\n")
+	assert.Contains(t, string(content), "Plan: "+planPath+"\n", "the main-checkout path stays recorded as the fallback")
+}
+
+func TestWorktreePlanFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		planFile string
+		repoRoot string
+		wtPath   string
+		want     string
+	}{
+		{
+			name: "maps plan into the worktree", planFile: "/repo/docs/plans/a.md", repoRoot: "/repo",
+			wtPath: "/repo/.ralphex/worktrees/a", want: "/repo/.ralphex/worktrees/a/docs/plans/a.md",
+		},
+		{name: "relative plan path yields empty", planFile: "docs/plans/a.md", repoRoot: "/repo", wtPath: "/repo/.ralphex/worktrees/a"},
+		{
+			name: "plan outside the repo root still maps by relative walk", planFile: "/other/a.md", repoRoot: "/repo",
+			wtPath: "/repo/.ralphex/worktrees/a", want: "/repo/.ralphex/worktrees/other/a.md",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, worktreePlanFile(tc.planFile, tc.repoRoot, tc.wtPath))
+		})
+	}
+}
+
 func TestRunWithWorktree_CreateWorktreeError(t *testing.T) {
 	dir := setupTestRepo(t)
 	origDir, err := os.Getwd()

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -140,13 +140,14 @@ type Logger struct {
 
 // Config holds logger configuration.
 type Config struct {
-	PlanFile        string    // plan filename (used to derive progress filename)
-	PlanDescription string    // plan description for plan mode (used for filename)
-	Mode            string    // execution mode: full, review, codex-only, plan
-	Branch          string    // current git branch
-	BranchOverride  string    // explicit branch name override (--branch flag); when set, used as filename stem instead of plan file
-	Params          RunParams // user-set run parameters recorded in the header
-	NoColor         bool      // disable color output (sets color.NoColor globally)
+	PlanFile         string    // plan filename (used to derive progress filename)
+	WorktreePlanFile string    // absolute path of the plan copy the run ticks inside the worktree; empty outside worktree mode
+	PlanDescription  string    // plan description for plan mode (used for filename)
+	Mode             string    // execution mode: full, review, codex-only, plan
+	Branch           string    // current git branch
+	BranchOverride   string    // explicit branch name override (--branch flag); when set, used as filename stem instead of plan file
+	Params           RunParams // user-set run parameters recorded in the header
+	NoColor          bool      // disable color output (sets color.NoColor globally)
 }
 
 // RunParams holds user-set executor/model parameters written to the progress
@@ -261,6 +262,11 @@ func (l *Logger) writeHeader(cfg Config) {
 	}
 	l.writeFileLocked("# Ralphex Progress Log\n")
 	l.writeFileLocked("Plan: %s\n", planStr)
+	// worktree runs tick the copy inside the worktree, not the path above; record it so the
+	// dashboard can read the file the run actually writes to while the worktree exists.
+	if cfg.WorktreePlanFile != "" {
+		l.writeFileLocked("Worktree plan: %s\n", cfg.WorktreePlanFile)
+	}
 	l.writeFileLocked("Branch: %s\n", cfg.Branch)
 	l.writeFileLocked("Mode: %s\n", cfg.Mode)
 	if cfg.Params.Executor != "" {

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -132,6 +132,50 @@ func TestNewLogger_HeaderRunParams(t *testing.T) {
 	}
 }
 
+func TestNewLogger_HeaderWorktreePlan(t *testing.T) {
+	colors := testColors()
+
+	tests := []struct {
+		name             string
+		worktreePlanFile string
+		wantLines        []string
+		absentLines      []string
+	}{
+		{name: "unset omits the line", absentLines: []string{"Worktree plan: "}},
+		{
+			name:             "set records the worktree copy alongside the original",
+			worktreePlanFile: "/repo/.ralphex/worktrees/feature/docs/plans/feature.md",
+			wantLines: []string{
+				"Plan: docs/plans/feature.md\n",
+				"Worktree plan: /repo/.ralphex/worktrees/feature/docs/plans/feature.md\n",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origDir, _ := os.Getwd()
+			require.NoError(t, os.Chdir(t.TempDir()))
+			defer func() { _ = os.Chdir(origDir) }()
+
+			holder := &status.PhaseHolder{}
+			cfg := Config{PlanFile: "docs/plans/feature.md", WorktreePlanFile: tc.worktreePlanFile, Mode: "full", Branch: "feature"}
+			l, err := NewLogger(cfg, colors, holder)
+			require.NoError(t, err)
+			defer l.Close()
+
+			content, err := os.ReadFile(l.Path())
+			require.NoError(t, err)
+			for _, want := range tc.wantLines {
+				assert.Contains(t, string(content), want)
+			}
+			for _, absent := range tc.absentLines {
+				assert.NotContains(t, string(content), absent)
+			}
+		})
+	}
+}
+
 func TestNewLogger_AppendOnRestart(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()

--- a/pkg/web/plan.go
+++ b/pkg/web/plan.go
@@ -9,6 +9,15 @@ import (
 	"github.com/umputun/ralphex/pkg/plan"
 )
 
+// loadSessionPlan loads a plan recorded in a session's progress header. relative paths are
+// resolved against sessionDir, the directory holding the progress file.
+func loadSessionPlan(planPath, sessionDir string) (*plan.Plan, error) {
+	if !filepath.IsAbs(planPath) {
+		planPath = filepath.Join(sessionDir, planPath)
+	}
+	return loadPlanWithFallback(planPath)
+}
+
 // loadPlanWithFallback loads a plan from disk with completed/ directory fallback.
 // probes the original path, then completed/<basename>, then completed/<alt-basename>
 // with the date prefix swapped between YYYY-MM-DD and YYYYMMDD conventions to handle

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -234,16 +234,25 @@ func (s *Server) handleSessionPlan(w http.ResponseWriter, sessionID string) {
 		return
 	}
 
-	// resolve plan path: absolute paths used as-is, relative paths resolved from session directory
-	var planPath string
-	if filepath.IsAbs(meta.PlanPath) {
-		planPath = meta.PlanPath
-	} else {
-		sessionDir := filepath.Dir(session.Path)
-		planPath = filepath.Join(sessionDir, meta.PlanPath)
+	sessionDir := filepath.Dir(session.Path)
+
+	// a worktree run ticks its own copy of the plan, so serve that while the worktree exists.
+	// only a missing copy falls through to the recorded path: any other error means the live
+	// plan is there but unreadable, and answering with the stale main copy would hide it.
+	if meta.WorktreePlanPath != "" {
+		p, err := loadSessionPlan(meta.WorktreePlanPath, sessionDir)
+		switch {
+		case err == nil:
+			s.writePlanJSON(w, p)
+			return
+		case !errors.Is(err, fs.ErrNotExist):
+			log.Printf("[WARN] failed to load worktree plan file %s: %v", meta.WorktreePlanPath, err)
+			http.Error(w, "unable to load plan", http.StatusInternalServerError)
+			return
+		}
 	}
 
-	p, err := loadPlanWithFallback(planPath)
+	p, err := loadSessionPlan(meta.PlanPath, sessionDir)
 	if err != nil {
 		log.Printf("[WARN] failed to load plan file %s: %v", meta.PlanPath, err)
 		http.Error(w, "unable to load plan", http.StatusInternalServerError)

--- a/pkg/web/server_test.go
+++ b/pkg/web/server_test.go
@@ -548,6 +548,109 @@ func TestServer_HandlePlan_WithSession(t *testing.T) {
 		assert.Contains(t, string(body), "session not found")
 	})
 
+	// pins #440: the recorded "Plan:" path is the main checkout, which a worktree run never ticks
+	t.Run("prefers the worktree plan copy over the recorded main-checkout path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		mainPlan := filepath.Join(tmpDir, "main-plan.md")
+		require.NoError(t, os.WriteFile(mainPlan, []byte("# Plan\n\n### Task 1: Work\n\n- [ ] step\n"), 0o600))
+		wtPlan := filepath.Join(tmpDir, "wt", "main-plan.md")
+		require.NoError(t, os.MkdirAll(filepath.Dir(wtPlan), 0o750))
+		require.NoError(t, os.WriteFile(wtPlan, []byte("# Plan\n\n### Task 1: Work\n\n- [x] step\n"), 0o600))
+
+		progressPath := filepath.Join(tmpDir, "progress-wt.txt")
+		progressContent := "# Ralphex Progress Log\nPlan: " + mainPlan + "\nWorktree plan: " + wtPlan +
+			"\nBranch: main-plan\nMode: full\nStarted: 2026-01-22 10:30:00\n" +
+			"------------------------------------------------------------\n"
+		require.NoError(t, os.WriteFile(progressPath, []byte(progressContent), 0o600))
+
+		sm := NewSessionManager()
+		defer sm.Close()
+		_, err := sm.Discover(tmpDir)
+		require.NoError(t, err)
+
+		srv, err := NewServerWithSessions(ServerConfig{Port: 8080}, sm)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/plan?session="+sessionIDFromPath(progressPath), http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handlePlan(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"checked":true`, "should serve the ticked worktree copy")
+	})
+
+	t.Run("falls back to the recorded path once the worktree is gone", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		mainPlan := filepath.Join(tmpDir, "main-plan.md")
+		require.NoError(t, os.WriteFile(mainPlan, []byte("# Fallback Plan\n\n### Task 1: Work\n\n- [ ] step\n"), 0o600))
+
+		progressPath := filepath.Join(tmpDir, "progress-wt-gone.txt")
+		progressContent := "# Ralphex Progress Log\nPlan: " + mainPlan +
+			"\nWorktree plan: " + filepath.Join(tmpDir, "removed", "main-plan.md") +
+			"\nBranch: main-plan\nMode: full\nStarted: 2026-01-22 10:30:00\n" +
+			"------------------------------------------------------------\n"
+		require.NoError(t, os.WriteFile(progressPath, []byte(progressContent), 0o600))
+
+		sm := NewSessionManager()
+		defer sm.Close()
+		_, err := sm.Discover(tmpDir)
+		require.NoError(t, err)
+
+		srv, err := NewServerWithSessions(ServerConfig{Port: 8080}, sm)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/plan?session="+sessionIDFromPath(progressPath), http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handlePlan(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "Fallback Plan")
+	})
+
+	t.Run("surfaces an unreadable worktree plan instead of the stale main copy", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		mainPlan := filepath.Join(tmpDir, "main-plan.md")
+		require.NoError(t, os.WriteFile(mainPlan, []byte("# Stale Plan\n\n### Task 1: Work\n\n- [ ] step\n"), 0o600))
+		wtPlan := filepath.Join(tmpDir, "wt", "main-plan.md")
+		require.NoError(t, os.MkdirAll(wtPlan, 0o750))
+
+		progressPath := filepath.Join(tmpDir, "progress-wt-unreadable.txt")
+		progressContent := "# Ralphex Progress Log\nPlan: " + mainPlan + "\nWorktree plan: " + wtPlan +
+			"\nBranch: main-plan\nMode: full\nStarted: 2026-01-22 10:30:00\n" +
+			"------------------------------------------------------------\n"
+		require.NoError(t, os.WriteFile(progressPath, []byte(progressContent), 0o600))
+
+		sm := NewSessionManager()
+		defer sm.Close()
+		_, err := sm.Discover(tmpDir)
+		require.NoError(t, err)
+
+		srv, err := NewServerWithSessions(ServerConfig{Port: 8080}, sm)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/plan?session="+sessionIDFromPath(progressPath), http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handlePlan(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.NotContains(t, string(body), "Stale Plan")
+	})
+
 	t.Run("returns 404 when session has no plan path", func(t *testing.T) {
 		tmpDir := t.TempDir()
 

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -54,14 +54,15 @@ const (
 
 // SessionMetadata holds parsed information from progress file header.
 type SessionMetadata struct {
-	PlanPath    string    // path to plan file (from "Plan:" header line)
-	Branch      string    // git branch (from "Branch:" header line)
-	Mode        string    // execution mode: full, review, codex-only (from "Mode:" header line)
-	Executor    string    // executor name when not the default claude (from "Executor:" header line)
-	PlanModel   string    // model[:effort] spec for plan creation (from "Plan model:" header line)
-	TaskModel   string    // model[:effort] spec for task execution (from "Task model:" header line)
-	ReviewModel string    // model[:effort] spec for review phases (from "Review model:" header line)
-	StartTime   time.Time // start time (from "Started:" header line)
+	PlanPath         string    // path to plan file (from "Plan:" header line)
+	WorktreePlanPath string    // path to the worktree's plan copy, ticked by the run (from "Worktree plan:" header line); empty outside worktree mode
+	Branch           string    // git branch (from "Branch:" header line)
+	Mode             string    // execution mode: full, review, codex-only (from "Mode:" header line)
+	Executor         string    // executor name when not the default claude (from "Executor:" header line)
+	PlanModel        string    // model[:effort] spec for plan creation (from "Plan model:" header line)
+	TaskModel        string    // model[:effort] spec for task execution (from "Task model:" header line)
+	ReviewModel      string    // model[:effort] spec for review phases (from "Review model:" header line)
+	StartTime        time.Time // start time (from "Started:" header line)
 }
 
 // defaultTopic is the SSE topic used for all events within a session.

--- a/pkg/web/session_progress.go
+++ b/pkg/web/session_progress.go
@@ -18,6 +18,7 @@ import (
 //
 //	# Ralphex Progress Log
 //	Plan: path/to/plan.md
+//	Worktree plan: /repo/.ralphex/worktrees/feature-branch/path/to/plan.md
 //	Branch: feature-branch
 //	Mode: full
 //	Executor: codex
@@ -27,8 +28,9 @@ import (
 //	Started: 2026-01-22 10:30:00
 //	------------------------------------------------------------
 //
-// the Executor and model lines are optional — they appear only when the
-// corresponding parameter was set for the run.
+// the Worktree plan, Executor and model lines are optional — Worktree plan appears
+// only for a run in a git worktree, the rest only when the corresponding parameter
+// was set for the run.
 //
 // the second return value reports whether the terminating separator line was
 // observed, which means the header is fully written. during a truncate+rewrite
@@ -80,6 +82,7 @@ func parseHeaderField(meta *SessionMetadata, line string) {
 		dst    *string
 	}{
 		{"Plan: ", &meta.PlanPath},
+		{"Worktree plan: ", &meta.WorktreePlanPath},
 		{"Branch: ", &meta.Branch},
 		{"Mode: ", &meta.Mode},
 		{"Executor: ", &meta.Executor},

--- a/pkg/web/session_progress_test.go
+++ b/pkg/web/session_progress_test.go
@@ -72,6 +72,29 @@ Started: 2026-01-22 10:30:00
 		assert.Equal(t, "docs/plans/my-plan.md", meta.PlanPath, "Plan model line must not shadow Plan line")
 	})
 
+	t.Run("parses worktree plan path", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "progress-test.txt")
+
+		content := `# Ralphex Progress Log
+Plan: /repo/docs/plans/my-plan.md
+Worktree plan: /repo/.ralphex/worktrees/my-plan/docs/plans/my-plan.md
+Branch: my-plan
+Mode: full
+Started: 2026-01-22 10:30:00
+------------------------------------------------------------
+`
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		meta, complete, err := ParseProgressHeader(path)
+		require.NoError(t, err)
+		assert.True(t, complete)
+
+		assert.Equal(t, "/repo/docs/plans/my-plan.md", meta.PlanPath)
+		assert.Equal(t, "/repo/.ralphex/worktrees/my-plan/docs/plans/my-plan.md", meta.WorktreePlanPath)
+		assert.Equal(t, "my-plan", meta.Branch, "Worktree plan line must not consume the Branch line")
+	})
+
 	t.Run("handles review-only mode", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "progress-test.txt")


### PR DESCRIPTION
in `--worktree` mode the dashboard's plan tree showed every task as pending, because the progress header recorded the main-checkout plan path while the run ticks the worktree copy.

`runWithWorktree` builds the progress logger before the chdir, so progress files land in the main repo's `.ralphex/progress/`. That means the `Plan:` header gets `req.PlanFile`, the main-checkout path, while the run works on `wtPlanFile` inside the worktree. `pkg/web` parses that header into `meta.PlanPath` and `handleSessionPlan` loads exactly it, so the dashboard read a file the run never writes to.

the header now carries a second optional line, `Worktree plan:`, naming the copy the run ticks. It is computed before the logger is built, so the pre-chdir ordering is unchanged. `handleSessionPlan` serves that copy while it exists and falls back to `Plan:` once the worktree is removed at the end of the run, so a finished run reads exactly as it does today.

`resolveWorktreePlanFile` became `worktreePlanFile`, taking the worktree root as an argument instead of depending on the current directory. One derivation now feeds both the header and the run, and it produces the same string as before: the old code did `filepath.Abs(rel)` with the CWD already inside the worktree, the new one does `filepath.Join(wtPath, rel)`, and the repo root is absolute and symlink-resolved.

**scope**: this fixes the live case only. Related to #440, which stays open for the rest.

the reported repro (`ralphex --worktree --serve <plan>`) does not reproduce on its own. Without watch dirs the dashboard is single-session, and `/api/plan` with no `?session=` reads `s.cfg.PlanFile`, which already holds the worktree path. The defect needs `--watch` or `watch_dirs`, and there it always fires: the frontend auto-selects a session, so every plan fetch is session-scoped and goes through the header.

after the run this is still wrong, and this PR does not address it. `MovePlanToCompleted` archives the main-checkout copy, which was never ticked, so a finished worktree run still reports 0 done. Fixing that needs a durable source for the ticked plan once the worktree is gone, either a snapshot under `.ralphex/progress` or loading it from the preserved branch, and that is a separate decision.

**compatibility**: the line is written only in worktree mode. `parseHeaderField` ignores unknown header lines and the header parser stops at the separator, so an older ralphex reading a newer progress file is unaffected, and a newer one reading an older file falls back to `Plan:` as before. On the restart path `NewLogger` skips `writeHeader` entirely, so a preserved progress file keeps the prior run's header, including `Branch:`, `Mode:` and the model lines. A failed non-worktree run retried under `--worktree` therefore keeps the old header for that run and behaves as it did before this change.

**tests**: `worktreePlanFile` mapping including the relative and out-of-root cases, the header line present in worktree mode and absent otherwise, `Worktree plan:` parsing without shadowing `Branch:`, and three cases on `handleSessionPlan`: prefers the ticked worktree copy, falls back when the worktree is gone, returns 500 when the copy is present but unreadable rather than answering with the stale main copy.
