### PR TITLE
fix: return repo-relative paths with forward slashes so the plan file excludes itself on Windows

### DIFF
--- a/pkg/git/external.go
+++ b/pkg/git/external.go
@@ -506,14 +506,17 @@ func (e *externalBackend) refExists(ref string) bool {
 	return cmd.Run() == nil
 }
 
-// toRelative converts a path to be relative to the repository root.
+// toRelative converts a path to be relative to the repository root, always with forward slashes.
+// git speaks forward slashes on every platform, both in its own output (status --porcelain) and in
+// the paths it accepts as arguments, while filepath.Clean and filepath.Rel yield backslashes on
+// windows - an unconverted result would never match the paths git reports back.
 func (e *externalBackend) toRelative(path string) (string, error) {
 	if !filepath.IsAbs(path) {
 		cleaned := filepath.Clean(path)
 		if strings.HasPrefix(cleaned, "..") {
 			return "", fmt.Errorf("path %q escapes repository root", path)
 		}
-		return cleaned, nil
+		return filepath.ToSlash(cleaned), nil
 	}
 
 	// resolve symlinks for consistent comparison (macOS /var -> /private/var)
@@ -531,7 +534,7 @@ func (e *externalBackend) toRelative(path string) (string, error) {
 	if strings.HasPrefix(rel, "..") {
 		return "", fmt.Errorf("path %q is outside repository root %q", path, e.path)
 	}
-	return rel, nil
+	return filepath.ToSlash(rel), nil
 }
 
 // addWorktree creates a git worktree at the given path.

--- a/pkg/git/external_test.go
+++ b/pkg/git/external_test.go
@@ -879,6 +879,12 @@ func TestExternalBackend_toRelative(t *testing.T) {
 		assert.Equal(t, "docs/plans/test.md", rel)
 	})
 
+	t.Run("converts os-specific separators to forward slashes", func(t *testing.T) {
+		rel, err := eb.toRelative(filepath.Join("docs", "plans", "test.md"))
+		require.NoError(t, err)
+		assert.Equal(t, "docs/plans/test.md", rel, "git reports forward slashes on every platform")
+	})
+
 	t.Run("rejects .. path", func(t *testing.T) {
 		_, err := eb.toRelative("../outside.txt")
 		require.Error(t, err)
@@ -889,11 +895,14 @@ func TestExternalBackend_toRelative(t *testing.T) {
 		absPath := filepath.Join(eb.path, "docs", "plans", "test.md")
 		rel, err := eb.toRelative(absPath)
 		require.NoError(t, err)
-		assert.Equal(t, filepath.Join("docs", "plans", "test.md"), rel)
+		assert.Equal(t, "docs/plans/test.md", rel)
 	})
 
 	t.Run("rejects absolute path outside repo", func(t *testing.T) {
-		_, err := eb.toRelative("/tmp/outside/file.txt")
+		// t.TempDir is absolute on every platform; a unix-style literal would fall into the
+		// relative branch on windows and never reach the check under test
+		outside := filepath.Join(t.TempDir(), "file.txt")
+		_, err := eb.toRelative(outside)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "outside repository")
 	})

--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -523,12 +523,12 @@ func TestService_MovePlanToCompleted(t *testing.T) {
 
 		files := runGit(t, dir, "show", "--name-status", "--format=", "HEAD")
 		assert.NotContains(t, files, "unrelated.txt", "unrelated staged file must stay out of the archive commit")
-		assert.Contains(t, files, filepath.Join("docs", "plans", "completed", "feature.md"))
-		assert.Contains(t, files, filepath.Join("docs", "plans", "feature.md"),
+		assert.Contains(t, files, "docs/plans/completed/feature.md")
+		assert.Contains(t, files, "docs/plans/feature.md",
 			"git mv stages the source deletion, so the source must be committed too or the rename is half recorded")
 
 		tree := runGit(t, dir, "ls-tree", "-r", "--name-only", "HEAD", "docs/")
-		assert.NotContains(t, tree, filepath.Join("docs", "plans", "feature.md")+"\n",
+		assert.NotContains(t, tree, "docs/plans/feature.md\n",
 			"plan must not survive at its original path in HEAD")
 
 		assert.Equal(t, "A  unrelated.txt\n", runGit(t, dir, "status", "--porcelain", "--", unrelated),
@@ -555,7 +555,7 @@ func TestService_MovePlanToCompleted(t *testing.T) {
 
 		files := runGit(t, dir, "show", "--name-status", "--format=", "HEAD")
 		assert.NotContains(t, files, "unrelated.txt", "unrelated staged file must stay out of the archive commit")
-		assert.Contains(t, files, filepath.Join("docs", "plans", "completed", "untracked.md"))
+		assert.Contains(t, files, "docs/plans/completed/untracked.md")
 
 		assert.Equal(t, "A  unrelated.txt\n", runGit(t, dir, "status", "--porcelain", "--", unrelated),
 			"unrelated file must remain staged, not unstaged or discarded")


### PR DESCRIPTION
Fixes #453.

## What

`toRelative` (`pkg/git/external.go`) returned the output of `filepath.Clean` / `filepath.Rel` unchanged, so on Windows a repo-relative path came back as `docs\plans\my-plan.md`. `hasChangesOtherThan` compares that against the paths from `git status --porcelain`, which are forward-slashed on every platform, so the `strings.EqualFold` check never matched and the plan file could not exclude itself once it lived in a subdirectory — `plans_dir` defaults to `docs/plans`, so `--worktree` with an uncommitted plan file was blocked on Windows in general.

Both return paths now go through `filepath.ToSlash`. The other callers (`add`, `moveFile`, `commitFiles`, `fileHasChanges`) pass the value straight to git, which accepts forward slashes everywhere, so the conversion is safe for them too.

The second commit fixes test expectations, not code: `TestService_MovePlanToCompleted` built its expected paths with `filepath.Join` and matched them against the output of `git show --name-status` and `git ls-tree`. Those strings come from git, so the expectation side was wrong — those two cases fail on Windows both before and after the fix, and without the change `go test ./pkg/git/` cannot go green there.

## How tested

`go test ./pkg/git/` on Windows 11, Go 1.27.0, git 2.55.0.

Before, on unchanged `master`, six subtests fail:

```
--- FAIL: TestExternalBackend_toRelative/returns_repo-relative_path_unchanged
        expected: "docs/plans/test.md"
        actual  : "docs\plans\test.md"
--- FAIL: TestExternalBackend_toRelative/rejects_absolute_path_outside_repo
--- FAIL: TestExternalBackend_HasChangesOtherThan/returns_empty_when_only_target_file_is_untracked
--- FAIL: TestExternalBackend_HasChangesOtherThan/returns_dirty_file_when_other_file_is_untracked
--- FAIL: TestExternalBackend_HasChangesOtherThan/returns_dirty_file_when_tracked_file_is_modified
--- FAIL: TestExternalBackend_HasChangesOtherThan/excludes_plan_file_with_different_case
```

After: `ok github.com/umputun/ralphex/pkg/git`, `golangci-lint run ./pkg/git/...` reports 0 issues, `gofmt` clean.

Test changes beyond the new case:

- `converts absolute path to relative` now expects forward slashes, matching the documented behaviour of `toRelative`.
- `rejects absolute path outside repo` used the literal `/tmp/outside/file.txt`, which `filepath.IsAbs` rejects on Windows — the case took the relative branch and never reached the check it names. It now uses `t.TempDir()`, absolute on every platform.
- New case `converts os-specific separators to forward slashes`, so a regression is caught on Linux too.

Note for anyone reproducing on Windows: run the suite with `core.autocrlf=false`, otherwise `TestService_CreateWorktreeForPlan` fails on a `\r\n` vs `\n` comparison of test fixture content. That is unrelated to this change.
